### PR TITLE
Preserve unknown attributes on ODK intent

### DIFF
--- a/src/intentManager.js
+++ b/src/intentManager.js
@@ -19,6 +19,7 @@ define([
             xmlns: "http://opendatakit.org/xforms",
             extra: {},
             response: {},
+            unknownAttributes: {},
             initialNodeID: nodeID
         });
     }
@@ -54,6 +55,9 @@ define([
         xmlWriter.writeAttributeString("xmlns:odkx", this.getAttr('xmlns'));
         xmlWriter.writeAttributeString("id", currentNodeID || this.getAttr('initialNodeID'));
         xmlWriter.writeAttributeString("class", this.getAttr('path'));
+        _.each(this.getAttr('unknownAttributes'), function (value, name) {
+            xmlWriter.writeAttributeString(name, value);
+        });
         writeInnerTagXML(xmlWriter, 'extra', this.getAttr('extra'));
         writeInnerTagXML(xmlWriter, 'response', this.getAttr('response'));
         xmlWriter.writeEndElement('odkx:intent');
@@ -75,6 +79,15 @@ define([
                 newTag.setAttr('xmlns', xmlns || newTag.getAttr('xmlns'));
                 newTag.setAttr('extra', parseInnerTags($tag, 'extra'));
                 newTag.setAttr('response', parseInnerTags($tag, 'response'));
+                var unknowns = newTag.getAttr('unknownAttributes');
+                _.each(tagXML.attributes, function (attr) {
+                    if (attr.nodeName !== 'id' &&
+                        attr.nodeName !== 'class' &&
+                        attr.nodeName !== 'xmlns:odkx')
+                    {
+                        unknowns[attr.nodeName] = attr.nodeValue;
+                    }
+                });
                 that.unmappedIntentTags[tagId] = newTag;
             });
         };
@@ -124,7 +137,6 @@ define([
                 };
             intents = dataTree.treeMap(getIntentMugs);
             if (intents.length > 0) {
-                xmlWriter.writeComment('Intents inserted by Vellum:');
                 intents.map(function (intentMug) {
                     intentMug.intentTag.writeXML(
                         xmlWriter, intentMug.p.nodeID);

--- a/tests/intentManager.js
+++ b/tests/intentManager.js
@@ -1,0 +1,27 @@
+define([
+    'tests/utils',
+    'chai',
+    'underscore',
+    'jquery',
+    'text!static/intentManager/intent-with-unknown-attrs.xml'
+], function (
+    util,
+    chai,
+    _,
+    $,
+    INTENT_WITH_UNKNOWN_ATTRS_XML
+) {
+    describe("The intent manager plugin", function() {
+        before(function (done) {
+            util.init({
+                javaRosa: {langs: ['en']},
+                core: {onReady: done}
+            });
+        });
+
+        it("should preserve unknown attributes of intent tag", function () {
+            util.loadXML(INTENT_WITH_UNKNOWN_ATTRS_XML);
+            util.assertXmlEqual(util.call("createXML"), INTENT_WITH_UNKNOWN_ATTRS_XML);
+        });
+    });
+});

--- a/tests/main.js
+++ b/tests/main.js
@@ -99,6 +99,7 @@ require(['jquery', 'jquery.vellum'], function ($) {
         'tests/exporter',
         'tests/writer',
         'tests/javaRosa',
+        'tests/intentManager',
         'tests/formdesigner.ignoreButRetain',
         'tests/formdesigner.lock',
         'tests/itemset',

--- a/tests/static/all_question_types.xml
+++ b/tests/static/all_question_types.xml
@@ -298,7 +298,6 @@
 				</translation>
 			</itext>
 		</model>
-		&lt;!-- Intents inserted by Vellum: --&gt;
 		<odkx:intent xmlns:odkx="http://opendatakit.org/xforms" id="question7" class="app_id">
 			<extra key="key1" ref="value1" />
 			<response key="key2" ref="value2" />

--- a/tests/static/intentManager/intent-with-unknown-attrs.xml
+++ b/tests/static/intentManager/intent-with-unknown-attrs.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/DCA5F7B5-E9C1-4F7F-B432-A94B00252A46" uiVersion="1" version="1" name="Untitled Form">
+					<breath_count />
+				</data>
+			</instance>
+			<bind nodeset="/data/breath_count" type="intent" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="breath_count-label">
+						<value>breath_count</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+		<odkx:intent xmlns:odkx="http://opendatakit.org/xforms" id="breath_count" type="vnd.android-dir/mms-sms" class="android.intent.action.VIEW" button-label="Send SMS">
+			<extra key="sms_body" ref="/data/content" />
+			<extra key="address" ref="/data/address" />
+		</odkx:intent>
+	</h:head>
+	<h:body>
+		<input ref="/data/breath_count" appearance="intent:breath_count">
+			<label ref="jr:itext('breath_count-label')" />
+		</input>
+	</h:body>
+</h:html>

--- a/tests/static/profiling/small-form.xml
+++ b/tests/static/profiling/small-form.xml
@@ -262,7 +262,6 @@
 				</translation>
 			</itext>
 		</model>
-        &lt;!-- Intents inserted by Vellum: --&gt;
 		<odkx:intent xmlns:odkx="http://opendatakit.org/xforms" id="question7" class="app_id">
 			<extra key="key1" ref="value1" />
 			<response key="key2" ref="value2" />


### PR DESCRIPTION
This improves intent handling so Derek doesn't need to use ignore/retain anymore. See also [FB #149925](http://manage.dimagi.com/default.asp?149925).