### PR TITLE
Require core before itemset

### DIFF
--- a/src/itemset.js
+++ b/src/itemset.js
@@ -28,6 +28,7 @@ define([
     'vellum/parser',
     'vellum/util',
     'vellum/debugutil',
+    'vellum/core',
     'jquery.bootstrap-better-typeahead'
 ], function (
     _,


### PR DESCRIPTION
https://github.com/dimagi/Vellum/commit/e67377561ebb7f50126b27154d1db00524d7a5e7

When itemset is not enabled (aka HQ) then vellum fails to load.

It's a little difficult to go through the compiled JS, but it errors on this line trying to use vellum before it's been defined: return t.vellum.plugin("itemset", {}, {getSelectQuestions: function() {
