### PR TITLE
copy linked itext on id change instead of changing id in all questions

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1486,9 +1486,9 @@ formdesigner.controller = (function () {
                     constraintItext = getITextReference(constraintMsg);
 
                 if (constraintItext) {
-                    attrs.constraintMsgItextID = Itext.getOrCreateItem(constraintItext);
+                    attrs.constraintMsgItextID = Itext.getOrCreateItem(constraintItext, true);
                 } else {
-                    attrs.constraintMsgItextID = Itext.createItem("");
+                    attrs.constraintMsgItextID = Itext.createItem("", true);
                     attrs.constraintMsgAttr = constraintMsg;    
                 }
                                 
@@ -1708,7 +1708,7 @@ formdesigner.controller = (function () {
                             //strip itext incantation
                             asItext = getITextReference(labelRef);
                             if (asItext) {
-                                labelItext = Itext.getOrCreateItem(asItext);
+                                labelItext = Itext.getOrCreateItem(asItext, true);
                             } else {
                                 // this is likely an error, though not sure what we should do here
                                 // for now just populate with the default
@@ -1738,11 +1738,11 @@ formdesigner.controller = (function () {
                         //strip itext incantation
                         var asItext = getITextReference(hintRef);
                         if (asItext) {
-                            cProps.hintItextID = Itext.getOrCreateItem(asItext);
+                            cProps.hintItextID = Itext.getOrCreateItem(asItext, true);
                         } else {
                             // couldn't parse the hint as itext.
                             // just create an empty placeholder for it
-                            cProps.hintItextID = Itext.createItem(""); 
+                            cProps.hintItextID = Itext.createItem("", true); 
                         }
                         cProps.hintLabel = hintVal;
                     }

--- a/js/widgets.js
+++ b/js/widgets.js
@@ -279,7 +279,13 @@ formdesigner.widgets = (function () {
             // override save to call out to rename itext
             var oldItext = widget.mug.getPropertyValue(this.path);
             var val = widget.getValue();
+
             if (oldItext.id !== val) {
+                if (oldItext.refCount > 1) {
+                    oldItext.refCount--;
+                    oldItext = $.extend(true, {}, oldItext, {refCount: 1});
+                    formdesigner.model.Itext.addItem(oldItext);
+                }
                 oldItext.id = val;
                 formdesigner.controller.setMugPropertyValue(
                     widget.mug.mug,


### PR DESCRIPTION
This is a minimal change that adds a reference count to itext items.
When editing question properties and changing an itext id for an itext
item that's referenced by more than one question, the itext item will be
duplicated and the duplicate given the new id, while the existing item
and references will remain unchanged.

This allows you to more easily fix mistakes made when normalizing your
itext.

Tested with normal, constraint, and hint itext ids, with > 2 linked
itexts, and also renaming the original on one of the unchanged
questions, and verifying everything in the XML.
