### PR TITLE
Focus modal dialog input or text area on load

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -494,7 +494,7 @@ define([
         codeMirror.setSize('100%', '100%');
 
         $modal.modal('show');
-        $modal.on('shown', function () {
+        $modal.one('shown', function () {
             codeMirror.refresh();
             codeMirror.focus();
         });
@@ -512,8 +512,10 @@ define([
         $modal.find('.modal-body').html($exportForm);
 
         // display current values
-        $exportForm.find('textarea').val(this.data.core.form.getExportTSV());
+        var $text = $exportForm.find('textarea');
+        $text.val(this.data.core.form.getExportTSV());
         $modal.modal('show');
+        $modal.one('shown', function () { $text.focus(); });
     };
         
     fn.showFormPropertiesDialog = function () {
@@ -561,6 +563,9 @@ define([
         });
 
         $modal.modal('show');
+        $modal.one('shown', function () {
+            $modalBody.find("input:first").focus().select();
+        });
     };
     
     fn.generateNewModal = function (title, buttons, closeButtonTitle) {

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -1931,6 +1931,7 @@ define([
             $textarea.val(generateItextXLS(this, Itext));
 
             $modal.modal('show');
+            $modal.one('shown', function () { $textarea.focus(); });
         }
     });
 });


### PR DESCRIPTION
Small usability tweak to make keyboard shortcuts (such as CTRL+A to select all text or Escape to close) work as expected.
