### PR TITLE
fix choice default value broken after refactoring

### DIFF
--- a/js/model.js
+++ b/js/model.js
@@ -291,10 +291,6 @@ formdesigner.model = function () {
         if (mugSpec) {
             mug = new Mug(mugSpec);
             if (controlElSpec) {
-                if (formdesigner.util.isSelectItem(mugType) &&
-                    typeof controlElSpec.defaultValue !== 'undefined') {
-                    controlElSpec.defaultValue = formdesigner.util.generate_item_label();
-                }
                 mug.properties.controlElement = new ControlElement(controlElSpec);
             }
             if (dataElSpec) {
@@ -1348,6 +1344,8 @@ formdesigner.model = function () {
         mug = that.createMugFromMugType(mType);
         mType.mug = mug;
         mType.mug.properties.controlElement.properties.tagName = "item";
+        mType.mug.properties.controlElement.properties.defaultValue = formdesigner.util.generate_item_label();
+
         return mType;
     };
 


### PR DESCRIPTION
mug.typeSlug is no longer defined manually in the mugtype
definition.  It's now just the mugType class name, and is set after
mug creation in a wrapper.  (We eventually, if it's ever worthwhile,
want to switch to prototypes and instanceof and get rid of typeSlug
altogether -- probably the only real justification would be using
prototypes to make long form loads faster by not creating duplicates of
every function on every mugtype object.)

This caused a problem in this one instance where during mug creation
typeSlug was referenced.  Moving the value definition to a better place
fixes.
