### PR TITLE
switch logic and itext inputs to contenteditable

### DIFF
--- a/js/formdesigner.javarosa.js
+++ b/js/formdesigner.javarosa.js
@@ -886,7 +886,7 @@ var itextMediaBlock = function (mug, options) {
 
 var itextLabelWidget = function (mug, language, form, options) {
     var Itext = formdesigner.pluginManager.javaRosa.Itext;
-    var widget = formdesigner.widgets.baseWidget(mug);
+    var widget = formdesigner.widgets.droppableMultilineTextWidget(mug, options);
 
     widget.displayName = options.displayName;
     widget.itextType = options.itextType;
@@ -972,32 +972,19 @@ var itextLabelWidget = function (mug, language, form, options) {
         }
     };
 
-    var $input = $("<input />")
-        .attr("id", widget.getID())
-        .attr("type", "text")
-        .addClass('input-block-level itext-widget-input')
-        .on('change keyup', widget.updateValue);
+    widget.getControl()
+        .attr('id', widget.getID())
+        .addClass('itext-widget-input');
 
     widget.mug.on('question-itext-deleted', widget.destroy);
-
-    widget.getControl = function () {
-        return $input;
-    };
 
     widget.toggleDefaultLangSync = function (val) {
         widget.isSyncedWithDefaultLang = !val && !widget.isDefaultLang;
     };
 
-    widget.setValue = function (val) {
-        $input.val(val);
-    };
-
     widget.setPlaceholder = function (val) {
-        $input.attr("placeholder", val);
-    };
-
-    widget.getValue = function () {
-        return $input.val();
+        // need to use attr() instead of data() for css to take effect
+        widget.getControl().attr("data-placeholder", val.trim());
     };
 
     widget.getDefaultValue = function () {

--- a/js/model.js
+++ b/js/model.js
@@ -2260,7 +2260,7 @@ var mugs = (function () {
                     visibility: 'visible',
                     editable: 'w',
                     presence: 'optional',
-                    uiType: formdesigner.widgets.droppableTextWidget
+                    uiType: formdesigner.widgets.droppableMultilineTextWidget
                 },
                 no_add_remove: {
                     lstring: 'Disallow Repeat Add and Remove?',

--- a/js/ui.js
+++ b/js/ui.js
@@ -1501,7 +1501,8 @@ formdesigner.ui = function () {
             },
             "dnd" : {
                 "drop_finish" : function(data) {
-                    formdesigner.controller.handleTreeDrop(data.o, data.r);
+                    formdesigner.controller.handleTreeDrop(
+                        data.o, data.r, data.e.clientX, data.e.clientY);
                 }
             },
             "types": {

--- a/style/question-props.css
+++ b/style/question-props.css
@@ -25,6 +25,9 @@
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
+[contentEditable=true]:empty:not(:focus):before {
+  content: attr(data-placeholder);
+}
 #formdesigner .itext-lang-group-config {
   margin-right: 45px;
   margin-bottom: 20px;

--- a/style/question-props.less
+++ b/style/question-props.less
@@ -1,5 +1,9 @@
 @import "lib/main";
 
+[contentEditable=true]:empty:not(:focus):before{
+    content:attr(data-placeholder);
+}
+
 #formdesigner {
   .itext-lang-group-config {
     margin-right: 45px;


### PR DESCRIPTION
This allows dragging questions into an "input" and having the question
ref get inserted where your mouse is, not where the cursor was.

(This is impossible to do with inputs because browser security model
disallows simulating a click from actually doing anything, but
contenteditable allows you to get insert nodes at a given X,Y point,
which you can get from the drag mouseup event.)

It also has a side-effect of giving us multi-line inputs that expand
with the size of the current input.  Formatting is preserved across
saves and the user never sees a &#10;, including in the advanced logic
editor.

contenteditable is HTML behind the scenes, so we do some hacky parsing
to handle converting values with &#10; newline escapes back and forth,
and make sure it works in Chrome and FF.

For now the styling is slightly off, it was some extra work just to
maintain the itext placeholder when using a contenteditable div.  I'll
try to get to the styling soon.
