### PR TITLE
Use itext value instead of widget value/placeholder

### DIFF
--- a/src/uploader.js
+++ b/src/uploader.js
@@ -168,9 +168,9 @@ define([
         widget.handleUploadComplete = function (event, data, objectMap) {
             if (data.ref && data.ref.path) {
                 var newExtension = '.' + data.ref.path.split('.').pop().toLowerCase(),
-                    oldExtension = '.' + widget.getValue().split('.').pop().toLowerCase();
+                    oldExtension = '.' + widget.getItextValue().split('.').pop().toLowerCase();
                 if (newExtension !== oldExtension) {
-                    var currentPath = widget.getValue().replace(/\.[^/.]+$/, newExtension);
+                    var currentPath = widget.getItextValue().replace(/\.[^/.]+$/, newExtension);
                     widget.getControl().val(currentPath);
                     widget.handleChange();
                 }
@@ -191,14 +191,14 @@ define([
         };
 
         widget.updateReference = function () {
-            var currentPath = widget.getValue();
+            var currentPath = widget.getItextValue();
             $uiElem.attr('data-hqmediapath', currentPath);
             widget.mediaRef.updateRef(currentPath);
         };
     };
 
     var getPreviewUI = function (widget, objectMap, ICONS) {
-        var currentPath = widget.getValue(),
+        var currentPath = widget.getItextValue(),
             previewHtml;
         if (!currentPath && !widget.isDefaultLang) {
             currentPath = widget.getItextItem().getValue(widget.form, widget.defaultLang);
@@ -217,7 +217,7 @@ define([
     };
 
     var getUploadButtonUI = function (widget, objectMap) {
-        var currentPath = widget.getValue() || widget.getPlaceholder(),
+        var currentPath = widget.getItextValue(),
             $uploadBtn;
         $uploadBtn = $(multimedia_upload_trigger({
             multimediaExists: currentPath in objectMap,

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -257,34 +257,42 @@ define([
                 return;
             }
 
-            this.data.uploader.uploadControls = {
-                'image': this.initUploadController({
-                    uploaderSlug: 'fd_hqimage', 
-                    mediaType: 'image',
-                    sessionid: sessionid,
-                    uploadUrl: uploadUrls.image,
-                    swfUrl: swfUrl
-                }),
-                'audio': this.initUploadController({
-                    uploaderSlug: 'fd_hqaudio',
-                    mediaType: 'audio',
-                    sessionid: sessionid,
-                    uploadUrl: uploadUrls.audio,
-                    swfUrl: swfUrl
-                }),
-                'video': this.initUploadController({
-                    uploaderSlug: 'fd_hqvideo',
-                    mediaType: 'video',
-                    sessionid: sessionid,
-                    uploadUrl: uploadUrls.video,
-                    swfUrl: swfUrl
-                })
+            this.data.deferredInit = function () {
+                this.data.uploader.uploadControls = {
+                    'image': this.initUploadController({
+                        uploaderSlug: 'fd_hqimage',
+                        mediaType: 'image',
+                        sessionid: sessionid,
+                        uploadUrl: uploadUrls.image,
+                        swfUrl: swfUrl
+                    }),
+                    'audio': this.initUploadController({
+                        uploaderSlug: 'fd_hqaudio',
+                        mediaType: 'audio',
+                        sessionid: sessionid,
+                        uploadUrl: uploadUrls.audio,
+                        swfUrl: swfUrl
+                    }),
+                    'video': this.initUploadController({
+                        uploaderSlug: 'fd_hqvideo',
+                        mediaType: 'video',
+                        sessionid: sessionid,
+                        uploadUrl: uploadUrls.video,
+                        swfUrl: swfUrl
+                    })
+                };
             };
         },
         initWidget: function (widget) {
             this.__callOld();
             if (!this.data.uploader.uploadEnabled) {
                 return;
+            }
+
+            var deferredInit = this.data.deferredInit;
+            if (deferredInit !== null) {
+                this.data.deferredInit = null;
+                deferredInit.apply(this);
             }
 
             addUploaderToWidget(widget, 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?159721

FYI @emord, https://github.com/dimagi/Vellum/pull/346 was incomplete because it only fixed one of the `widget.getValue()` calls. `widget.getPlaceholder()` had an odor when I reviewed that PR, but I couldn't think of an easy better way. Turns out `widget.getItextValue()` is exactly what we needed.

The second commit is a test speed optimization, and is completely unrelated to the fix.
