### PR TITLE
fix validation condition getting lost

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1475,17 +1475,13 @@ formdesigner.controller = (function () {
         }
         
         // create new mug and copy old data to newly generated mug
-        var options = {};
-        if (oldMug) {
-            options = {
-                dataElement: oldMug.dataElement,
-                bindElement: oldMug.bindElement
-            };
-        }
-        mug = new MugClass(options);
+        mug = new MugClass();
 
         if(oldMug) {
             mug.ufid = oldMug.ufid;
+
+            mug.bindElement.setAttrs(oldMug.bindElement || {});
+            mug.dataElement.setAttrs(oldMug.dataElement || {});
 
             //replace in dataTree
             that.form.replaceMug(oldMug, mug, 'data');

--- a/js/model.js
+++ b/js/model.js
@@ -1406,7 +1406,8 @@ var MugElement = Class.$extend({
     },
     setAttr: function (attr, val) {
         // todo: replace all direct setting of element properties with this
-        if (this.__spec[attr] && this.__spec[attr].presence !== "notallowed") { 
+
+        if (this.__spec[attr] && attr.indexOf('_') !== 0) { 
             // avoid potential duplicate references (e.g., itext items)
             if (val && typeof val === "object") {
                 val = $.extend(true, {}, val);
@@ -1646,23 +1647,17 @@ var mugs = (function () {
         // whether you can change to or from this question's type in the UI
         isTypeChangeable: true,
         isODKOnly: false,
-        __init__: function (options) {
-            var options = options || {};
+        __init__: function () {
             var self = this;
             this.__spec = this.getSpec();
 
             _(this.__spec).each(function (spec, name) {
                 if (spec) {
-                    var newElement = new MugElement({
+                    self[name] = new MugElement({
                         spec: spec,
                         mug: self,
                         name: name
                     });
-                    var oldElement = options[name];
-                    if (oldElement) {
-                        newElement.setAttrs(oldElement);
-                    }
-                    self[name] = newElement;
                 } else {
                     self[name] = null;
                 }


### PR DESCRIPTION
The main change here is

```
-        if (this.__spec[attr] && this.__spec[attr].presence !== "notallowed") {
+
+        if (this.__spec[attr] && attr.indexOf('_') !== 0) {
```

Since all nodes initially get created as DataBindOnly mugs, because the
data tree (and then bind list) are parsed before the control block (and
then things get copied over to a new instance of the final control
node's question type), and proper Hidden Values have constraintAttr and
requiredAttr as "notallowed", this was preventing them from getting set.

It's ok to only reference notallowed on the side that displays validation
errors to the user.

This also changes some things to make setting and copying MugElement
attrs safer/more consistent.
