### PR TITLE
Roll back absolute path check

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -2043,8 +2043,7 @@ formdesigner.controller = (function () {
     function circularReferenceCheck(mug, path) {
         var group = $('#fd-xpath-editor').data("group");
         var property = $('#fd-xpath-editor').data("property");
-        if ((path === "." || path === form.dataTree.getAbsolutePath(mug)) &&
-            group === "bindElement" &&
+        if (path === "." && group === "bindElement" &&
             (property === "relevantAttr" || property === "calculateAttr")) {
 
             var fieldName = mug.bindElement.__spec[property].lstring;


### PR DESCRIPTION
- It was broken (should have used `that.form...`)
- There's no way to drag/drop an absolute path to the current mug anyway.

http://manage.dimagi.com/default.asp?85054
