### PR TITLE
Fix “Case” property not showing for Balance

### DIFF
--- a/src/commtrack.js
+++ b/src/commtrack.js
@@ -78,7 +78,7 @@ define([
         },
         sectionData = {
             Balance: [
-                _.extend(basicSection, {
+                _.extend({}, basicSection, {
                     properties: [
                         "nodeID",
                         "entityId",
@@ -90,7 +90,7 @@ define([
                 logicSection
             ],
             Transfer: [
-                _.extend(basicSection, {
+                _.extend({}, basicSection, {
                     properties: [
                         "nodeID",
                         "src",

--- a/tests/commtrack.js
+++ b/tests/commtrack.js
@@ -279,5 +279,11 @@ define([
             assert.equal($xml.find("instance[src='jr://instance/ledgerdb']").length, 1,
                          "ledger instance should be removed\n" + xml);
         });
+
+        it("should show 'Case' property for Balance", function () {
+            util.loadXML("");
+            util.addQuestion("Balance", "bal");
+            assert.equal($("[name=property-entityId]").length, 1);
+        });
     });
 });


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?166979

`_.extend` is tricky. In this case it was mutating the first argument, which meant Balance's section data was getting Transfer's properties.

@orangejenny 