### PR TITLE
Select text on tab into label widget

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -953,7 +953,7 @@ define([
         // for choices, return the quoted value.
         // for everything else return the path
         if (mug.__className === "Item") {
-            return '"' + mug.p.defaultValue + '"';
+            return '"' + mug.p.nodeID + '"';
         } else {
             // for the currently selected mug, return a "."
             return (mug.ufid === this.getCurrentlySelectedMug().ufid) ? 
@@ -1921,7 +1921,6 @@ define([
     fn.getMainProperties = function () {
         return [
             "nodeID",
-            "defaultValue",
             "label",
             "readOnlyControl"
         ];

--- a/src/exporter.js
+++ b/src/exporter.js
@@ -56,7 +56,7 @@ define([
                 row.Question = form.getAbsolutePath(mug, true);
             } else {
                 row.Question = form.getAbsolutePath(mug.parentMug, true) +
-                                "-" + mug.p.defaultValue;
+                                "-" + mug.p.nodeID;
             }
             row.Type = mug.options.typeName;
 

--- a/src/form.js
+++ b/src/form.js
@@ -523,8 +523,7 @@ define([
                 conflictParent = mug.parentMug;
             }
 
-            // TODO make Item not a special case
-            if (mug.__className !== "Item") {
+            if (!mug.options.isControlOnly) {
                 if (this.findFirstMatchingChild(conflictParent, match)) {
                     mug.p.conflictedNodeId = newId;
                     newId = this.generate_question_id(newId, mug);
@@ -650,16 +649,10 @@ define([
 
             if (depth === 0) {
                 var nodeID = mug.p.nodeID;
-                if (nodeID) {
-                    if (duplicate.p.conflictedNodeId) {
-                        duplicate.p.conflictedNodeId = null;
-                    } else {
-                        duplicate.p.nodeID = this.generate_question_id(nodeID, mug);
-                    }
+                if (duplicate.p.conflictedNodeId) {
+                    duplicate.p.conflictedNodeId = null;
                 } else {
-                    var newItemValue = this.generate_question_id(
-                        mug.p.defaultValue);
-                    duplicate.p.defaultValue = newItemValue;
+                    duplicate.p.nodeID = this.generate_question_id(nodeID, mug);
                 }
                 
                 this.insertQuestion(duplicate, mug, 'after', true);
@@ -733,7 +726,7 @@ define([
             }
             if (mug.__className === "Item") {
                 var parent = refMug.__className === "Item" ? refMug.parentMug : refMug;
-                mug.p.defaultValue = this.generate_item_label(parent);
+                mug.p.nodeID = this.generate_item_label(parent);
             }
             this.insertQuestion(mug, refMug, position, isInternal);
             // should we fix broken references when nodeID is auto-generated?
@@ -862,7 +855,7 @@ define([
                 count = 0;
             for (var i = 0; i < allMugs.length; i++) {
                 var mug = allMugs[i];
-                if (qId === mug.p.nodeID || qId === mug.p.defaultValue) {
+                if (qId === mug.p.nodeID) {
                     count++; 
                 }
             }
@@ -896,7 +889,7 @@ define([
             do {
                 ret = 'item' + i++;
             } while (_.any(items, function (i) {
-                return i.p.defaultValue === ret;
+                return i.p.nodeID === ret;
             }));
             return ret;
         },

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -797,11 +797,9 @@ define([
             .attr("name", widget.id)
             .attr("rows", "2")
             .addClass('input-block-level itext-widget-input')
-            .focus(function() {
-                this.select();
-            })
-            .on('change input', function (e) {
-                widget.handleChange();
+            .on('change input', function (e) { widget.handleChange(); })
+            .focus(function() { this.select(); })
+            .keyup(function (e) {
                 // workaround for webkit: http://stackoverflow.com/a/12114908
                 if (e.which === 9) {
                     this.select();

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -413,8 +413,7 @@ define([
     var iTextIDWidget = function (mug, options) {
         var widget = widgets.text(mug, options),
             $input = widget.input,
-            currentValue = null,
-            isSelectItem = mug.__className === "Item";
+            currentValue = null;
 
         function autoGenerateId() {
             return getDefaultItextId(mug, widget.path);
@@ -487,9 +486,7 @@ define([
         });
 
         mug.on("property-changed", function (e) {
-            if (getAutoMode() && (
-                    e.property === "nodeID" ||
-                    (isSelectItem && e.property === "defaultValue"))) {
+            if (getAutoMode() && e.property === "nodeID") {
                 $input.val(autoGenerateId());
             }
         }, null, "teardown-mug-properties");

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -243,8 +243,6 @@ define([
                 return label;
             } else if (nodeID) {
                 return nodeID;
-            } else if (this.__className === "Item") {
-                return this.p.defaultValue;
             }
         },
 
@@ -260,8 +258,11 @@ define([
                 return "";
             }
         },
+        /**
+         * deprecated
+         */
         getNodeID: function () {
-            return this.p.nodeID || this.p.defaultValue;
+            return this.p.nodeID;
         },
         getDisplayName: function (lang) {
             var itextItem = this.p.labelItext,
@@ -269,7 +270,7 @@ define([
                 defaultLang = Itext.getDefaultLanguage(),
                 disp,
                 defaultDisp,
-                nodeID = this.p.conflictedNodeId || this.getNodeID();
+                nodeID = this.p.conflictedNodeId || this.p.nodeID;
 
             if (this.__className === "ReadOnly") {
                 return "Unknown (read-only) question type";
@@ -1061,43 +1062,42 @@ define([
         writeControlHelp: false,
         writeControlRefAttr: null,
         writeCustomXML: function (xmlWriter, mug) {
-            var defaultValue = mug.p.defaultValue;
-            if (defaultValue) {
+            var value = mug.p.nodeID;
+            if (value) {
                 xmlWriter.writeStartElement('value');
-                xmlWriter.writeString(defaultValue);
+                xmlWriter.writeString(value);
                 xmlWriter.writeEndElement();
             }
         },
         init: function (mug, form) {
         },
         spec: {
-            hintLabel: { presence: 'notallowed' },
-            hintItext: { presence: 'notallowed' },
-            helpItext: { presence: 'notallowed' },
-            defaultValue: {
+            nodeID: {
                 lstring: 'Choice Value',
                 visibility: 'visible',
                 presence: 'required',
                 widget: widgets.identifier,
+                setter: null,
                 validationFunc: function (mug) {
-                    if (/\s/.test(mug.p.defaultValue)) {
+                    if (/\s/.test(mug.p.nodeID)) {
                         return "Whitespace in values is not allowed.";
                     }
                     if (mug.parentMug) {
-                        var num = 0;
-                        _.each(mug.form.getChildren(mug.parentMug), function(ele, index) {
-                            if (ele.p.defaultValue === mug.p.defaultValue) {
-                                num++;
-                            }
-                        });
-                        if (num > 1) {
-                            // TODO make this a warning instead of an error
+                        var siblings = mug.form.getChildren(mug.parentMug),
+                            dup = _.any(siblings, function(ele) {
+                                return ele !== mug && ele.p.nodeID === mug.p.nodeID;
+                            });
+                        if (dup) {
                             return "This choice value has been used in the same question";
                         }
                     }
                     return "pass";
                 }
-            }
+            },
+            conflictedNodeId: { presence: 'notallowed' },
+            hintLabel: { presence: 'notallowed' },
+            hintItext: { presence: 'notallowed' },
+            helpItext: { presence: 'notallowed' },
         }
     });
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -395,7 +395,7 @@ define([
                     mug = adaptItem(mug, form);
                     var value = xml.humanize($cEl.children('value'));
                     if (value) {
-                        mug.p.defaultValue = value;
+                        mug.p.nodeID = value;
                     }
                     return mug;
                 };

--- a/tests/core.js
+++ b/tests/core.js
@@ -104,7 +104,7 @@ require([
             util.init({core: { form: INCREMENT_ITEM_XML, onReady: function () {
                 util.clickQuestion("question1");
                 var item = util.addQuestion("Item");
-                assert.equal(item.p.defaultValue, "item3");
+                assert.equal(item.p.nodeID, "item3");
                 done();
             }}});
         });
@@ -113,7 +113,7 @@ require([
             util.init({core: { form: INCREMENT_ITEM_XML, onReady: function () {
                 util.clickQuestion("question1/item1");
                 var item = util.addQuestion("Item");
-                assert.equal(item.p.defaultValue, "item3");
+                assert.equal(item.p.nodeID, "item3");
                 done();
             }}});
         });

--- a/tests/form.js
+++ b/tests/form.js
@@ -202,7 +202,7 @@ define([
                 item2 = select.form.getChildren(select)[1];
             assert(util.isTreeNodeValid(item1), item1.getErrors().join("\n"));
             assert(util.isTreeNodeValid(item2), item2.getErrors().join("\n"));
-            item2.p.defaultValue = "item1";
+            item2.p.nodeID = "item1";
             assert(util.isTreeNodeValid(item1), "item1 should be valid");
             assert(!util.isTreeNodeValid(item2), "item2 should be invalid");
         });

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -531,8 +531,8 @@ require([
             util.addQuestion("Select", "ew");
             var north = util.getMug("ns/item1"),
                 south = util.getMug("ew/item1");
-            north.p.defaultValue = "north";
-            south.p.defaultValue = "south";
+            north.p.nodeID = "north";
+            south.p.nodeID = "south";
             north.form.moveMug(south, "after", north);
             util.assertXmlEqual(util.call("createXML"), ITEXT_ITEM_RENAME_XML,
                                 {normalize_xmlns: true});

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -89,7 +89,7 @@ require([
             var mug = call("getMugByPath", "/ClassroomObservationV3/Q0003"),
                 // HACK how to reference items in select?
                 item = mug._node_control.children[1].value;
-            assert.equal(item.p.defaultValue, 'other');
+            assert.equal(item.p.nodeID, 'other');
         });
 
         it("should load mugs with relative paths and label without itext", function () {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -239,7 +239,7 @@ define([
                     return children[0];
                 }
                 for (var i = 0; i < children.length; i++) {
-                    if (children[i].p.defaultValue === nodeID) {
+                    if (children[i].p.nodeID === nodeID) {
                         return children[i];
                     }
                 }


### PR DESCRIPTION
Fix the labels on select choices, which did not work correctly because the itext widget uses the mug's `nodeID` property, and choices had their value in `defaultValue`. Been wanting to change that one for a while. http://manage.dimagi.com/default.asp?124210

Also [UserVoice](https://dimagi.uservoice.com/forums/176376-form-builder/suggestions/7672437-tab-key-action-in-form-builder).

Merging into copy-paste-dev because the `defaultValue` -> `nodeID` change is much easier since the duplicate question ID refactor.

@emord 
cc @benrudolph 