### PR TITLE
Validation message inputs disappearing

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1344,6 +1344,10 @@ define([
 
     fn.toggleConstraintItext = function (mug) {
         // todo: don't handle this one-off in the UI layer
+        var current = this.getCurrentlySelectedMug();
+        if (current && current.ufid !== mug.ufid) {
+	         return;
+        }
         var state = (mug.p.constraintMsgItext &&
                      (!mug.p.constraintMsgItext.isEmpty() ||
                       mug.p.constraintAttr)),

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -1020,7 +1020,7 @@ define([
                     var treeName = itextItem.get(widget.form, widget.language) || 
                             mug.form.vellum.getMugDisplayName(mug),
                         it = mug.p.labelItext;
-                    if (it && it.id && it.id === itextItem.id && widget.form === "default") {
+                    if (it && it.id === itextItem.id && widget.form === "default") {
                         mug.form.fire({
                             type: 'question-label-text-change',
                             mug: mug,

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -1020,7 +1020,7 @@ define([
                     var treeName = itextItem.get(widget.form, widget.language) || 
                             mug.form.vellum.getMugDisplayName(mug),
                         it = mug.p.labelItext;
-                    if (it && it.id === itextItem.id && widget.form === "default") {
+                    if (it && it.id && it.id === itextItem.id && widget.form === "default") {
                         mug.form.fire({
                             type: 'question-label-text-change',
                             mug: mug,

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -12,6 +12,7 @@ require([
     'text!static/javaRosa/multi-line-trans.xml',
     'text!static/javaRosa/output-refs.xml',
     'text!static/javaRosa/outputref-with-inequality.xml',
+    'text!static/javaRosa/group-with-constraint.xml',
     'text!static/javaRosa/text-with-constraint.xml',
     'text!static/javaRosa/group-help.xml',
     'text!static/javaRosa/itext-item-rename.xml',
@@ -31,6 +32,7 @@ require([
     MULTI_LINE_TRANS_XML,
     OUTPUT_REFS_XML,
     OUTPUTREF_WITH_INEQUALITY_XML,
+    GROUP_WITH_CONSTRAINT_XML,
     TEXT_WITH_CONSTRAINT_XML,
     GROUP_HELP_XML,
     ITEXT_ITEM_RENAME_XML,
@@ -675,6 +677,16 @@ require([
             } finally {
                 mug.p.constraintAttr = before;
             }
+        });
+
+        it("should show and hide the validation message as appropriate", function() {
+            util.loadXML(GROUP_WITH_CONSTRAINT_XML);
+            $("[name='property-constraintAttr']").val('true()').change();
+            $("[name='itext-en-constraintMsg']").val('This is not possible').change();
+            assert($("[name='itext-en-constraintMsg']").is(":visible"));
+            $("[name='itext-en-constraintMsg']").val('').change();
+            $("[name='property-constraintAttr']").val('').change();
+            assert(!$("[name='itext-en-constraintMsg']").is(":visible"));
         });
     });
 

--- a/tests/static/javaRosa/group-with-constraint.xml
+++ b/tests/static/javaRosa/group-with-constraint.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/4f203b784b4f49328949420c7047ebaf091774e6" uiVersion="1" version="1" name="Untitled Form">
+					<question1 />
+					<Group />
+				</data>
+			</instance>
+			<bind nodeset="/data/question1" />
+			<bind nodeset="/data/Group" relevant="true()" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="question1-label">
+						<value>This is a label.</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<trigger ref="/data/question1" appearance="minimal">
+			<label ref="jr:itext('question1-label')" />
+		</trigger>
+		<group ref="/data/Group" />
+	</h:body>
+</h:html>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?164598

In certain forms, when constraint text changes and fireChangeEvents goes through all mugs to update any that share itext with the changed itext, ids are blank for both widget.getItextItem() and some other mug's labelItext...so a question-label-text-change event gets fired for that other mug, which causes  toggleConstraintItext to run, which updates the visibility of the currently-displayed validation message inputs based on the constraintMsgItext of this other mug, which isn't right.

I'm not clear on when it's expected for an itext id to be blank, and therefore not sure if this is a reasonable fix or a band-aid for a larger problem.