### PR TITLE
Hide hints and help for groups

### DIFF
--- a/src/mugs.js
+++ b/src/mugs.js
@@ -912,6 +912,8 @@ define([
         },
         spec: {
             hintLabel: { presence: "notallowed" },
+            hintItext: { presence: "notallowed" },
+            helpItext: { presence: "notallowed" },
             calculateAttr: { presence: "notallowed" },
             constraintAttr: { presence: "notallowed" },
             constraintMsgAttr: { presence: "notallowed" },

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -518,16 +518,6 @@ require([
             assert.equal(hinLabel[0].selectionEnd, 15);
         });
 
-        _.each({group: GROUP_HELP_XML, select: SELECT1_HELP_XML}, function (XML, name) {
-            it("should not create duplicate <help> node on " + name, function () {
-                util.loadXML(XML);
-                var xml = call("createXML"),
-                    $xml = $(xml);
-                assert.strictEqual($xml.find("help").length, 1,
-                                   "wrong <help> node count\n" + xml);
-            });
-        });
-
         it("should rename itext item ID after move", function () {
             util.loadXML("");
             util.addQuestion("Select", "ns");


### PR DESCRIPTION
Mobile ignores both help text and hint text for all kind of groups (base, repeat, and question list). Remove them from the Vellum UI.

Verified that old forms with help/hint text specified will work with the new code. Any old help/hint for groups will not be visible on the UI and will be removed from XML when the form is saved.