### PR TITLE
remove constraint itext id if constraint message is deleted (Case:54143)

### DIFF
--- a/js/widgets.js
+++ b/js/widgets.js
@@ -161,7 +161,7 @@ formdesigner.widgets = (function () {
             return input.val();
         };
 
-        input.keyup(widget.updateValue);
+        input.bind("change keyup", widget.updateValue);
         return widget;
     };
 
@@ -402,8 +402,15 @@ formdesigner.widgets = (function () {
         };
 
         widget.checkAutoIDIfNeeded = function() {
-            if (!$.trim($(widget.elementPrefix).val())) {
-                $(widget.elementPrefix + "-auto-itext").prop('checked', true).change();
+            var $idInput = $(widget.elementPrefix),
+                currentId = $.trim($idInput.val()),
+                $autoIdCheckbox = $(widget.elementPrefix + "-auto-itext");
+
+            if (widget.getValue() && !currentId) {
+                $autoIdCheckbox.prop('checked', true).change();
+            } else if (!widget.getValue() && currentId) {
+                $autoIdCheckbox.prop('checked', false).change();
+                $idInput.val('').change();
             }
         };
 


### PR DESCRIPTION
If the user clears a constraint message (or hint) text input, clear the
constraint itext id advanced field.

There is a bug when there are multiple language inputs and a user clears
one of them.  The itext id will be deleted even if the other language
itext input still has a value.  But if the user either re-enters a new
value for the language they cleared or clears the other language then it
will end up in the correct state.  Amelia said this is better than the
current behavior.
