### PR TITLE
Defer duplicate Question ID error popup until click save

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -524,7 +524,7 @@ define([
                 if (spec && spec.validationFunc(mug) !== 'pass') {
                     mug.p.set("dataParent"); // clear dataParent
                 }
-                newId = oldId;
+                newId = mug.p.conflictedNodeId || oldId;
                 conflictParent = mug.parentMug;
             }
 

--- a/src/form.js
+++ b/src/form.js
@@ -449,37 +449,111 @@ define([
                 errors: this.errors
             });
         },
+        /**
+         * Get a list of warnings pertaining to form serialization
+         *
+         * All serialization warnings reported here can be fixed
+         * automatically, but the user may prefer to fix them manually.
+         *
+         * @returns - A list of error objects. See
+         * `Mug.getSerializationWarnings` for more details.
+         */
+        getSerializationWarnings: function () {
+            var errors = [];
+            this.walkMugs(function (mug) {
+                var errs = mug.getSerializationWarnings();
+                if (errs.length) {
+                    errors.push({mug: mug, errors: errs});
+                }
+            });
+            return errors;
+        },
+        /**
+         * Automatically fix serialization errors
+         *
+         * After fixing serialization errors, no more errors
+         * should be reported by `getSerializationWarnings`.
+         *
+         * @param errors - The list of error objects returned by
+         *                 `getSerializationWarnings`.
+         */
+        fixSerializationWarnings: function (errors) {
+            _.each(errors || [], function (error) {
+                error.mug.fixSerializationWarnings(error.errors);
+            });
+        },
         isFormValid: function (validateMug) {
             return this.tree.isTreeValid(validateMug);
         },
