### PR TITLE
fix itext id removal when deleting all values

### DIFF
--- a/js/formdesigner.javarosa.js
+++ b/js/formdesigner.javarosa.js
@@ -469,9 +469,7 @@ var iTextIDWidget = function (mug, options) {
     };
 
     widget.setValue = function (value) {
-        if (value) {
-            widget.setUIValue(value.id);
-        }
+        widget.setUIValue(value.id);
     };
 
     widget.getValue = function() {
@@ -585,7 +583,7 @@ var iTextIDWidget = function (mug, options) {
             widget.updateValue();
         } else if (!isItextPresent && currentVal) {
             widget.setAutoMode(false);
-            widget.setValue('');
+            widget.setValue({id: ''});
             widget.updateValue();
         }
 


### PR DESCRIPTION
I added a

if (value)

check in setValue() because I thought this would break, but apparently
''.id == undefined.  This makes it more explicit in the end, though.
