### PR TITLE
Bulk export translations with real newlines

### DIFF
--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -1216,7 +1216,8 @@ define([
     var generateItextXLS = function (vellum, Itext) {
         // todo: fix abstraction barrier
         vellum.beforeSerialize();
-        
+
+        // TODO move TSV generation logic into tsv module
         function getItemFormValues(item, languages, form) {
 
             var ret = [];
@@ -1225,8 +1226,11 @@ define([
                 var language = languages[i];
                 var value = item.hasForm(form) ? (item.getForm(form).getValueOrDefault(language) || "") : "";
 
-                // escape newlines.  What ever generates a \r ?
-                ret.push(value.replace(/\r?\n/g, "&#10;"));
+                if (specialChars.test(value)) {
+                    // quote field
+                    value = '"' + value.replace(/"/g, '""') + '"';
+                }
+                ret.push(value);
             }
             return ret.join("\t");
         }
@@ -1252,6 +1256,7 @@ define([
             return header_row.join("\t");
         }
 
+        var specialChars = /[\r\n\u2028\u2029"]/g;
         var ret = [];
         // TODO: should this be configurable?
         var exportCols = ["default", "audio", "image" , "video"];
@@ -1314,6 +1319,7 @@ define([
 
             // exposed for testing
             this.data.javaRosa.parseXLSItext = parseXLSItext;
+            this.data.javaRosa.generateItextXLS = generateItextXLS;
         },
         insertOutputRef: function (mug, target, path, dateFormat) {
             var output = getOutputRef(path, dateFormat),

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -6,7 +6,8 @@ require([
     'vellum/javaRosa',
     'vellum/util',
     'text!static/javaRosa/outputref-group-rename.xml',
-    'text!static/javaRosa/text-question.xml'
+    'text!static/javaRosa/text-question.xml',
+    'text!static/javaRosa/multi-line-trans.xml'
 ], function (
     chai,
     $,
@@ -14,7 +15,8 @@ require([
     jr,
     vellum_util,
     OUTPUTREF_GROUP_RENAME_XML,
-    TEXT_QUESTION_XML
+    TEXT_QUESTION_XML,
+    MULTI_LINE_TRANS_XML
 ) {
     var assert = chai.assert,
         call = util.call;
@@ -254,6 +256,17 @@ require([
             assert.equal(q1.p.labelItextID.get("en"),
                          'First "line\nSecond" line\nThird line');
             assert.equal(q1.p.labelItextID.get("hin"), 'Hindu trans');
+        });
+
+        it("should generate bulk multi-line translation with user-friendly newlines", function () {
+            util.loadXML(MULTI_LINE_TRANS_XML);
+            var jr = util.call("getData").javaRosa,
+                fakeVellum = {beforeSerialize: function () {}};
+            assert.equal(jr.generateItextXLS(fakeVellum, jr.Itext),
+                         'label\tdefault-en\tdefault-hin\t' +
+                         'audio-en\taudio-hin\timage-en\timage-hin\tvideo-en\tvideo-hin\n' +
+                         'question1-label\t"First ""line\nSecond"" line\nThird line"\t' +
+                         'Hindu trans\t\t\t\t\t\t');
         });
     });
 

--- a/tests/static/javaRosa/multi-line-trans.xml
+++ b/tests/static/javaRosa/multi-line-trans.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/D2AEA80D-D518-430A-924B-39D1AE2207F8" uiVersion="1" version="1" name="Untitled Form">
+					<question1 />
+				</data>
+			</instance>
+			<bind nodeset="/data/question1" type="xsd:string" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="question1-label">
+						<value>First "line
+Second" line
+Third line</value>
+					</text>
+				</translation>
+				<translation lang="hin">
+					<text id="question1-label">
+						<value>Hindu trans</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/question1">
+			<label ref="jr:itext('question1-label')" />
+		</input>
+	</h:body>
+</h:html>


### PR DESCRIPTION
This is possible now that we have a real TSV parser.

@amsagoff @czue what do you think of this? It was really easy to code up, and I think it's a big improvement (no more `&#10;` in bulk-exported translations).

NOTE to reviewer: this is merging into #267, not master.
