### PR TITLE
fix Case:58847 (adding a question takes painfully long on large forms)

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -1133,12 +1133,6 @@ formdesigner.ui = function () {
         showConfirmDialog();
     };
 
-    var init_misc = function () {
-        controller.on('question-creation', function (e) {
-            that.setAllTreeValidationIcons();
-        });
-    };
-
     var set_event_listeners = function () {
         formdesigner.controller.on("question-itext-changed", function (e) {
             // Update any display values that are affected
@@ -1742,7 +1736,6 @@ formdesigner.ui = function () {
         init_form_paste();
         init_modal_dialogs();
 
-        init_misc();
         set_event_listeners();
 
         setup_fancybox();


### PR DESCRIPTION
Currently when you add a question on a large form it can take several
seconds.  This is because every time a question is added every single
question in the form is validated in order to redraw the error icons
in the question tree.

This change removes that and makes adding a question snappy on even very
large forms.

Revalidating all questions seems unnecessary because this is already
done on form load and when you change a question that question itself is
automatically validated.

Since by default questions are created in a valid state (non-duplicate
question id, etc), adding a new question never introduces new validation
errors until the question is edited to be invalid, and anyway if the
question wasn't created in a valid state you would see an error as soon
as you edited it.

As far as I can tell validation only occurs isolated to each individual
question and there is no structural validation except for a few things
like unique question IDs.
