### PR TITLE
Put space between icon and text in multimedia button groups

### DIFF
--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -726,7 +726,7 @@ define([
             var $buttonGroup = $("<div />").addClass("btn-group itext-options");
             _.each(block.forms, function (form) {
                 var $btn = $('<div />');
-                $btn.text(form)
+                $btn.text(' ' + form)
                     .addClass(block.getAddFormButtonClass(form))
                     .addClass('btn itext-option').click(function () {
                         block.addItext(form);


### PR DESCRIPTION
This looks bad:
![before](https://cloud.githubusercontent.com/assets/1486591/5144469/aac58464-7168-11e4-876f-e7714fa41e0c.png)

This is better:
![after](https://cloud.githubusercontent.com/assets/1486591/5144476/b2eeb5c0-7168-11e4-88c4-8f8ddb46c8c0.png)
