### PR TITLE
Fix save after delete

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -221,6 +221,16 @@ define([
     }
 
     Form.prototype = {
+        clearDataTree: function() {
+            var rootId = this.getBasePath().slice(1,-1),
+                dataTree = new Tree(rootId, 'data');
+            this.tree.walk(function(mug, nodeID, processChildren) {
+                processChildren();
+                if (mug) {
+                    dataTree.removeMug(mug);
+                }
+            });
+        },
         dataTree: function() {
             var rootId = this.getBasePath().slice(1,-1),
                 dataTree = new Tree(rootId, 'data'),

--- a/src/writer.js
+++ b/src/writer.js
@@ -36,6 +36,7 @@ define([
         }
         
         createBindList(dataTree, xmlWriter);
+        form.clearDataTree();
         
         _.each(form.getSetValues(), function (setValue) {
             xmlWriter.writeStartElement('setvalue');

--- a/tests/writer.js
+++ b/tests/writer.js
@@ -73,6 +73,18 @@ require([
                 {normalize_xmlns: true}
             );
         });
+
+        it("should still save more than once", function () {
+            util.call("loadXML", "");
+            util.addQuestion("FieldList", 'fieldlist');
+            util.addQuestion("Text", 'text1');
+            util.addQuestion("Text", 'text2');
+            util.addQuestion("Text", 'text3');
+            util.addQuestion("Text", 'text4');
+            util.call("createXML");
+            util.deleteQuestion("/data/fieldlist/text1");
+            util.call("createXML");
+        });
     });
 
 });


### PR DESCRIPTION
@millerdev 

http://manage.dimagi.com/default.asp?161469#899207

This is not a great solution, but the issue is that saving breaks if you try to delete something in a group, question list, or repeat group and you try to save more than once.

The root issue here is the Tree is a little too clever. If you create a new tree inside each node it has an attribute _node_treeName. That attribute holds it's place in the tree.

After my recent refactor we simplified down to one tree, but we need a second tree to dynamically create the data tree. That adds _node_data to each mug so the group still references a deleted node in the data tree, but removes it from the main tree. 

That means that on the second save, while you are creating the data tree, once you get to that group you will try to iterate over a node that has no _node_control attribute, so it will crash as it cannot find the path of the node.

The real solution here is to create a walkDataTree method that does not create a new tree, but  dynamically applies a callback to the mugs. Unfortunately that's kind of hard to do and my first efforts have broken a lot of things (like nesting in the data tree).