### PR TITLE
Fix tab order

### DIFF
--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -464,15 +464,18 @@ define([
         var _getUIElement = widget.getUIElement;
         widget.getUIElement = function () {
             var $uiElem = _getUIElement(),
-                $autoBoxContainer = $('<div />').addClass('pull-right fd-itextID-checkbox-container'),
+                $autoBoxContainer = $('<div />').addClass('fd-itextID-checkbox-container'),
                 $autoBoxLabel = $("<label />").text("auto?").addClass('checkbox');
+                $autoBoxContainer.css('position', 'absolute').css('right', 0);
 
             $autoBoxLabel.prepend($autoBox);
             $autoBoxContainer.append($autoBoxLabel);
 
+            $uiElem.css('position', 'relative');
+            $uiElem.find('.controls').css('position', 'absolute').css('left', 0).css('right', 0);
             $uiElem.find('.controls')
                 .addClass('fd-itextID-controls')
-                .before($autoBoxContainer);
+                .after($autoBoxContainer);
 
             return $uiElem;
         };

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -466,13 +466,11 @@ define([
             var $uiElem = _getUIElement(),
                 $autoBoxContainer = $('<div />').addClass('fd-itextID-checkbox-container'),
                 $autoBoxLabel = $("<label />").text("auto?").addClass('checkbox');
-                $autoBoxContainer.css('position', 'absolute').css('right', 0);
 
             $autoBoxLabel.prepend($autoBox);
             $autoBoxContainer.append($autoBoxLabel);
-
             $uiElem.css('position', 'relative');
-            $uiElem.find('.controls').css('position', 'absolute').css('left', 0).css('right', 0);
+
             $uiElem.find('.controls')
                 .addClass('fd-itextID-controls')
                 .after($autoBoxContainer);

--- a/src/less-style/question-props.less
+++ b/src/less-style/question-props.less
@@ -121,8 +121,22 @@
   text-transform: capitalize;
 }
 
+.fd-edit-controls {
+  position: absolute;
+  left: 0;
+  right: 0;
+}
+
+.fd-edit-button {
+  position: absolute;
+  right: 0;
+}
+
 .fd-itextID-controls {
   margin-right: 75px;
+  position: absolute;
+  left: 0;
+  right: 0;
 }
 
 .fd-itextID-checkbox-container {
@@ -130,6 +144,8 @@
   padding: 0 5px;
   background-color: lighten(@green, 50);
   .border-radius(5px);
+  position: absolute;
+  right: 0;
 
   label {
     display: block;

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -312,15 +312,19 @@ define([
             isDisabled = input ? input.prop('disabled') : false;
 
         var button = $('<button />')
-            .addClass("fd-edit-button pull-right")
+            .addClass("fd-edit-button")
             .text("Edit")
             .stopLink()
             .addClass('btn')
             .attr('type', 'button')
             .prop('disabled', isDisabled)
+            .css('position', 'absolute')
+            .css('right', 0)
             .click(editFn);
 
-        $uiElem.find('label').after(button);
+        $uiElem.css('position', 'relative');
+        $uiElem.find('.controls').css('position', 'absolute').css('left', 0).css('right', 0);
+        $uiElem.find('.controls').after(button);
         $uiElem.find('.controls').css('margin-right', '60px');
         return $uiElem;
     };

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -318,13 +318,12 @@ define([
             .addClass('btn')
             .attr('type', 'button')
             .prop('disabled', isDisabled)
-            .css('position', 'absolute')
-            .css('right', 0)
             .click(editFn);
 
         $uiElem.css('position', 'relative');
-        $uiElem.find('.controls').css('position', 'absolute').css('left', 0).css('right', 0);
-        $uiElem.find('.controls').after(button);
+        $uiElem.find('.controls')
+            .addClass('fd-edit-controls')
+            .after(button);
         $uiElem.find('.controls').css('margin-right', '60px');
         return $uiElem;
     };


### PR DESCRIPTION
The edit buttons for display/validation conditions, and the "auto?" checkboxes for various advanced properties, grab focus before their text boxes, which is annoying if you're tabbing through properties. It's easier to change the markup & styling than to futz with global tabindex.

Checked that this looks & behaves the same in Chrome, Firefox, Safari.