### PR TITLE
Include jquery-ui theme images in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ _rjs:
 	cp bower_components/jstree/dist/themes/default/*.png \
 	   bower_components/jstree/dist/themes/default/*.gif \
 	   _build/bower_components/jstree/dist/themes/default
+	mkdir -p _build/bower_components/jquery-ui/themes/redmond/images
+	cp bower_components/jquery-ui/themes/redmond/images/*.png \
+	   bower_components/jquery-ui/themes/redmond/images/*.gif \
+	   _build/bower_components/jquery-ui/themes/redmond/images
 # combine CSS files (and adjust location for relative image paths)
 	# TODO do we need a blank line between the files? doesn't seem like it after initial test
 	cat _build/src/local-deps.css _build/src/main-components.css > _build/style.css


### PR DESCRIPTION
Not entirely certain why this wasn't done before, but after running `bower update` I'm getting 404's on the jquery-ui images when I load Vellum in HQ.

Related: I think these are the bower components that were updated on my machine when I ran `bower update`. Unfortunately it doesn't say what versions were in place before they were updated.
```
requirejs#2.1.15 bower_components/requirejs
sinonjs#1.10.2 bower_components/sinonjs
langcodes#4804f8f687 bower_components/langcodes
jsdiff#1.2.1 bower_components/jsdiff
requirejs-text#2.0.13 bower_components/requirejs-text
MediaUploader#170f4b63c7 bower_components/MediaUploader
requirejs-tpl#a3ca1e0e7f bower_components/requirejs-tpl
require-less#0.1.5 bower_components/require-less
require-css#0.1.8 bower_components/require-css
chai#1.10.0 bower_components/chai
requirejs-plugins#1.0.3 bower_components/requirejs-plugins
jquery#1.11.2 bower_components/jquery
```

@emord 