### PR TITLE
up z-index of jstree-marker to fullscreen's z-in

### DIFF
--- a/src/less-style/tree-content.less
+++ b/src/less-style/tree-content.less
@@ -56,3 +56,7 @@
     color: @blueLight;
   }
 }
+
+#jstree-marker {
+  z-index:10000000
+}


### PR DESCRIPTION
Increased z-index by two orders. There should be a better 'style' to manage stacking elements or agreed-upon z-index orders. 
http://manage.dimagi.com/default.asp?150285
