### PR TITLE
Minimal fix to preserve newlines

### DIFF
--- a/src/ignoreButRetain.js
+++ b/src/ignoreButRetain.js
@@ -114,9 +114,16 @@ define([
             var _this = this,
                 ignoredEls = [],
                 xmlDoc = $.parseXML(xmlStr),
-                xml = $(xmlDoc);
+                xml = $(xmlDoc),
+                ignores = xml.find('[vellum\\:ignore="retain"]');
 
-            xml.find('[vellum\\:ignore="retain"]').each(function (i, el) {
+            if (ignores.length === 0) {
+                // skip serialize
+                this.__callOld();
+                return;
+            }
+
+            ignores.each(function (i, el) {
                 _this.data.ignore.ignoredNodes.push(getPathAndPosition(el));
                 ignoredEls.push(el);
             });

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -1,3 +1,4 @@
+/*jshint multistr: true */
 require([
     'chai',
     'jquery',
@@ -63,9 +64,21 @@ require([
                 }
             });
         });
+
+        it("should not drop newlines in calculate conditions", function (done) {
+            util.init({
+                core: {
+                    form: TEST_XML_2,
+                    onReady: function () {
+                        var mug = call("getMugByPath", "/data/question1");
+                        assert.equal(mug.p.calculateAttr, 'concat("Line 1","\nLine 2")');
+                        done();
+                    }
+                }
+            });
+        });
     });
 
-    /*jshint multistr: true */
     var TEST_XML_1 = '' + 
     '<?xml version="1.0" encoding="UTF-8" ?>\
     <h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">\
@@ -100,4 +113,24 @@ require([
             </select1>\
         </h:body>\
     </h:html>';
+
+    var TEST_XML_2 = util.xmlines('' +
+    '<?xml version="1.0" encoding="UTF-8"?>\
+    <h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">\
+        <h:head>\
+            <h:title>Untitled Form</h:title>\
+            <model>\
+                <instance>\
+                    <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">\
+                        <question1 />\
+                    </data>\
+                </instance>\
+                <bind nodeset="/data/question1" calculate="concat(&quot;Line 1&quot;,&quot;&#10;Line 2&quot;)" />\
+                <itext>\
+                    <translation lang="en" default=""/>\
+                </itext>\
+            </model>\
+        </h:head>\
+        <h:body></h:body>\
+    </h:html>');
 });


### PR DESCRIPTION
Fixes all forms that do not contain `vellum:ignore=“retain”` attributes.

Note that this is as good as the pre-RequireJS Vellum did. [vellum-before-requirejs formdesigner.ignoreButRetain.js](https://github.com/dimagi/Vellum/blob/abb5c227d452d244ec3f7072160fee84054a8d45/src/js/formdesigner.ignoreButRetain.js#L52-L80) did the same parse/serialize dance if there were ignored nodes, which would presumably cause newlines, etc. to be lost on the next load/save.

Beginning of a more complete fix: https://github.com/dimagi/Vellum/commit/b15afd1f6e78d09c597479bb67e4dea6dd556778
