### PR TITLE
added link to common logic and calculations to the expression editor

### DIFF
--- a/templates/main.html
+++ b/templates/main.html
@@ -39,6 +39,9 @@
     <div id="fd-xpath-editor" class="fd-column">
         <div id="fd-xpath-editor-head" class="fd-head">Expression Editor</div>
         <div class="fd-scrollable fd-scrollable-main">
+            <a href="https://help.commcarehq.org/display/commcarepublic/Common+Logic+and+Calculations">
+                Guide to Common Logic and Calculations
+            </a>
             <div id="fd-xpath-editor-content"></div>
         </div>
     </div>


### PR DESCRIPTION
This puts a link there, but I'm not crazy happy about the way I did it.  The template is used by javascript, so I can't use a {% translate %} tag, so the link description and the link will always be English only.
