### PR TITLE
Real fix save after delete

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -183,6 +183,12 @@ define([
 
             //If we got this far, everything checks out.
             return true;
+        },
+        getRootNode: function () {
+            if (this.isRootNode) {
+                return this;
+            }
+            return this.parent.getRootNode();
         }
     };
 
@@ -252,7 +258,7 @@ define([
                 node = this.getNodeFromMug(mug),
                 refNodeIndex, refNodeParent;
 
-            if (node) {
+            if (node && this.rootNode === node.getRootNode()) {
                 this._removeNodeFromTree(node); 
             } else {
                 node = new Node(null, mug);

--- a/tests/writer.js
+++ b/tests/writer.js
@@ -73,6 +73,18 @@ require([
                 {normalize_xmlns: true}
             );
         });
+
+        it("should still save more than once", function () {
+            util.call("loadXML", "");
+            util.addQuestion("FieldList", 'fieldlist');
+            util.addQuestion("Text", 'text1');
+            util.addQuestion("Text", 'text2');
+            util.addQuestion("Text", 'text3');
+            util.addQuestion("Text", 'text4');
+            util.call("createXML");
+            util.deleteQuestion("/data/fieldlist/text1");
+            util.call("createXML");
+        });
     });
 
 });


### PR DESCRIPTION
Shout out to @millerdev for this more intelligent fix. This is take 2 of https://github.com/dimagi/Vellum/pull/358

The solution is to remove node from the tree if it has a different root node from the current tree. This can happen if you try to create a new tree type with the same name as a previously used one. (like when you create data trees dynamically)

I still think a better solution is to create walkDataTree which never actually creates a new tree, but that's a little harder than initially thought.