### PR TITLE
don't eat odkx:intent tag in head (FB:55436)

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1929,11 +1929,23 @@ formdesigner.controller = (function () {
             };
             var xmlDoc = $.parseXML(xmlString),
                 xml = $(xmlDoc),
-                binds = xml.find('bind'),
+                head = xml.find('h\\:head, head'),
+                title = head.children('h\\:title, title'),
+                binds = head.find('bind'),
                 instances = _getInstances(xml),
-                controls = xml.find('h\\:body').children(),
-                itext = xml.find('itext'),
-                formID, formName, title;
+                itext = head.find('itext'),
+                formID;
+
+            that.form.extraHeadNodes = [];
+            var extraHeadTags = [
+                "odkx\\:intent, intent"
+            ];
+            extraHeadTags.map(function (tag) {
+                var found = head.children(tag);
+                if (found.length) {
+                    that.form.extraHeadNodes.push(found[0]);
+                }
+            });
 
             var data = $(instances[0]).children();
             if($(xml).find('parsererror').length > 0) {
@@ -1947,14 +1959,8 @@ formdesigner.controller = (function () {
                 formID = this.nodeName;
             });
             
-            title = xml.find('title');
-            if(title.length === 0) {
-                title = xml.find('h\\:title');
-            }
-
             if(title.length > 0) {
-                title = $(title).text();
-                that.form.formName = title;
+                that.form.formName = $(title).text();
             }
             
             // set all instance metadatas
@@ -1975,11 +1981,8 @@ formdesigner.controller = (function () {
             parseDataTree (data[0]);
             parseBindList (binds);
 
-            if(controls.length === 0) {
-                controls = xml.find('body').children();
-            }
+            var controls = xml.find('h\\:body, body').children();
             parseControlTree(controls);
-            
 
             that.fire({
                 type: 'parse-finish'

--- a/js/model.js
+++ b/js/model.js
@@ -2707,16 +2707,16 @@ formdesigner.model = function () {
                     _writeInstance(xmlWriter, formdesigner.controller.form.instanceMetadata[i], true);
                 }
                 
-                /////////////////BINDS /////////////////
                 createBindList();
-                ///////////////////////////////////////
                 
-                //////////ITEXT //////////////////////
                 createITextBlock();
-                ////////////////////////////////////
                 
                 xmlWriter.writeEndElement(); //CLOSE MODEL
-                ///////////////////////////////////
+
+                formdesigner.controller.form.extraHeadNodes.map(function (node) {
+                    xmlWriter.writeString(formdesigner.util.serializeXml(node));
+                });
+
                 xmlWriter.writeEndElement(); //CLOSE HEAD
 
                 xmlWriter.writeStartElement('h:body');

--- a/js/util.js
+++ b/js/util.js
@@ -345,8 +345,7 @@ formdesigner.util = (function(){
 //            console.log(mug);
 //            console.groupEnd();
             throw 'Newly created mug did not validate! MugType and Mug logged to console...'
-    }
-
+    };
 
     that.parseXml = function (xml) {
        var dom = null;
@@ -370,6 +369,23 @@ formdesigner.util = (function(){
           alert("cannot parse xml string!");
        return dom;
     };
+
+    that.serializeXml = function (xmlNode) {
+        try {
+            // Gecko- and Webkit-based browsers (Firefox, Chrome), Opera.
+            return (new XMLSerializer()).serializeToString(xmlNode);
+        } catch (e) {
+            try {
+                // Internet Explorer
+                return xmlNode.xml;
+            } catch (e) {
+                // Other browsers without XML Serializer
+                alert('XML serialization not supported');
+            }
+        }
+        return false;
+    };
+
     /**
      * Takes in a reference mugType and makes a copy of
      * the object (the copy is returned).


### PR DESCRIPTION
This adds the ability to specify tag names of first-level children of `<head>` 
to store on parsing and re-output when serializing the XML.  The
nodes are simply stored as a list of XML DOM objects on the form and
serialized using a simple cross-browser compatible XML node to string
function.

I also cleaned up some of the selectors to be more explicit (for
example, only looking for title in the children of head, not the entire
xml body, and changed some selectors to be more compatible across
browser implementations (jQuery doesn't abstract away browser
differences in support for finding namespaced node names).
