### PR TITLE
Fix tests failing only in my local environment

### DIFF
--- a/src/uploader.js
+++ b/src/uploader.js
@@ -309,6 +309,9 @@ define([
             var uploadController = {value: null};
 
             require(['file-uploader'], function (HQMediaFileUploadController) {
+                if (uploadController.value !== null) {
+                    return;
+                }
                 uploadController.value = new HQMediaFileUploadController(
                     options.uploaderSlug, 
                     options.mediaType, 
@@ -332,9 +335,12 @@ define([
         },
         destroy: function () {
             _.each(this.data.uploader.uploadControls, function (control, key) {
-                // HACK deep reach
-                // HQMediaFileUploadController should have a destroy method
-                control.value.uploader.destroy();
+                if (control.value) {
+                    // HACK deep reach
+                    // HQMediaFileUploadController should have a destroy method
+                    control.value.uploader.destroy();
+                }
+                delete control.value;
             });
         }
     });

--- a/test
+++ b/test
@@ -21,8 +21,7 @@ if [[ "$1" == "--no-jshint" ]]; then
     shift
 fi
 
-mocha-phantomjs -s loadImages=false "index.html$qs" "$@" \
-    | grep -v "Error loading resource file:///"
+mocha-phantomjs -s loadImages=false "index.html$qs" "$@"
 test ${PIPESTATUS[0]} -eq 0 # stop on mocha-phantomjs non-zero exit status
 # NOTE there may be edge cases where grep exits with non-zero causing this
 # script to exit prematurely


### PR DESCRIPTION
Also remove filter from test script now that it's not needed.

There seems to be a timing bug with asynchronously loading the file-uploader component, which subsequently caused the destroy method to fail, breaking tests. This was only observed in my local environment. Other developers and Travis did not see the problem. The bug was uncovered by https://github.com/dimagi/Vellum/pull/303, which seems entirely unrelated.

@emord 