### PR TITLE
Show correct language when node is opened

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -841,6 +841,7 @@ define([
             _this.activateQuestionTypeGroup(mug);
         }).bind("open_node.jstree", function (e, data) {
             _this.activateQuestionTypeGroup(_this.data.core.form.getMugByUFID(data.node.id));
+            _this.refreshVisibleData();
         }).bind("close_node.jstree", function (e, data) {
             var selected = _this.jstree('get_selected'),
                 sel = selected.length && _this.jstree('get_node', selected[0]);

--- a/src/core.js
+++ b/src/core.js
@@ -840,8 +840,11 @@ define([
             _this.displayMugProperties(mug);
             _this.activateQuestionTypeGroup(mug);
         }).bind("open_node.jstree", function (e, data) {
-            _this.activateQuestionTypeGroup(_this.data.core.form.getMugByUFID(data.node.id));
-            _this.refreshVisibleData();
+            var mug = _this.data.core.form.getMugByUFID(data.node.id);
+            _this.activateQuestionTypeGroup(mug);
+            _this.data.core.form.getDescendants(mug).map(function(descendant) {
+                _this.refreshMugName(descendant);
+            });
         }).bind("close_node.jstree", function (e, data) {
             var selected = _this.jstree('get_selected'),
                 sel = selected.length && _this.jstree('get_node', selected[0]);

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -179,6 +179,20 @@ require([
             assert(!hinItext.attr("placeholder"), hinItext.attr("placeholder"));
         });
 
+        it("should display correct language for question that was collapsed when language changed", function () {
+            util.loadXML("");
+            var group = util.addQuestion("Group", "group");
+            util.addQuestion("Text", "question2");
+            util.clickQuestion("group/question2");
+            $("[name='itext-en-label']").val('english').change();
+            $("[name='itext-hin-label']").val('hindi').change();
+            util.collapseGroup(group);
+            assert.equal($(".fd-question-tree .jstree-anchor").length, 1);
+            $(".fd-question-tree-lang select").val('hin').change();
+            util.expandGroup(group);
+            assert.equal($(".fd-question-tree .jstree-anchor:last").text(), "hindi");
+        });
+
         it("itext widget should not overwrite label with question id", function () {
             util.loadXML("");
             var q1 = util.addQuestion("Text");

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -220,10 +220,12 @@ define([
 
     function expandGroup(mug) {
         call("jstree", "open_node", mug.ufid);
+        call("jstree", "redraw_node", mug.ufid, true, false, false);
     }
 
     function collapseGroup(mug) {
         call("jstree", "close_node", mug.ufid);
+        call("jstree", "redraw_node", mug.ufid, true, false, false);
     }
 
     return {


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?148701

Are there any (performance) reasons to be more surgical about this, rather than just refreshing the whole tree?