### PR TITLE
Reduce size of advanced expression editor

### DIFF
--- a/templates/main.html
+++ b/templates/main.html
@@ -460,7 +460,7 @@
                 </label>
                 <div class="controls">
                     <textarea id="fd-xpath-editor-text"
-                              rows="20"
+                              rows="5"
                               class="input-block-level jstree-drop"></textarea>
                     <p class="help-block">Hint: You can drag a question into the box.</p>
                     <p class="help-block">


### PR DESCRIPTION
The editor text area can be enlarged by dragging the lower left corner, so it is still possible to get a larger editor if desired.

See http://manage.dimagi.com/default.asp?90767
