### PR TITLE
change question copy naming scheme

### DIFF
--- a/js/util.js
+++ b/js/util.js
@@ -401,12 +401,12 @@ formdesigner.util = (function(){
      */
     that.generate_question_id = function (question_id) {
         if (question_id) {
-            var match = /(.+)-\d$/.exec(question_id) ;
+            var match = /^copy-(\d+)-of-(.+)$/.exec(question_id) ;
             if (match) {
-                question_id = match[1]; 
+                question_id = match[2]; 
             }
             for (var i = 1;; i++) {
-                var new_id = question_id + "-" + i;
+                var new_id = "copy-" + i + "-of-" + question_id;
                 if (!formdesigner.model.questionIdCount(new_id)) {
                     return new_id; 
                 }


### PR DESCRIPTION
change from question, question-n to question, copy-n-of-question

Copy question introduced some unexpected side effects where the way
copies of questions were named caused questions to get intertangled when
you renamed the copy and momentarily had the same name as the old one.

In attempting to fix this https://github.com/dimagi/Vellum/pull/69 I
made select item itext ids always automatically generated.  This had the
unfornate side-effect of making it impossible to copy a select question
with numeric item values without having immediately overlapping itext
ids.

This change avoids that but should also avoid any other rename issues.

To be more robust, we should also
- make the question id and item value inputs only fire on change, not
  textchange
- alert and disallow the user from having duplicate item values in the
  same select question
- alert and disallow from having duplicate question IDs as long as that
  requirement is in place (although we should probably support duplicate
  IDs by using full paths as itext ids)
