### PR TITLE
Resizable vellum anyone?

### DIFF
--- a/src/window.js
+++ b/src/window.js
@@ -16,6 +16,21 @@ define([
             $(window).resize(adjustToWindow);
             $(document).scroll(adjustToWindow);
 
+            $('.fd-content-divider').mousedown(function (mousedown) {
+                var $left = $('.fd-content-left');
+                var leftWidth = $left.width();
+                var resize = function (mousemove) {
+                    $left.width(leftWidth + mousemove.pageX - mousedown.pageX);
+                    adjustToWindow();
+                };
+                $(window).disableSelection().on('mousemove', resize).one('mouseup', function () {
+                    $(this).enableSelection();
+                    $(this).off('mousemove', resize);
+                });
+            }).hover(function (e) {
+                e.target.style.cursor = 'col-resize';
+            });
+
             this.data.windowManager.offset = {
                 top: opts.topOffset || this.$f.offset().top-1,
                 bottom: opts.bottomOffset || 0,


### PR DESCRIPTION
You can now click on the divider (it'll give you a vertical resize cursor on hover) and drag it to resize the left and right panes real-time.

Due to how `windowManager` already auto-calculates the right pane to fit the rest of the screen, this was really easy.
