### PR TITLE
temporary mask for hidden value icon bug

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -1568,7 +1568,10 @@ formdesigner.ui = function () {
         if (!qtype && mugType) {
             qtype = mugType.typeSlug;
         }
-        iconClass = (mugType) ? mugType.getIcon() : that.QUESTION_TYPE_TO_ICONS[qtype];
+        iconClass = that.QUESTION_TYPE_TO_ICONS[qtype];
+        if (mugType) {
+            iconClass = mugType.getIcon() || iconClass;
+        }
         if (!iconClass) {
             iconClass = 'icon-circle';
         }


### PR DESCRIPTION
`formdesigner.controller.getMTFromFormByUFID` does not get the correct mugType from the mugTypeMaker, it just gets the base dataBind / dataOnly mugType. Poking through it a bit to figure out the root cause, but this at least shows an icon for hidden value on reload.

http://manage.dimagi.com/default.asp?73633
