### PR TITLE
Escape apostrophes in itext

### DIFF
--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -1206,7 +1206,8 @@ define([
 
     function getDefaultItextRoot(mug) {
         if (mug.__className === "Item") {
-            return getDefaultItextRoot(mug.parentMug) + "-" + mug.getNodeID();
+            return getDefaultItextRoot(mug.parentMug) + "-" +
+                mug.getNodeID().replace(/'/g, '-apos-');
         } else {
             var path = mug.form.getAbsolutePath(mug, true);
             if (!path) {

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -1206,8 +1206,9 @@ define([
 
     function getDefaultItextRoot(mug) {
         if (mug.__className === "Item") {
+            var regex = new RegExp(util.invalidAttributeRegex.source, 'g');
             return getDefaultItextRoot(mug.parentMug) + "-" +
-                mug.getNodeID().replace(/'/g, '-apos-');
+                mug.getNodeID().replace(regex, '_');
         } else {
             var path = mug.form.getAbsolutePath(mug, true);
             if (!path) {

--- a/src/util.js
+++ b/src/util.js
@@ -60,12 +60,15 @@ define([
         return $(_.template($(selector).text(), params));
     };
     
+    that.validAttributeRegex = /^[^<&'"]$/;
+    that.invalidAttributeRegex = /[<&'"]/;
+
     /**
      * Check if value is a valid XML attribute value (additionally disallow all
      * ' and ")
      */
     that.isValidAttributeValue = function (value) {
-        return (/^[^<&'"]*$/).test(value);
+        return that.validAttributeRegex.test(value);
     };
     
     // Simple Event Framework

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -586,6 +586,13 @@ require([
                 }
             });
         });
+
+        it("should not allow apostrophes in item labels", function() {
+            util.addQuestion("Select", "select");
+            util.clickQuestion('select/item1');
+            $("[name='property-defaultValue']").val("blah ' blah").change();
+            assert.strictEqual($("[name='property-labelItext']").val(), 'select-blah_-apos-_blah-labelItext');
+        });
     });
 
     describe("The javaRosa plugin itext widgets", function() {

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -591,7 +591,7 @@ require([
             util.addQuestion("Select", "select");
             util.clickQuestion('select/item1');
             $("[name='property-defaultValue']").val("blah ' blah").change();
-            assert.strictEqual($("[name='property-labelItext']").val(), 'select-blah_-apos-_blah-labelItext');
+            assert.strictEqual($("[name='property-labelItext']").val(), 'select-blah___blah-labelItext');
         });
     });
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?166079#925204

This was already enforced for labelItext, but it isn't checked for auto ids. (and probably shouldn't be. Those should generate valid labels)

On other mugs it is already enforced as you can't have an apostrophe in a node id.