-        getMugChildrenByNodeID: function (mug, nodeID) {
-            var parentNode = (mug ? this.tree.getNodeFromMug(mug)
-                                  : this.tree.rootNode);
-            return _.filter(parentNode.getChildrenMugs(), function (m) {
-                return m.p.nodeID === nodeID;
-            });
+        findFirstMatchingChild: function (parentMug, match) {
+            var parent = (parentMug ? this.tree.getNodeFromMug(parentMug)
+                                    : this.tree.rootNode);
+            return _.find(parent.getChildrenMugs(), match);
         },
         insertMug: function (refMug, newMug, position) {
             this.tree.insertMug(newMug, position, refMug);
         },
         /**
          * Move a mug from its current place to
-         * the position specified by the arguments,
+         * the position specified by the arguments.
+         *
+         * @param mug - The mug to be moved.
+         * @param position - The position relative to `refMug`
+         *          ("after", "into", "last", etc.) or "rename", in
+         *          which case `refMug` is the new name.
+         * @param refMug - The mug relative to which `mug` is moving.
+         *          Alternately, the new name if `position` is "rename".
+         * @returns - True if the mug was able to be moved without
+         *          changing it's nodeID, otherwise false.
          */
-        moveMug: function (mug, refMug, position) {
-            var oldPath = this.tree.getAbsolutePath(mug);
+        moveMug: function (mug, position, refMug) {
+            function match(sibling) {
+                return sibling !== mug && sibling.p.nodeID === newId;
+            }
+            var oldId = mug.p.nodeID,
+                oldPath = this.tree.getAbsolutePath(mug),
+                oldParent = mug.parentMug,
+                newId, conflictParent;
 
-            this.insertMug(refMug, mug, position);
+            if (position === "rename") {
+                newId = refMug;
+                conflictParent = oldParent;
+            } else {
+                this.insertMug(refMug, mug, position);
+                var spec = mug.spec.dataParent;
+                if (spec && spec.validationFunc(mug) !== 'pass') {
+                    mug.p.set("dataParent"); // clear dataParent
+                }
+                newId = oldId;
+                conflictParent = mug.parentMug;
+            }
 
-            var currentPath = this.tree.getAbsolutePath(mug);
+            // TODO make Item not a special case
+            if (mug.__className !== "Item") {
+                if (this.findFirstMatchingChild(conflictParent, match)) {
+                    mug.p.conflictedNodeId = newId;
+                    newId = this.generate_question_id(newId, mug);
+                    // HACK broken abstraction barrier
+                    this.vellum.setTreeValidationIcon(mug);
+                } else if (mug.p.has("conflictedNodeId")) {
+                    mug.p.set("conflictedNodeId"); // clear conflict
+                    // HACK broken abstraction barrier
+                    this.vellum.setTreeValidationIcon(mug);
+                }
+
+                if (mug.p.nodeID !== newId) {
+                    // rename without events; nodeID setter calls form.moveMug
+                    mug.p.set("nodeID", newId);
+                }
+            }
+
+            var newPath = this.tree.getAbsolutePath(mug);
             this.vellum.handleMugRename(
-                this, mug, mug.p.nodeID, mug.p.nodeID, currentPath, oldPath);
+                this, mug, newId, oldId, newPath, oldPath, oldParent);
 
-            this.fire({
-                type: 'question-move',
-                mug: mug
-            });
-            this.fireChange(mug);
+            if (position !== "rename") {
+                this.fireChange(mug);
+            }
         },
         /**
          * Walk through the mugs of the tree and call valueFunc on each mug
@@ -503,30 +577,26 @@ define([
             }
             return desc;
         },
-        handleMugRename: function (mug, currentId, oldId, currentPath, oldPath) {
-            this._logicManager.updatePath(mug.ufid, oldPath, currentPath);
-            this.mugWasRenamed(mug, oldId, oldPath);
-        },
         /**
          * Update references to mug and its children after it is renamed.
          */
-        mugWasRenamed: function(mug, oldName, oldPath) {
+        handleMugRename: function (mug, newId, oldId, newPath, oldPath, oldParent) {
             function getPreMovePath(postPath) {
-                if (postPath === mugPath) {
+                if (postPath === newPath) {
                     return oldPath;
                 }
                 return postPath.replace(postRegExp, oldPath + "/");
             }
-            var tree = this.tree,
-                mugPath = tree.getAbsolutePath(mug);
-            if (!mugPath) {
+            this._logicManager.updatePath(mug.ufid, oldPath, newPath);
+            var tree = this.tree;
+            if (!newPath) {
                 // Items don't have an absolute path. I wonder if it would
                 // matter if they had one?
                 return;
             }
             var mugs = this.getDescendants(mug).concat([mug]),
                 postMovePaths = _(mugs).map(function(mug) { return tree.getAbsolutePath(mug); }),
-                postRegExp = new RegExp("^" + RegExp.escape(mugPath) + "/"),
+                postRegExp = new RegExp("^" + RegExp.escape(newPath) + "/"),
                 updates = {},
                 preMovePath;
             for (var i = 0; i < mugs.length; i++) {
@@ -538,6 +608,17 @@ define([
             }
             this._logicManager.updatePaths(updates);
             this.fixBrokenReferences(mug);
+            // TODO make Item not a special case
+            if (mug.__className !== "Item") {
+                // update first child of old parent with matching conflicted nodeID
+                var conflict = this.findFirstMatchingChild(oldParent, function (mug) {
+                        var conflictId = mug.p.conflictedNodeId;
+                        return conflictId && conflictId === oldId;
+                    });
+                if (conflict) {
+                    this.moveMug(conflict, "rename", oldId);
+                }
+            }
         },
         changeMugType: function (mug, questionType) {
             this.mugTypes.changeType(mug, questionType);
@@ -580,8 +661,7 @@ define([
             if (depth === 0) {
                 var nodeID = mug.p.nodeID;
                 if (nodeID) {
-                    var newQuestionID = this.generate_question_id(nodeID); 
-                    duplicate.p.nodeID = newQuestionID;
+                    duplicate.p.set("conflictedNodeId"); // clear conflict
                 } else {
                     var newItemValue = this.generate_question_id(
                         mug.p.defaultValue);
@@ -627,14 +707,6 @@ define([
                 // skip property change handlers during loading phase
                 return function () {};
             }
-            // update the logic properties that reference the mug
-            if (property === 'nodeID' && previous &&
-                this.getMugChildrenByNodeID(mug.parentMug, value).length > 0)
-            {
-                // Short-circuit invalid change and trigger warning in UI
-                this.vellum.setUnsavedDuplicateNodeId(value);
-                return null;
-            }
 
             return function () {
                 var event = {
@@ -661,28 +733,9 @@ define([
             }.bind(this);
         },
         handleMugPropertyChange: function (mug, e) {
-            if (e.property === 'nodeID') {
-                var currentPath = this.getAbsolutePath(mug),
-                    valid = true,
-                    parsed;
-                try {
-                    parsed = xpath.parse(currentPath);
-                    if (_.isUndefined(parsed.steps)) {
-                        valid = false;
-                    }
-                } catch (err) {
-                    valid = false;
-                }
-                if (valid) {
-                    parsed.steps[parsed.steps.length - 1].name = e.previous;
-                    var oldPath = parsed.toXPath();
-                    this.vellum.handleMugRename(this, mug, e.val, e.previous, currentPath, oldPath);
-                }
-            } else {
-                if (mug.p.getDefinition(e.property).widget === widgets.xPath ||
-                    mug.p.getDefinition(e.property).widget === widgets.droppableText) {
-                    this.updateAllLogicReferences(mug);
-                }
+            var widget = mug.p.getDefinition(e.property).widget;
+            if (widget === widgets.xPath || widget === widgets.droppableText) {
+                this.updateAllLogicReferences(mug);
             }
         },
         createQuestion: function (refMug, position, newMugType, isInternal) {

--- a/src/form.js
+++ b/src/form.js
@@ -503,8 +503,6 @@ define([
          *          which case `refMug` is the new name.
          * @param refMug - The mug relative to which `mug` is moving.
          *          Alternately, the new name if `position` is "rename".
-         * @returns - True if the mug was able to be moved without
-         *          changing it's nodeID, otherwise false.
          */
         moveMug: function (mug, position, refMug) {
             function match(sibling) {
@@ -609,11 +607,10 @@ define([
             this._logicManager.updatePaths(updates);
             this.fixBrokenReferences(mug);
             // TODO make Item not a special case
-            if (mug.__className !== "Item") {
+            if (oldId && mug.__className !== "Item") {
                 // update first child of old parent with matching conflicted nodeID
                 var conflict = this.findFirstMatchingChild(oldParent, function (mug) {
-                        var conflictId = mug.p.conflictedNodeId;
-                        return conflictId && conflictId === oldId;
+                        return mug.p.conflictedNodeId === oldId;
                     });
                 if (conflict) {
                     this.moveMug(conflict, "rename", oldId);

--- a/src/form.js
+++ b/src/form.js
@@ -734,7 +734,7 @@ define([
         },
         handleMugPropertyChange: function (mug, e) {
             var widget = mug.p.getDefinition(e.property).widget;
-            if (widget === widgets.xPath || widget === widgets.droppableText) {
+            if (widget && widget.hasLogicReferences) {
                 this.updateAllLogicReferences(mug);
             }
         },

--- a/src/jstree-plugins.js
+++ b/src/jstree-plugins.js
@@ -23,7 +23,7 @@ define([
     "use strict";
     $.jstree.defaults.conditionalevents = {
         should_activate: function () { return true; },
-        should_move: function () { return true; },
+        //should_move: function () { return true; },
         redraw_node: function () {
             var args = Array.prototype.slice.call(arguments);
             return this.parent.redraw_node.apply(this.inst, args);
@@ -36,12 +36,12 @@ define([
                 parent.activate_node.apply(this, args);
             }
         };
-        this.move_node = function () {
-            var args = Array.prototype.slice.call(arguments);
-            if(this.settings.conditionalevents.should_move.apply(this, args)) {
-                parent.move_node.apply(this, args);
-            }
-        };
+        //this.move_node = function () {
+        //    var args = Array.prototype.slice.call(arguments);
+        //    if(this.settings.conditionalevents.should_move.apply(this, args)) {
+        //        parent.move_node.apply(this, args);
+        //    }
+        //};
         this.redraw_node = function () {
             var args = Array.prototype.slice.call(arguments),
                 base = {inst: this, parent: parent};

--- a/src/modeliteration.js
+++ b/src/modeliteration.js
@@ -300,6 +300,7 @@ define([
         if (Boolean(value && value.idsQuery) !== Boolean(previous && previous.idsQuery)) {
             var nodeID = mug.p.nodeID,
                 currentPath = mug.form.getAbsolutePath(mug),
+                oldParent = mug.parentMug,
                 oldPath;
             if (value && value.idsQuery) {
                 oldPath = currentPath.replace(/\/item$/, "");
@@ -310,7 +311,7 @@ define([
                 }
             }
             mug.form.vellum.handleMugRename(
-                mug.form, mug, nodeID, nodeID, currentPath, oldPath);
+                mug.form, mug, nodeID, nodeID, currentPath, oldPath, oldParent);
         }
     }
 

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -71,26 +71,42 @@ define([
         getAttrs: function () {
             return _.clone(this.__data);
         },
+        has: function (attr) {
+            return this.__data.hasOwnProperty(attr);
+        },
+        set: function (attr, val) {
+            // set or clear property without triggering events, unlike _set
+            if (arguments.length > 1) {
+                this.__data[attr] = val;
+            } else {
+                delete this.__data[attr];
+            }
+        },
         _get: function (attr) {
             return this.__data[attr];
         },
         _set: function (attr, val) {
             var spec = this.__spec[attr],
-                prev = this.__data[attr];
+                prev = this.__data[attr],
+                mug = this.__mug;
 
             if (!spec || val === prev ||
                 // only set attr if spec allows this attr, except if mug is a
                 // DataBindOnly (which all mugs are before the control block has
                 // been parsed).
                 (spec.presence === 'notallowed' &&
-                 this.__mug.__className !== 'DataBindOnly'))
+                 mug.__className !== 'DataBindOnly'))
             {
                 return;
             }
 
-            var callback = this.shouldChange(this.__mug, attr, val, prev);
+            var callback = this.shouldChange(mug, attr, val, prev);
             if (callback) {
-                this.__data[attr] = val;
+                if (spec.setter) {
+                    spec.setter(mug, attr, val);
+                } else {
+                    this.__data[attr] = val;
+                }
                 callback();
             }
         },
@@ -138,10 +154,32 @@ define([
                 visibility: 'visible',
                 presence: 'required',
                 lstring: 'Question ID',
+                setter: function (mug, attr, value) {
+                    mug.form.moveMug(mug, "rename", value);
+                },
+                mugValue: function (mug, value) {
+                    if (arguments.length === 1) {
+                        if (mug.p.has("conflictedNodeId")) {
+                            return mug.p.conflictedNodeId;
+                        }
+                        return mug.p.nodeID;
+                    }
+                    mug.p.nodeID = value;
+                },
                 widget: widgets.identifier,
                 validationFunc: function (mug) {
+                    var warnings = mug.getSerializationWarnings();
+                    if (warnings.length) {
+                        return _.map(warnings, function (err) {
+                            return err.message;
+                        }).join("\n");
+                    }
                     return validateElementName(mug.p.nodeID, "Question ID");
                 }
+            },
+            conflictedNodeId: {
+                visibility: 'hidden',
+                presence: 'optional'
             },
             dataValue: {
                 visibility: 'visible',
@@ -511,6 +549,51 @@ define([
         },
         getErrors: function () {
             return this.p.getErrors();
+        },
+        /**
+         * Get a list of form serialization warnings
+         *
+         * All warnings returned by this function should also be reported
+         * by the normal mug validation process. Serialization warnings
+         * can be ignored or fixed automatically, but the user may
+         * prefer to fix them manually.
+         *
+         * @returns - A list of warning objects, each having a `message`
+         * attribute describing the warning. This list can be passed to
+         * `fixSerializationWarnings` to automatically fix the warnings.
+         */
+        getSerializationWarnings: function () {
+            var dupId = this.p.conflictedNodeId;
+            if (!_.isUndefined(dupId)) {
+                return [{
+                    code: "conflictedNodeId",
+                    message: "'" + dupId + "' has the same Question ID as " +
+                        "another question in the same group. Please choose " +
+                        "a unique Question ID."
+                }];
+            }
+            return [];
+        },
+        /**
+         * Automatically fix serialization warnings
+         *
+         * No warnings should be reported by `getSerializationWarnings`
+         * after calling this function with the list of warnings
+         * returned by `getSerializationWarnings`.
+         *
+         * @param warnings - The list of warnings returned by
+         *                 `getSerializationWarnings`.
+         */
+        fixSerializationWarnings: function (warnings) {
+            var mug = this;
+            _.each(warnings, function (warning) {
+                if (warning.code === "conflictedNodeId") {
+                    // clear warning; mug already has copy-N-of-... ID
+                    mug.p.set("conflictedNodeId");
+                    return;
+                }
+                throw new Error("unknown warning: " + warning.code);
+            });
         },
         isValid: function () {
             return !this.getErrors().length;

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -303,6 +303,11 @@ define([
                     return recFunc(mug.parentMug);
                 },
                 presence: 'optional',
+                setter: function (mug, attr, value) {
+                    var oldPath = mug.absolutePath;
+                    mug.p.set(attr, value);
+                    mug.form._updateMugPath(mug, oldPath);
+                },
                 widget: widgets.droppableText,
                 validationFunc: function(mug) {
                     var dataParent = mug.p.dataParent,

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -138,6 +138,7 @@ define([
                 visibility: 'visible',
                 presence: 'required',
                 lstring: 'Question ID',
+                widget: widgets.identifier,
                 validationFunc: function (mug) {
                     return validateElementName(mug.p.nodeID, "Question ID");
                 }
@@ -825,6 +826,7 @@ define([
                 lstring: 'Choice Value',
                 visibility: 'visible',
                 presence: 'required',
+                widget: widgets.identifier,
                 validationFunc: function (mug) {
                     if (/\s/.test(mug.p.defaultValue)) {
                         return "Whitespace in values is not allowed.";

--- a/src/templates/form_errors_template.html
+++ b/src/templates/form_errors_template.html
@@ -1,0 +1,12 @@
+<ul>
+<% _.each(errors, function (error) { %>
+    <li>
+        <%= error.mug.getDisplayName(displayLanguage) %>
+        <ul>
+        <% _.each(error.errors, function (error) { %>
+            <li><%= error.message %></li>
+        <% }); %>
+        </ul>
+    </li>
+<% }); %>
+</ul>

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -84,11 +84,17 @@ define([
         var path = options.widgetValuePath || options.path,
             inputID = 'property-' + path,
             disabled = options.disabled || false,
-            widget = base(mug, options);
+            widget = base(mug, options),
+            mugValue = options.mugValue || function (mug, value) {
+                if (arguments.length === 1) {
+                    return mug.p[path];
+                }
+                mug.p[path] = value;
+            };
 
         widget.path = path;
         widget.definition = mug.p.getDefinition(options.path);
-        widget.currentValue = mug.p[path];
+        widget.currentValue = mugValue(mug);
         widget.id = inputID;
 
         widget.input = $("<input />")
@@ -100,7 +106,7 @@ define([
         };
 
         widget.save = function () {
-            this.mug.p[this.path] = this.getValue();
+            mugValue(mug, widget.getValue());
         };
         return widget;
     };

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -180,6 +180,7 @@ define([
 
         return widget;
     };
+    droppableText.hasLogicReferences = true;
 
     var checkbox = function (mug, options) {
         var widget = normal(mug, options),
@@ -201,9 +202,8 @@ define([
     };
 
     var xPath = function (mug, options) {
-        var widget = text(mug, options);
-
-        var super_getValue = widget.getValue,
+        var widget = text(mug, options),
+            super_getValue = widget.getValue,
             super_setValue = widget.setValue;
         widget.getValue = function() {
             var val = super_getValue();
@@ -239,6 +239,7 @@ define([
 
         return widget;
     };
+    xPath.hasLogicReferences = true;
 
     var baseKeyValue = function (mug, options) {
         var widget = base(mug, options),

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -65,24 +65,6 @@ define([
         widget.updateValue = function () {
             // When a widget's value changes, do whatever work you need to in 
             // the model/UI to make sure we are in a consistent state.
-            
-            var isID = (['nodeID', 'defaultValue'].indexOf(widget.path) !== -1),
-                val = widget.getValue();
-
-            if (isID && val.indexOf(' ') !== -1) { 
-                // attempt to sanitize nodeID and choice values
-                // TODO, still may allow some bad values
-                widget.setValue(val.replace(/\s/g, '_'));
-            }
-            
-            //short circuit the mug property changing process for when the
-            //nodeID is changed to empty-string (i.e. when the user backspaces
-            //the whole value).  This allows us to keep a reference to everything
-            //and rename smoothly to the new value the user will ultimately enter.
-            if (isID && val === "") {
-                return;
-            }
-            
             widget.save();
         };
 
@@ -152,6 +134,33 @@ define([
         input.bind("change input", function () {
             widget.handleChange();
         });
+        return widget;
+    };
+
+    var identifier = function (mug, options) {
+        var widget = text(mug, options),
+            super_updateValue = widget.updateValue;
+
+        widget.updateValue = function () {
+            var val = widget.getValue();
+
+            if (val.indexOf(' ') !== -1) {
+                // attempt to sanitize nodeID and choice values
+                // TODO, still may allow some bad values
+                widget.setValue(val.replace(/\s/g, '_'));
+            }
+
+            //short circuit the mug property changing process for when the
+            //nodeID is changed to empty-string (i.e. when the user backspaces
+            //the whole value).  This allows us to keep a reference to everything
+            //and rename smoothly to the new value the user will ultimately enter.
+            if (val === "") {
+                return;
+            }
+
+            super_updateValue();
+        };
+
         return widget;
     };
 
@@ -356,6 +365,7 @@ define([
         base: base,
         normal: normal,
         text: text,
+        identifier: identifier,
         droppableText: droppableText,
         checkbox: checkbox,
         xPath: xPath,

--- a/tests/commtrack.js
+++ b/tests/commtrack.js
@@ -116,7 +116,7 @@ define([
             util.loadXML(TRANSFER_BLOCK_XML);
             var group = util.addQuestion("Repeat", "group"),
                 trans = util.getMug("transfer[@type='trans-1']");
-            trans.form.moveMug(trans, group, "into");
+            trans.form.moveMug(trans, "into", group);
             var xml = util.call("createXML"),
                 $xml = $(xml);
             assert.equal($xml.find("setvalue[event=jr-insert]").length, 4, xml);

--- a/tests/core.js
+++ b/tests/core.js
@@ -29,27 +29,13 @@ require([
         pluginsWithoutItemset = _(util.options.options.plugins || []).without("itemset");
 
     describe("Vellum core", function () {
-        it("should not allow adding questions with matching paths", function (done) {
-            util.init({
-                core: {
-                    onReady: function () {
-                        var dup;
-                        util.addQuestion("Text", "question1");
-                        dup = util.addQuestion("Text", "question2");
-                        dup.p.nodeID = "question1";
-
-                        // TODO fix tight coupling of this functionality with UI
-                        // HACK prevent modal alert in UI
-                        this.data.core.isAlertVisible = true;
-
-                        assert(!this.ensureCurrentMugIsSaved(),
-                               "save should fail with duplicate question ID");
-
-                        this.data.core.isAlertVisible = false;
-                        done();
-                    }
-                }
-            });
+        it("should show validation error on add question with duplicate path", function () {
+            var form = util.loadXML("");
+            util.addQuestion("Text", "question1");
+            var dup = util.addQuestion("Text", "question2");
+            dup.p.nodeID = "question1";
+            assert(form.vellum.ensureCurrentMugIsSaved(), "mug is not saved");
+            assert(!util.isTreeNodeValid(dup), "mug should not be valid");
         });
 
         it("should load form with save button in 'saved' state", function (done) {

--- a/tests/diffDataParent.js
+++ b/tests/diffDataParent.js
@@ -59,7 +59,7 @@ require([
             util.addQuestion("Group", 'group1');
             text2.p.dataParent = '/data/group1';
 
-            form.moveMug(text2, text1, 'before');
+            form.moveMug(text2, 'before', text1);
 
             assert.equal(text2.p.dataParent, '/data/group1');
         });
@@ -73,7 +73,7 @@ require([
 
             text1.p.dataParent = '/data/group1';
             assert.equal(text1.p.dataParent, "/data/group1");
-            form.moveMug(group1, group2, 'into');
+            form.moveMug(group1, 'into', group2);
             assert.equal(text1.p.dataParent, "/data/group2/group1");
         });
 
@@ -84,8 +84,8 @@ require([
             var repeat1= util.addQuestion.bind({prevId: text1.p.nodeID})("Repeat", 'repeat1'),
                 form = call("getData").core.form;
             text1.p.dataParent = '/data/group1';
-            form.moveMug(text1, repeat1, 'into');
-            assert(util.isTreeNodeValid(text1), "text1 should be valid");
+            form.moveMug(text1, 'into', repeat1);
+            assert(util.isTreeNodeValid(text1), text1.getErrors().join("\n"));
             assert.isUndefined(text1.p.dataParent);
         });
 

--- a/tests/diffDataParent.js
+++ b/tests/diffDataParent.js
@@ -105,6 +105,21 @@ require([
             );
         });
 
+        it("should update mug path mapping on set data parent", function() {
+            var form = util.loadXML(""),
+                text = util.addQuestion("Text", 'text');
+            util.addQuestion("Group", 'group');
+            text.p.dataParent = '/data/group';
+            var map = JSON.stringify(_.object(_.map(form.mugMap, function (mug, path) {
+                if (path.startsWith("/")) {
+                    return [path, mug.__className];
+                }
+                return ["", undefined];
+            })));
+            assert(util.getMug('/data/group/text'),
+                   'cannot find "/data/group/text" in ' + map);
+        });
+
         it("should parse and write XML to have the same order", function() {
             util.loadXML(PARSE_XML);
             util.assertXmlEqual(call("createXML"), PARSE_XML);
@@ -129,7 +144,7 @@ require([
             util.addQuestion("Text", 'text2');
 
             text1.p.dataParent = '/data/group';
-            util.addQuestion.bind({prevId: text1.p.nodeID})("Text", 'text3');
+            util.addQuestion.bind({prevId: text1.absolutePath})("Text", 'text3');
             // questions with alternate dataParent always come last in the data tree
             util.assertTreeState(form.dataTree(),
                 "text3",

--- a/tests/form.js
+++ b/tests/form.js
@@ -68,6 +68,24 @@ define([
             assert(util.isTreeNodeValid(black), black.getErrors().join("\n"));
         });
 
+        it("should retain conflicted mug ID on move", function () {
+            var form = util.loadXML(""),
+                hid = util.addQuestion("DataBindOnly", "hid"),
+                text = util.addQuestion("Text", "text"),
+                group = util.addQuestion("Group", "group");
+            util.addQuestion("Text", "text");
+            hid.p.calculateAttr = "/data/text + /data/group/text";
+            form.moveMug(text, "into", group);
+            assert.notEqual(hid.p.calculateAttr, "/data/text + /data/group/text");
+            assert.notEqual(text.p.nodeID, "text");
+            assert(!util.isTreeNodeValid(text), "expected /data/text error");
+
+            form.moveMug(text, "into", null);
+            assert.equal(text.p.nodeID, "text");
+            assert.equal(hid.p.calculateAttr, "/data/text + /data/group/text");
+            assert(util.isTreeNodeValid(text), text.getErrors().join("\n"));
+        });
+
         it("should show warnings for broken references on delete mug", function () {
             util.loadXML(QUESTION_REFERENCING_OTHER_XML);
             var blue = call("getMugByPath", "/data/blue"),

--- a/tests/form.js
+++ b/tests/form.js
@@ -36,6 +36,38 @@ define([
             });
         });
 
+        it("should get and fix serialization errors for mugs with matching paths", function () {
+            var form = util.loadXML(""),
+                one = util.addQuestion("Text", "question"),
+                two = util.addQuestion("Text", "question");
+            assert.notEqual(one.absolutePath, two.absolutePath);
+            var errors = form.getSerializationWarnings();
+            assert.equal(errors.length, 1, "missing serialization error message");
+            assert.equal(errors[0].mug.ufid, two.ufid);
+
+            form.fixSerializationWarnings(errors);
+            assert.equal(one.p.nodeID, "question");
+            assert.notEqual(one.absolutePath, two.absolutePath);
+            assert.deepEqual(form.getSerializationWarnings(), []);
+        });
+
+        it("should retain expression meaning on rename matching path", function () {
+            var blue = util.addQuestion("Text", "blue"),
+                green = util.addQuestion("Text", "green"),
+                black = util.addQuestion("DataBindOnly", "black");
+            black.p.calculateAttr = "/data/blue + /data/green";
+            green.p.nodeID = "blue";
+            assert.notEqual(green.p.nodeID, "blue");
+            assert(!util.isTreeNodeValid(green), "expected validation error");
+
+            blue.p.nodeID = "orange";
+            assert.equal(green.p.nodeID, "blue");
+            assert.equal(black.p.calculateAttr, "/data/orange + /data/blue");
+            assert(util.isTreeNodeValid(blue), blue.getErrors().join("\n"));
+            assert(util.isTreeNodeValid(green), green.getErrors().join("\n"));
+            assert(util.isTreeNodeValid(black), black.getErrors().join("\n"));
+        });
+
         it("should show warnings for broken references on delete mug", function () {
             util.loadXML(QUESTION_REFERENCING_OTHER_XML);
             var blue = call("getMugByPath", "/data/blue"),
@@ -84,7 +116,7 @@ define([
                 item1 = util.getMug("question1/item1"),
                 item2 = util.getMug("question2/item2");
             // should not throw an error
-            form.moveMug(item1, item2, 'before');
+            form.moveMug(item1, 'before', item2);
         });
 
         it("should update reference to hidden value in group", function () {
@@ -109,7 +141,7 @@ define([
 
             chai.expect(label.p.relevantAttr).to.include("/data/group/hidden");
             chai.expect(label.p.labelItext.defaultValue()).to.include("/data/group/hidden");
-            form.moveMug(hidden, null, "first");
+            form.moveMug(hidden, "first", null);
             assert.equal(hidden.absolutePath, "/data/hidden");
             chai.expect(label.p.relevantAttr).to.include("/data/hidden");
             chai.expect(label.p.labelItext.defaultValue()).to.include("/data/hidden");

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -194,7 +194,7 @@ require([
                 btn.click();
                 assert.equal(
                     btn.next().find('li:contains("Cannot Change Question Type")').length,
-                    !bool);
+                    +!bool);
             }
             it("shows the type changer for type-changeable questions", function () {
                 testTypeChangeable(true);

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -536,7 +536,7 @@ require([
                 south = util.getMug("ew/item1");
             north.p.defaultValue = "north";
             south.p.defaultValue = "south";
-            north.form.moveMug(south, north, "after");
+            north.form.moveMug(south, "after", north);
             util.assertXmlEqual(util.call("createXML"), ITEXT_ITEM_RENAME_XML,
                                 {normalize_xmlns: true});
         });
@@ -546,7 +546,7 @@ require([
             var green = util.addQuestion("Group", "green"),
                 blue = util.addQuestion("Group", "blue");
             util.addQuestion("Text", "text");
-            blue.form.moveMug(blue, green, "before");
+            blue.form.moveMug(blue, "before", green);
             util.assertXmlEqual(util.call("createXML"),
                                 ITEXT_ITEM_RENAME_GROUP_MOVE_XML,
                                 {normalize_xmlns: true});

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -18,7 +18,11 @@ define([
     var assert = chai.assert,
         savedForm = null,
         saveCount = 0;
-    
+
+    // monkey-patch chai to use ===/!== instead of ==/!= in assert.equal
+    assert.equal = assert.strictEqual;
+    assert.notEqual = assert.notStrictEqual;
+
     function xmlEqual(str1, str2) {
         var xml1 = EquivalentXml.xml(str1),
             xml2 = EquivalentXml.xml(str2);


### PR DESCRIPTION
This makes it possible to create questions with conflicting IDs and resolve the warnings as convenient rather than being forced to deal with the conflict on navigating away from the question.

May be easier to review each commit individually.

@emord 