### PR TITLE
fix constraint id not allowed error for groups

### DIFF
--- a/js/model.js
+++ b/js/model.js
@@ -1407,7 +1407,9 @@ var MugElement = Class.$extend({
     setAttr: function (attr, val) {
         // todo: replace all direct setting of element properties with this
 
-        if (this.__spec[attr] && attr.indexOf('_') !== 0) { 
+        var spec = this.__spec[attr];
+
+        if (spec && spec.presence !== 'notallowed' && attr.indexOf('_') !== 0) { 
             // avoid potential duplicate references (e.g., itext items)
             if (val && typeof val === "object") {
                 val = $.extend(true, {}, val);


### PR DESCRIPTION
somewhere in the refactoring, where we started to use the property
definitions more than they were actually being used before, it caused an
issue where you would set the constraint itext id on all mugs as you
parsed the bindlist, and then when you parsed the control tree and saw
that a mug was a group/repeat/field list (which don't allow constraint
messages), it would still set the constraint itext id on that mug, which
caused an error to show up.

This fixes that by ignoring properties where the spec says they aren't
allowed when calling mugElement.setAttr().  This also paves the way for
eventually less worrying about what question types can be changed to
what other question types, because it would all be handled here.
