### PR TITLE
Turn tab into space for copying

### DIFF
--- a/src/exporter.js
+++ b/src/exporter.js
@@ -41,8 +41,14 @@ define([
                 i;
 
             var defaultOrNothing = function (item, language, form) {
-                return (item && item.hasForm(form)) ? 
-                    item.getForm(form).getValueOrDefault(language) : "";
+                var value;
+                if (item && item.hasForm(form)) {
+                    value = item.getForm(form).getValueOrDefault(language);
+                    value = value.replace(/\t/g, " ");
+                } else {
+                    value = "";
+                }
+                return value;
                 // TODO see newline treatment in javaRosa.js TSV logic
                 //return value.replace(/\r?\n/g, "&#10;");
             };

--- a/tests/static/all_question_types.tsv
+++ b/tests/static/all_question_types.tsv
@@ -1,5 +1,5 @@
 Question	Type	Text (en)	Text (hin)	Audio (en)	Audio (hin)	Image (en)	Image (hin)	Display Condition	Validation Condition	Validation Message	Calculate Condition	Required
-/question1	Text	question1 en label	question1 hin label	jr://file/commcare/audio/data/question1.mp3	jr://file/commcare/audio/data/question1.mp3	jr://file/commcare/image/data/question1.png	jr://file/commcare/image/data/question1.png	/data/question20	/data/question20 = 2	question1 en validation		yes
+/question1	Text	 question1 en label	question1 hin label	jr://file/commcare/audio/data/question1.mp3	jr://file/commcare/audio/data/question1.mp3	jr://file/commcare/image/data/question1.png	jr://file/commcare/image/data/question1.png	/data/question20	/data/question20 = 2	question1 en validation		yes
 /question2	Label	question2	question2									no
 /question30	Label	question30	question30									no
 /question3	Single Answer	question3	question3									no

--- a/tests/static/all_question_types.xml
+++ b/tests/static/all_question_types.xml
@@ -66,7 +66,7 @@
 			<itext>
 				<translation lang="en" default="">
 					<text id="question1-label">
-						<value>question1 en label</value>
+						<value>	question1 en label</value>
 						<value form="image">jr://file/commcare/image/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/data/question1.3gp</value>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?104522#794142

This replaces the tab character with a space when doing a TSV export. Can't really do it another way because the expectation is that a user needs to copy it to put it into excel.

I also thought about replacing the tab character with a space in the input, but I figured if they went through the trouble of inputting a tab into that, then they expect to have it show up like that in the app.
