### PR TITLE
fix copying select items on firefox

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -553,7 +553,7 @@ formdesigner.controller = (function () {
 
         var oldSkip = formdesigner.ui.skipNodeSelectEvent,
             selected = that.getCurrentlySelectedMug(),
-            parent = that.form.controlTree.getParentMug(selected),
+            parent = selected.parentMug,
             foo = duplicateMug(selected, parent, options),
             duplicate = foo[0],
             pathReplacements = foo[1];
@@ -590,6 +590,14 @@ formdesigner.controller = (function () {
         position = position || 'into';
         var success = false;
 
+        // manually set mug.parentMug before UI insertion so it's accessible to
+        // overrideJSTreeIcon()
+        if (position === 'into') {
+            mug.parentMug = refMug;
+        } else {
+            mug.parentMug = refMug.parentMug;
+        }
+
         /* First try to insert into the currently selected question, then try to
          * insert after it, then after all of its ancestors. */
         while (!success && refMug) {
@@ -600,7 +608,7 @@ formdesigner.controller = (function () {
                 if (position !== 'after') {
                     position = 'after';
                 } else {
-                    refMug = that.form.controlTree.getParentMug(refMug);
+                    refMug = refMug.parentMug;
                 }
             }
         }
@@ -737,7 +745,7 @@ formdesigner.controller = (function () {
 
         // set the 'currently selected mug' to be that of this mug's parent.
         controlTree = that.form.controlTree;
-        parentMug = controlTree.getParentMug(mug);
+        parentMug = mug.parentMug;
         
         // check for control element because we want data nodes to be a flat
         // list at bottom.

--- a/js/formdesigner.javarosa.js
+++ b/js/formdesigner.javarosa.js
@@ -430,7 +430,7 @@ var iTextIDWidget = function (mug, options) {
     var widget = formdesigner.widgets.textWidget(mug, options);
 
     widget.isSelectItem = (mug.__className === "Item");
-    widget.parentMug = widget.isSelectItem ? formdesigner.controller.form.controlTree.getParentMug(widget.mug) : null;
+    widget.parentMug = widget.isSelectItem ? widget.mug.parentMug : null;
     widget.langs = formdesigner.pluginManager.javaRosa.Itext.getLanguages();
 
     var $input = widget.getControl();

--- a/js/model.js
+++ b/js/model.js
@@ -277,16 +277,6 @@ var Tree = function (tType) {
         return rootNode.getNodeFromMug(mug);
     };
 
-    that.getParentMug = function (mug) {
-        var node = this.getNodeFromMug(mug);
-        if (!node) {
-            return null;
-        }
-        var pNode = that.getParentNode(node),
-            pMug = pNode.getValue();
-        return (pMug === ' ') ? null : pMug;
-    };
-
     /**
      * Removes a node (and all it's children) from the tree (regardless of where it is located in the
      * tree) and returns it.
@@ -351,6 +341,9 @@ var Tree = function (tType) {
             refNodeParent = that.getParentNode(refNode);
             refNodeSiblings = refNodeParent.getChildren();
             refNodeIndex = refNodeSiblings.indexOf(refNode);
+            mug.parentMug = refNodeParent.getValue();
+        } else {
+            mug.parentMug = refMug;
         }
 
         switch (position) {
@@ -1789,7 +1782,7 @@ var mugs = (function () {
                 nodeID = this.dataElement.nodeID;
             } else if (this.__className === "Item") {
                 // if it's a choice, generate based on the parent and value
-                parent = formdesigner.controller.form.controlTree.getParentMug(this);
+                parent = this.parentMug;
                 if (parent) {
                     nodeID = parent.getDefaultItextRoot() + "-" + this.controlElement.defaultValue;
                 }
@@ -2120,8 +2113,7 @@ var mugs = (function () {
         icon: 'icon-circle-blank',
         isTypeChangeable: false,
         getIcon: function () {
-            var parentMug = formdesigner.controller.form.controlTree.getParentMug(this);
-            if (parentMug.__className === "Select") {
+            if (this.parentMug.__className === "Select") {
                 return 'icon-circle-blank';
             } else {
                 return 'icon-check-empty';


### PR DESCRIPTION
copying select items would fail only on firefox due to inserting nodes
in the UI tree before the data trees (which we do because it allows us
to let JSTree handle all the structural validation), but this fires
question icon overriding, which for select items depends on the parent
select's type.

This would throw an error in FF at

```
-            var parentMug = formdesigner.controller.form.controlTree.getParentMug(this);
-            if (parentMug.__className === "Select") {
```

which for some reason didn't happen in Chrome.  Seems like this was due
to inconsistencies in the event scheduler (if the UI insertion
succeeded, then the model insertion could potentially finish before the
icon overriding triggered by the UI insertion happened).

This fixes this by switching to use an explicitly set mug.parentMug, and
then manually setting that on the mug in the main initQuestion() method
before the UI insertion happens to handle this special case.

(This is ok wrt question moving because all question moving is actually
a deletion + an insertion.)
