### PR TITLE
fix more type-switching bugs

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -690,7 +690,11 @@ formdesigner.controller = (function () {
             // hack: force removal of the appearance attribute since this is statically
             // determined already by the question type
             if (mug.controlElement && mug.controlElement.appearance) {
-                mug.controlElement.appearance = null;
+                delete mug.controlElement.appearance;
+            }
+            // and do the same thing for the 'mediatype' property as well
+            if (mug.controlElement && mug.controlElement.mediaType) {
+                delete mug.controlElement.mediaType;
             }
 
             newMug.copyAttrs(mug);


### PR DESCRIPTION
the right way to do this is to probably have the Mug definition have
a list of static attributes that don't get overridden during `setAttr`
but this is a reasonable short term workaround.

http://manage.dimagi.com/default.asp?99152
