### PR TITLE
Ignore retain overhaul

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2107,6 +2107,10 @@ define([
         return parser.parseBindElement(form, el, path);
     };
 
+    fn.getControlNodeAdaptorFactory = function (tagName) {
+        return this.data.core.controlNodeAdaptorMap[tagName];
+    };
+
     /**
      * Extension point for mug setup during control node parsing
      *

--- a/src/form.js
+++ b/src/form.js
@@ -251,8 +251,8 @@ define([
             });
             return dataTree;
         },
-        getBasePath: function () {
-            return "/" + this.tree.getRootNode().getID() + "/";
+        getBasePath: function (noSep) {
+            return "/" + this.tree.getRootNode().getID() + (noSep ? "" : "/");
         },
         fireChange: function (mug) {
             this.fire({
@@ -848,14 +848,17 @@ define([
                 return this._make_label('question');
             }
         },
-        generate_item_label: function (parentMug) {
-            var items = this.getChildren(parentMug),
+        generate_item_label: function (parentMug, name) {
+            var node = (parentMug ? this.tree.getNodeFromMug(parentMug)
+                                  : this.tree.rootNode),
+                items = node.getChildrenMugs(),
                 i = items.length + 1,
                 ret;
+            if (!name) { name = "item"; }
             do {
-                ret = 'item' + i++;
-            } while (_.any(items, function (i) {
-                return i.p.defaultValue === ret;
+                ret = name + i++;
+            } while (_.any(items, function (item) {
+                return item.getNodeID() === ret;
             }));
             return ret;
         },

--- a/src/form.js
+++ b/src/form.js
@@ -848,13 +848,15 @@ define([
                 return this._make_label('question');
             }
         },
-        generate_item_label: function (parentMug, name) {
+        generate_item_label: function (parentMug, name, i) {
             var node = (parentMug ? this.tree.getNodeFromMug(parentMug)
                                   : this.tree.rootNode),
                 items = node.getChildrenMugs(),
-                i = items.length + 1,
                 ret;
             if (!name) { name = "item"; }
+            if (arguments.length < 3) {
+                i = items.length + 1;
+            }
             do {
                 ret = name + i++;
             } while (_.any(items, function (item) {

--- a/src/ignoreButRetain.js
+++ b/src/ignoreButRetain.js
@@ -2,18 +2,17 @@
  * "Ignore but Retain" plugin.
  *
  * This plugin allows you to mark any node in an XForm's XML with
- * 'ignore="true"'.
+ * 'vellum:ignore="retain"'.
  *
- * Marked nodes will be removed from the XML before it's processed by Vellum,
- * and reinserted when Vellum writes out XML.  Crucially, marked nodes are
- * reinserted in the same position relative to the node that they originally
- * followed, as identified by that node's attribute which includes a question
- * ID.
+ * Marked nodes (with the exception of data, bind, and control nodes) will be
+ * removed from the XML before it's processed by Vellum, and reinserted when
+ * Vellum writes out XML. Data, bind, and control nodes are consumed by a
+ * special `Ignored` mug type and inserted into the question tree like other
+ * mugs. Ignored nodes are reinserted as close as possible to their original
+ * position relative to the nodes that were around them when the form was
+ * originally parsed.
  *
- * Question ID changes are handled.
- *
- * If a reference node for an ignore node is deleted by the user, then that node
- * will be lost.
+ * Most question ID and path changes are handled.
  *
  * Spec:
  * https://docs.google.com/document/d/12see6m3Lr6nVVgjfstS3oS6Vc1UT7l4bqYNRtDB-GXQ/

--- a/src/ignoreButRetain.js
+++ b/src/ignoreButRetain.js
@@ -252,8 +252,8 @@ define([
         },
         handleMugRename: function (form, mug, newID, oldID, newPath, oldPath) {
             this.__callOld();
-            if (this.data.ignore.active) {
-                var oldEscaped = oldPath ? RegExp.escape(oldPath) : oldPath,
+            if (this.data.ignore.active && oldPath) {
+                var oldEscaped = RegExp.escape(oldPath),
                     pathRegex = new RegExp(oldEscaped + '(\\W|$)', 'g'),
                     newPattern = newPath + "$1";
                 _.each(this.data.ignore.ignoredNodes, function (node) {

--- a/src/ignoreButRetain.js
+++ b/src/ignoreButRetain.js
@@ -166,7 +166,6 @@ define([
             if (this.data.ignore.active) {
                 var mug = form.getMugByPath(path);
                 if (!mug) {
-                    throw new Error("test: " + path)
                     mug = findParent(path, form);
                 }
                 if ((mug && mug.__className === "Ignored") ||
@@ -302,7 +301,7 @@ define([
                     if (bind.relativeTo === MUG) {
                         basePath = mug.absolutePath;
                     } else if (bind.relativeTo === PARENT) {
-                        var parent = mug.parentMug
+                        var parent = mug.parentMug;
                         basePath = parent ? parent.absolutePath :
                                             mug.form.getBasePath(true);
                     }
@@ -332,12 +331,13 @@ define([
         };
 
     function findParent(path, form) {
-        var parent = null;
-        if (path && path.indexOf("/") > 0) {
-            do {
-                path = path.slice(0, path.lastIndexOf("/"));
+        var parent = null,
+            regex = /[\/[][^\/[]+$/;
+        while (!parent && path && regex.test(path)) {
+            path = path.replace(regex, "");
+            if (path) {
                 parent = form.getMugByPath(path);
-            } while (path && !parent);
+            }
         }
         return parent;
     }

--- a/src/ignoreButRetain.js
+++ b/src/ignoreButRetain.js
@@ -26,82 +26,6 @@ define([
     _,
     $
 ) {
-    function prependChild(element, child) {
-        if (element.firstElementChild) {
-            $(element).prepend($(child));
-        } else {
-            $(element).append($(child));
-        }
-    }
-
-    function getPathAndPosition(node) {
-        var origNode = node,
-            path = [],
-            position;
-        
-        position = getPreviousSiblingSelector(node);
-        node = node.parentElement;
-        
-        while (node) {   
-            path.unshift(getNodeIdentifierSelector(node));
-            node = node.parentElement;
-        }
-
-        var nodeXML = xmls.serializeToString(origNode)
-            // XMLSerializer adds xmlns to fragments, which we don't want.  This
-            // should only remove the xmlns from the root node, so if inner elements
-            // have an XMLNS, it will be preserved.
-                .replace(/xmlns="(.*?)"/, "");
-
-        return {
-            position: position,
-            path: path.join(" > "),
-            nodeXML: "\n" + nodeXML
-        };
-    }
-
-    function getPreviousSiblingSelector(node) {
-        var previousSibling = node.previousElementSibling;
-        if (previousSibling && previousSibling.tagName !== 'label') {
-            return getNodeIdentifierSelector(previousSibling);
-        } else {
-            return false;
-        }
-    }
-
-    function getNodeIdentifierSelector(node) {
-        var $node = $(node),
-            nodeset = $node.attr('nodeset'),
-            ref = $node.attr('ref'),
-            id = $node.attr('id'),
-            tagName = $node.prop('tagName').toLowerCase();
-
-        if (tagName === 'setvalue') {
-            return '[event="' + $node.attr('event') + '"]' +
-                   '[ref="' + ref + '"]';
-        } else if (nodeset) {
-            return '[nodeset="' + nodeset + '"]';
-        } else if (ref) {
-            return '[ref="' + ref + '"]';
-        } else if (id) {
-            return '[id="' + id + '"]';
-        } else {
-            // escape ':' in namespaced selector for jQuery selector usage
-            return node.nodeName.replace(":", "\\:");
-
-            // to have this be fully generic for a node with any path,
-            // we would have to add an :nth-child or even better :nth-of-type
-            // selector for intermediate nodes without a question ID but which
-            // could be at a level with multiple nodes with the same tag name.
-            // But this would have complex edge cases for when nodes at inner
-            // levels were added or deleted -- being able to recognize that a
-            // find failed and then retry with a different selector expression.
-            //
-            // For XForms and the ignored nodes that we expect to see, the
-            // current implementation is sufficient.
-        }
-    }
-
     var xmls = new XMLSerializer();
 
     $.vellum.plugin("ignore", {}, {
@@ -233,4 +157,80 @@ define([
             });
         }
     });
+
+    function prependChild(element, child) {
+        if (element.firstElementChild) {
+            $(element).prepend($(child));
+        } else {
+            $(element).append($(child));
+        }
+    }
+
+    function getPathAndPosition(node) {
+        var origNode = node,
+            path = [],
+            position;
+
+        position = getPreviousSiblingSelector(node);
+        node = node.parentElement;
+
+        while (node) {
+            path.unshift(getNodeIdentifierSelector(node));
+            node = node.parentElement;
+        }
+
+        var nodeXML = xmls.serializeToString(origNode)
+            // XMLSerializer adds xmlns to fragments, which we don't want.  This
+            // should only remove the xmlns from the root node, so if inner elements
+            // have an XMLNS, it will be preserved.
+                .replace(/xmlns="(.*?)"/, "");
+
+        return {
+            position: position,
+            path: path.join(" > "),
+            nodeXML: "\n" + nodeXML
+        };
+    }
+
+    function getPreviousSiblingSelector(node) {
+        var previousSibling = node.previousElementSibling;
+        if (previousSibling && previousSibling.tagName !== 'label') {
+            return getNodeIdentifierSelector(previousSibling);
+        } else {
+            return false;
+        }
+    }
+
+    function getNodeIdentifierSelector(node) {
+        var $node = $(node),
+            nodeset = $node.attr('nodeset'),
+            ref = $node.attr('ref'),
+            id = $node.attr('id'),
+            tagName = $node.prop('tagName').toLowerCase();
+
+        if (tagName === 'setvalue') {
+            return '[event="' + $node.attr('event') + '"]' +
+                   '[ref="' + ref + '"]';
+        } else if (nodeset) {
+            return '[nodeset="' + nodeset + '"]';
+        } else if (ref) {
+            return '[ref="' + ref + '"]';
+        } else if (id) {
+            return '[id="' + id + '"]';
+        } else {
+            // escape ':' in namespaced selector for jQuery selector usage
+            return node.nodeName.replace(":", "\\:");
+
+            // to have this be fully generic for a node with any path,
+            // we would have to add an :nth-child or even better :nth-of-type
+            // selector for intermediate nodes without a question ID but which
+            // could be at a level with multiple nodes with the same tag name.
+            // But this would have complex edge cases for when nodes at inner
+            // levels were added or deleted -- being able to recognize that a
+            // find failed and then retry with a different selector expression.
+            //
+            // For XForms and the ignored nodes that we expect to see, the
+            // current implementation is sufficient.
+        }
+    }
 });

--- a/src/ignoreButRetain.js
+++ b/src/ignoreButRetain.js
@@ -148,8 +148,14 @@ define([
                 if ($el.attr("vellum:ignore") === "retain") {
                     var mug = form.mugTypes.make("Ignored", form);
                     mug.p.nodeID = el.nodeName;
-                    mug.p.dataNode = $el;
                     mug.p.rawDataAttributes = parser.getAttributes(el);
+                    if ($el.children().length) {
+                        mug.p.dataNodeXML = serializeXML($el)
+                            // strip wrapper element
+                            .replace(/^<[^>]+>([^]*)<\/[^>]+>$/, "$1");
+                    } else {
+                        mug.p.dataNodeXML = "";
+                    }
                     this.data.ignore.ignoredMugs.push(mug);
                     return mug;
                 }
@@ -272,12 +278,15 @@ define([
             init: function (mug) {
                 mug.p.binds = [];
             },
+            parseDataNode: function (mug, node) {
+                return $([]);
+            },
             getTagName: function (mug, nodeID) {
-                return mug.p.dataNode ? nodeID : null;
+                return mug.p.rawDataAttributes ? nodeID : null;
             },
             writeDataNodeXML: function (writer, mug) {
-                if (mug.p.dataNode && mug.p.dataNode.children().length) {
-                    writer.writeXML(mug.p.dataNode[0].innerHTML);
+                if (mug.p.dataNodeXML) {
+                    writer.writeXML(mug.p.dataNodeXML);
                 }
             },
             getBindList: function (mug) {

--- a/src/ignoreButRetain.js
+++ b/src/ignoreButRetain.js
@@ -69,7 +69,11 @@ define([
             });
             ignores = ignores.not(function (i, el) {
                 var isDataOrControl = _.any($(el).parents(), function (parent) {
-                        return instance.is(parent) || body.is(parent);
+                        return instance.is(parent) || body.is(parent) ||
+                            _.any(ignores, function (ignored) {
+                                // exclude nested nodes ... O(n^2)
+                                return $(ignored).is(parent);
+                            });
                     });
                 if (!isDataOrControl && el.nodeName === "bind") {
                     return $(el).parent().is(model);

--- a/src/ignoreButRetain.js
+++ b/src/ignoreButRetain.js
@@ -60,7 +60,7 @@ define([
 
             var model = xml.find('h\\:html > h\\:head > model:first'),
                 instance = model.find('instance:first'),
-                body = xml.find('h\\:html > body:first');
+                body = xml.find('h\\:html > h\\:body:first, h\\:html > body:first');
             _.each([model, instance, body], function (el) {
                 if (!el.length) {
                     window.console.log("WARNING", el.selector, "not found");

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -617,6 +617,7 @@ define([
 
         // data node writer options
         getExtraDataAttributes: null, // function (mug) { return {...}; }
+        writeDataNodeXML: null,       // function (xmlWriter, mug) { ... }
 
         /**
          * Returns a list of objects containing bind element attributes

--- a/src/parser.js
+++ b/src/parser.js
@@ -485,18 +485,18 @@ define([
      * @param el - a jquery-wrapped xforms control element.
      * @return - a string of the ref/nodeset value
      */
-    function getPathFromControlElement(el, form, parentMug) {
+    function getPathFromControlElement(el, form, parentMug, noPop) {
         if(!el){
             return null;
         }
-        var path = el.popAttr('ref'),
+        var path = noPop ? el.attr('ref') : el.popAttr('ref'),
             nodeId, pathToTry;
         if(!path){
-            path = el.popAttr('nodeset');
+            path = noPop ? el.attr('nodeset') : el.popAttr('nodeset');
         }
         if (!path) {
             // attempt to support sloppy hand-written forms
-            nodeId = el.popAttr('bind');
+            nodeId = noPop ? el.attr('bind') : el.popAttr('bind');
             if (nodeId) {
                 pathToTry = processPath(nodeId);
                 if (!form.getMugByPath(pathToTry)) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -235,7 +235,7 @@ define([
             appearance = $cEl.popAttr('appearance'),
             adapt, mug = null;
 
-        var getAdaptor = form.vellum.data.core.controlNodeAdaptorMap[tagName];
+        var getAdaptor = form.vellum.getControlNodeAdaptorFactory(tagName);
         if (getAdaptor) {
             adapt = getAdaptor($cEl, appearance, form, parentMug);
         }

--- a/src/writer.js
+++ b/src/writer.js
@@ -117,6 +117,9 @@ define([
         dataTree.walk(function (mug, nodeID, processChildren) {
             if (mug && mug.options.getTagName) {
                 nodeID = mug.options.getTagName(mug, nodeID);
+                if (nodeID === null) {
+                    return;
+                }
             }
             xmlWriter.writeStartElement(nodeID);
             if (!mug) {
@@ -142,6 +145,9 @@ define([
                 
                 if (dataValue){
                     xmlWriter.writeString(dataValue);
+                }
+                if (mug.options.writeDataNodeXML) {
+                    mug.options.writeDataNodeXML(xmlWriter, mug);
                 }
                 if (keyAttr){
                     xmlWriter.writeAttributeString("key", keyAttr);

--- a/tests/formdesigner.ignoreButRetain.js
+++ b/tests/formdesigner.ignoreButRetain.js
@@ -10,6 +10,7 @@ define([
     'text!static/ignoreButRetain/delete-bug-before.xml',
     'text!static/ignoreButRetain/empty-parent.xml',
     'text!static/ignoreButRetain/ignore-in-head.xml',
+    'text!static/ignoreButRetain/ignored-control-node.xml',
     'text!static/ignoreButRetain/ignored-data-node.xml',
     'text!static/ignoreButRetain/ignored-tag-first.xml',
     'text!static/ignoreButRetain/multiple-ignores.xml',
@@ -30,6 +31,7 @@ define([
     DELETE_BUG_BEFORE,
     EMPTY_PARENT,
     IGNORE_IN_HEAD,
+    IGNORED_CONTROL_NODE,
     IGNORED_DATA_NODE,
     IGNORED_TAG_FIRST,
     MULTIPLE_IGNORES,
@@ -120,6 +122,15 @@ define([
             util.loadXML(IGNORED_DATA_NODE);
             util.assertJSTreeState("question");
             assertXmlEqual(call('createXML'), IGNORED_DATA_NODE);
+        });
+
+        it("should ignore control node", function () {
+            util.loadXML(IGNORED_CONTROL_NODE);
+            util.assertJSTreeState(
+                "question",
+                "ignored--1"
+            );
+            assertXmlEqual(call('createXML'), IGNORED_CONTROL_NODE);
         });
     });
 });

--- a/tests/formdesigner.ignoreButRetain.js
+++ b/tests/formdesigner.ignoreButRetain.js
@@ -9,6 +9,7 @@ define([
     'text!static/ignoreButRetain/delete-bug-before.xml',
     'text!static/ignoreButRetain/empty-parent.xml',
     'text!static/ignoreButRetain/ignore-in-head.xml',
+    'text!static/ignoreButRetain/ignored-tag-first.xml',
     'text!static/ignoreButRetain/multiple-ignores.xml',
     'text!static/ignoreButRetain/multi-match.xml',
     'text!static/ignoreButRetain/referenced-renamed.xml',
@@ -25,6 +26,7 @@ define([
     DELETE_BUG_BEFORE,
     EMPTY_PARENT,
     IGNORE_IN_HEAD,
+    IGNORED_TAG_FIRST,
     MULTIPLE_IGNORES,
     MUTLI_MATCH,
     REFERENCED_RENAMED,
@@ -71,6 +73,11 @@ define([
             assertXmlEqual(call('createXML'), IGNORE_IN_HEAD);
         });
 
+        it("preserves position when first tag in <HEAD> is ignored", function () {
+            util.loadXML(IGNORED_TAG_FIRST);
+            assertXmlEqual(call('createXML'), IGNORED_TAG_FIRST);
+        });
+
         it("handles multiple ignore nodes in a row", function () {
             testXmlPair(MULTIPLE_IGNORES, MULTIPLE_IGNORES);
         });
@@ -78,13 +85,13 @@ define([
         it("handles an ignore node's reference node being renamed", function () {
             util.loadXML(UNRENAMED);
             call('getMugByPath', '/data/question9').p.nodeID = 'question9a';
-            assertXmlEqual(RENAMED, call('createXML'));
+            assertXmlEqual(call('createXML'), RENAMED);
         });
 
         it("handles a node being renamed that's referenced in an ignore node's XML", function () {
             util.loadXML(REFERENCED_UNRENAMED);
             call('getMugByPath', '/data/question1').p.nodeID = 'foobar';
-            assertXmlEqual(REFERENCED_RENAMED, call('createXML'));
+            assertXmlEqual(call('createXML'), REFERENCED_RENAMED);
         });
 
         it("keeps relative position on delete sibling of ignored element", function () {

--- a/tests/formdesigner.ignoreButRetain.js
+++ b/tests/formdesigner.ignoreButRetain.js
@@ -10,6 +10,7 @@ define([
     'text!static/ignoreButRetain/delete-bug-before.xml',
     'text!static/ignoreButRetain/empty-parent.xml',
     'text!static/ignoreButRetain/ignore-in-head.xml',
+    'text!static/ignoreButRetain/ignored-binds-with-extra-path.xml',
     'text!static/ignoreButRetain/ignored-control-node.xml',
     'text!static/ignoreButRetain/ignored-data-node.xml',
     'text!static/ignoreButRetain/ignored-tag-first.xml',
@@ -31,6 +32,7 @@ define([
     DELETE_BUG_BEFORE,
     EMPTY_PARENT,
     IGNORE_IN_HEAD,
+    IGNORED_BINDS_WITH_EXTRA_PATH,
     IGNORED_CONTROL_NODE,
     IGNORED_DATA_NODE,
     IGNORED_TAG_FIRST,
@@ -122,6 +124,15 @@ define([
             util.loadXML(IGNORED_DATA_NODE);
             util.assertJSTreeState("question");
             assertXmlEqual(call('createXML'), IGNORED_DATA_NODE);
+        });
+
+        it("should ignore bind nodes with extra path elements", function () {
+            util.loadXML(IGNORED_BINDS_WITH_EXTRA_PATH);
+            util.assertJSTreeState(
+                "question",
+                "question2"
+            );
+            assertXmlEqual(call('createXML'), IGNORED_BINDS_WITH_EXTRA_PATH);
         });
 
         it("should ignore control node", function () {

--- a/tests/formdesigner.ignoreButRetain.js
+++ b/tests/formdesigner.ignoreButRetain.js
@@ -5,6 +5,8 @@ define([
     'jquery',
     'text!static/ignoreButRetain/common.xml',
     'text!static/ignoreButRetain/common-ignored.xml',
+    'text!static/ignoreButRetain/delete-bug-after.xml',
+    'text!static/ignoreButRetain/delete-bug-before.xml',
     'text!static/ignoreButRetain/empty-parent.xml',
     'text!static/ignoreButRetain/ignore-in-head.xml',
     'text!static/ignoreButRetain/multiple-ignores.xml',
@@ -19,6 +21,8 @@ define([
     $,
     COMMON,
     COMMON_IGNORED,
+    DELETE_BUG_AFTER,
+    DELETE_BUG_BEFORE,
     EMPTY_PARENT,
     IGNORE_IN_HEAD,
     MULTIPLE_IGNORES,
@@ -41,17 +45,15 @@ define([
 
         var testXmlPair = function (rawXml, processedXml) {
             util.loadXML(rawXml);
-            assertXmlEqual(rawXml, call('createXML'));
+            assertXmlEqual(call('createXML'), rawXml);
 
             call('getData').ignore.ignoredNodes = [];
-            assertXmlEqual(processedXml, call('createXML'));
+            assertXmlEqual(call('createXML'), processedXml);
         };
 
-        it("ignores data, bind, body, and setvalue nodes with various edge cases (see XML)", 
-            function () {
-                testXmlPair(COMMON, COMMON_IGNORED);
-            }
-        );
+        it("ignores data, bind, body, and setvalue nodes with various edge cases (see XML)", function () {
+            testXmlPair(COMMON, COMMON_IGNORED);
+        });
 
         it("can insert ignored element into empty parent", function () {
             util.loadXML(EMPTY_PARENT);
@@ -85,5 +87,10 @@ define([
             assertXmlEqual(REFERENCED_RENAMED, call('createXML'));
         });
 
+        it("keeps relative position on delete sibling of ignored element", function () {
+            util.loadXML(DELETE_BUG_BEFORE);
+            util.deleteQuestion("delete-me");
+            assertXmlEqual(call('createXML'), DELETE_BUG_AFTER);
+        });
     });
 });

--- a/tests/formdesigner.ignoreButRetain.js
+++ b/tests/formdesigner.ignoreButRetain.js
@@ -3,6 +3,7 @@ define([
     'tests/utils',
     'chai',
     'jquery',
+    'text!static/ignoreButRetain/case-with-update.xml',
     'text!static/ignoreButRetain/common.xml',
     'text!static/ignoreButRetain/common-ignored.xml',
     'text!static/ignoreButRetain/delete-bug-after.xml',
@@ -21,6 +22,7 @@ define([
     util,
     chai,
     $,
+    CASE_WITH_UPDATE,
     COMMON,
     COMMON_IGNORED,
     DELETE_BUG_AFTER,
@@ -105,6 +107,11 @@ define([
         it("should not duplicate nested ignored nodes", function () {
             util.loadXML(NESTED_IGNORED_NODES);
             assertXmlEqual(call('createXML'), NESTED_IGNORED_NODES);
+        });
+
+        it("should preserve data node children", function () {
+            util.loadXML(CASE_WITH_UPDATE);
+            assertXmlEqual(call('createXML'), CASE_WITH_UPDATE);
         });
     });
 });

--- a/tests/formdesigner.ignoreButRetain.js
+++ b/tests/formdesigner.ignoreButRetain.js
@@ -3,14 +3,28 @@ define([
     'tests/utils',
     'chai',
     'jquery',
+    'text!static/ignoreButRetain/common.xml',
+    'text!static/ignoreButRetain/common-ignored.xml',
     'text!static/ignoreButRetain/empty-parent.xml',
+    'text!static/ignoreButRetain/ignore-in-head.xml',
+    'text!static/ignoreButRetain/multiple-ignores.xml',
+    'text!static/ignoreButRetain/multi-match.xml',
+    'text!static/ignoreButRetain/referenced-renamed.xml',
+    'text!static/ignoreButRetain/referenced-unrenamed.xml',
     'text!static/ignoreButRetain/renamed.xml',
     'text!static/ignoreButRetain/unrenamed.xml'
 ], function (
     util,
     chai,
     $,
+    COMMON,
+    COMMON_IGNORED,
     EMPTY_PARENT,
+    IGNORE_IN_HEAD,
+    MULTIPLE_IGNORES,
+    MUTLI_MATCH,
+    REFERENCED_RENAMED,
+    REFERENCED_UNRENAMED,
     RENAMED,
     UNRENAMED
 ) {
@@ -56,7 +70,7 @@ define([
         });
 
         it("handles multiple ignore nodes in a row", function () {
-            testXmlPair(MULTIPLE_IGNORES, MULTIPLE_IGNORES_IGNORED);
+            testXmlPair(MULTIPLE_IGNORES, MULTIPLE_IGNORES);
         });
 
         it("handles an ignore node's reference node being renamed", function () {
@@ -72,251 +86,4 @@ define([
         });
 
     });
-
-    var COMMON = '' + 
-    '<?xml version="1.0" encoding="UTF-8"?>\
-    <h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">\
-        <h:head>\
-            <h:title>Untitled Form</h:title>\
-            <model>\
-                <instance>\
-                    <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/B3D39778-3AF6-4163-8D51-52DC9A105662" uiVersion="1" version="1" name="Untitled Form">\
-                        <question1 />\
-                        <question9>\
-                            <question10 vellum:ignore="retain" />\
-                            <question11 />\
-                        </question9>\
-                        <question4 vellum:ignore="retain" />\
-                    </data>\
-                </instance>\
-                <bind nodeset="/data/question1" type="xsd:string" />\
-                <bind nodeset="/data/question9" />\
-                <bind nodeset="/data/question9/question10" type="xsd:int" vellum:ignore="retain" />\
-                <bind nodeset="/data/question9/question11" type="xsd:int" />\
-                <bind nodeset="/data/question4" vellum:ignore="retain" />\
-                \
-                <setvalue event="xforms-revalidate" ref="/data/question1" value="0"/>\
-                <setvalue event="xforms-ready" ref="/data/question1" value="1" vellum:ignore="retain"/>\
-                <setvalue event="xforms-ready" ref="/data/question2" value="2" vellum:ignore="retain"/>\
-                <setvalue event="xforms-ready" ref="/data/question3" value="3"/>\
-                <itext>\
-                    <translation lang="en" default="">\
-                        <text id="question1-label">\
-                            <value>question1</value>\
-                        </text>\
-                        <text id="question9-label">\
-                            <value>question9</value>\
-                        </text>\
-                        <text id="question11-label">\
-                            <value>question11</value>\
-                        </text>\
-                    </translation>\
-                </itext>\
-            </model>\
-        </h:head>\
-        <!-- body nodes, including nesting -->\
-        <h:body>\
-            <input ref="/data/question1">\
-                <label ref="jr:itext(\'question1-label\')" />\
-            </input>\
-            <group ref="/data/question9">\
-                <label ref="jr:itext(\'question9-label\')" />\
-                <!-- ignored node after an inner label -->\
-                <input ref="/data/question9/question10" vellum:ignore="retain">\
-                    <label ref="jr:itext(\'question10-label\')" />\
-                </input>\
-                <input ref="/data/question9/question11">\
-                    <label ref="jr:itext(\'question11-label\')" />\
-                </input>\
-            </group>\
-            <select1 ref="/data/question4" vellum:ignore="retain">\
-                <label ref="jr:itext(\'question4-label\')" />\
-                <item>\
-                    <label ref="jr:itext(\'question4-item5-label\')" />\
-                    <value>item5</value>\
-                </item>\
-                <item>\
-                    <label ref="jr:itext(\'question4-item6-label\')" />\
-                    <value>item6</value>\
-                </item>\
-            </select1>\
-        </h:body>\
-    </h:html>';
-
-    var COMMON_IGNORED = '' + 
-    '<?xml version="1.0" encoding="UTF-8"?>\
-    <h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">\
-        <h:head>\
-            <h:title>Untitled Form</h:title>\
-            <model>\
-                <instance>\
-                    <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/B3D39778-3AF6-4163-8D51-52DC9A105662" uiVersion="1" version="1" name="Untitled Form">\
-                        <question1 />\
-                        <question9>\
-                            <question11 />\
-                        </question9>\
-                    </data>\
-                </instance>\
-                <bind nodeset="/data/question1" type="xsd:string" />\
-                <bind nodeset="/data/question9" />\
-                <bind nodeset="/data/question9/question11" type="xsd:int" />\
-                \
-                <setvalue event="xforms-revalidate" ref="/data/question1" value="0"/>\
-                <setvalue event="xforms-ready" ref="/data/question3" value="3"/>\
-                <itext>\
-                    <translation lang="en" default="">\
-                        <text id="question1-label">\
-                            <value>question1</value>\
-                        </text>\
-                        <text id="question9-label">\
-                            <value>question9</value>\
-                        </text>\
-                        <text id="question11-label">\
-                            <value>question11</value>\
-                        </text>\
-                    </translation>\
-                </itext>\
-            </model>\
-        </h:head>\
-        <h:body>\
-            <input ref="/data/question1">\
-                <label ref="jr:itext(\'question1-label\')" />\
-            </input>\
-            <group ref="/data/question9">\
-                <label ref="jr:itext(\'question9-label\')" />\
-                <input ref="/data/question9/question11">\
-                    <label ref="jr:itext(\'question11-label\')" />\
-                </input>\
-            </group>\
-        </h:body>\
-    </h:html>';
-
-    var MUTLI_MATCH = util.xmlines('' +
-    '<?xml version="1.0" encoding="UTF-8"?>\
-    <h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">\
-        <h:head>\
-            <h:title>Untitled Form</h:title>\
-            <model>\
-                <instance>\
-                    <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">\
-                        <question1 />\
-                    </data>\
-                </instance>\
-                <bind nodeset="/data/question1" type="xsd:string" />\
-                <bind nodeset="/data/question1" vellum:ignore="retain" />\
-                <bind nodeset="/data/question1" vellum:ignore="retain" />\
-                <itext>\
-                    <translation lang="en" default=""/>\
-                </itext>\
-            </model>\
-        </h:head>\
-        <h:body></h:body>\
-    </h:html>');
-
-    var IGNORE_IN_HEAD = util.xmlines('' +
-    '<?xml version="1.0" encoding="UTF-8"?>\
-    <h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">\
-        <h:head>\
-            <h:title>Untitled Form</h:title>\
-            <model>\
-                <instance>\
-                    <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">\
-                        <question1 />\
-                    </data>\
-                </instance>\
-                <bind nodeset="/data/question1" type="xsd:string" />\
-                <itext>\
-                    <translation lang="en" default=""/>\
-                </itext>\
-            </model>\
-    		<odkx:intent vellum:ignore="retain" xmlns:odkx="http://opendatakit.org/xforms" id="search" class="com.biometrac.core.PIPE">\
-    		</odkx:intent>\
-        </h:head>\
-        <h:body></h:body>\
-    </h:html>');
-
-    var MULTIPLE_IGNORES = '' + 
-    '<?xml version="1.0" encoding="UTF-8"?>\
-    <h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">\
-        <h:head>\
-            <h:title>Untitled Form</h:title>\
-            <model>\
-                <instance>\
-                    <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">\
-                        <question1 />\
-                        <question9 vellum:ignore="retain" />\
-                        <question4 vellum:ignore="retain" />\
-                    </data>\
-                </instance>\
-                <bind nodeset="/data/question1" type="xsd:string" />\
-                <bind nodeset="/data/question9" vellum:ignore="retain" />\
-                <bind nodeset="/data/question4" vellum:ignore="retain" />\
-                <itext>\
-                    <translation lang="en" default=""/>\
-                </itext>\
-            </model>\
-        </h:head>\
-        <h:body></h:body>\
-    </h:html>';
-
-    var MULTIPLE_IGNORES_IGNORED = '' + 
-    '<?xml version="1.0" encoding="UTF-8"?>\
-    <h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">\
-        <h:head>\
-            <h:title>Untitled Form</h:title>\
-            <model>\
-                <instance>\
-                    <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">\
-                        <question1 />\
-                    </data>\
-                </instance>\
-                <bind nodeset="/data/question1" type="xsd:string" />\
-                <itext>\
-                    <translation lang="en" default=""/>\
-                </itext>\
-            </model>\
-        </h:head>\
-        <h:body></h:body>\
-    </h:html>';
-
-    var REFERENCED_UNRENAMED = '' + 
-    '<?xml version="1.0" encoding="UTF-8"?>\
-    <h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">\
-        <h:head>\
-            <h:title>Untitled Form</h:title>\
-            <model>\
-                <instance>\
-                    <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">\
-                        <question1 />\
-                        <question9 vellum:ignore="retain" />\
-                    </data>\
-                </instance>\
-                <bind nodeset="/data/question1" type="xsd:string" />\
-                <bind nodeset="/data/question9" calculate="1 + /data/question1" vellum:ignore="retain"/>\
-            </model>\
-        </h:head>\
-        <h:body></h:body>\
-    </h:html>';
-
-    var REFERENCED_RENAMED = '' + 
-    '<?xml version="1.0" encoding="UTF-8"?>\
-    <h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">\
-        <h:head>\
-            <h:title>Untitled Form</h:title>\
-            <model>\
-                <instance>\
-                    <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">\
-                        <foobar />\
-                        <question9 vellum:ignore="retain" />\
-                    </data>\
-                </instance>\
-                <bind nodeset="/data/foobar" type="xsd:string" />\
-                <bind nodeset="/data/question9" calculate="1 + /data/foobar" vellum:ignore="retain"/>\
-                <itext>\
-                    <translation lang="en" default=""/>\
-                </itext>\
-            </model>\
-        </h:head>\
-        <h:body></h:body>\
-    </h:html>';
 });

--- a/tests/formdesigner.ignoreButRetain.js
+++ b/tests/formdesigner.ignoreButRetain.js
@@ -12,6 +12,7 @@ define([
     'text!static/ignoreButRetain/ignored-tag-first.xml',
     'text!static/ignoreButRetain/multiple-ignores.xml',
     'text!static/ignoreButRetain/multi-match.xml',
+    'text!static/ignoreButRetain/nested-ignored-nodes.xml',
     'text!static/ignoreButRetain/referenced-renamed.xml',
     'text!static/ignoreButRetain/referenced-unrenamed.xml',
     'text!static/ignoreButRetain/renamed.xml',
@@ -29,6 +30,7 @@ define([
     IGNORED_TAG_FIRST,
     MULTIPLE_IGNORES,
     MUTLI_MATCH,
+    NESTED_IGNORED_NODES,
     REFERENCED_RENAMED,
     REFERENCED_UNRENAMED,
     RENAMED,
@@ -98,6 +100,11 @@ define([
             util.loadXML(DELETE_BUG_BEFORE);
             util.deleteQuestion("delete-me");
             assertXmlEqual(call('createXML'), DELETE_BUG_AFTER);
+        });
+
+        it("should not duplicate nested ignored nodes", function () {
+            util.loadXML(NESTED_IGNORED_NODES);
+            assertXmlEqual(call('createXML'), NESTED_IGNORED_NODES);
         });
     });
 });

--- a/tests/formdesigner.ignoreButRetain.js
+++ b/tests/formdesigner.ignoreButRetain.js
@@ -10,6 +10,7 @@ define([
     'text!static/ignoreButRetain/delete-bug-before.xml',
     'text!static/ignoreButRetain/empty-parent.xml',
     'text!static/ignoreButRetain/ignore-in-head.xml',
+    'text!static/ignoreButRetain/ignored-data-node.xml',
     'text!static/ignoreButRetain/ignored-tag-first.xml',
     'text!static/ignoreButRetain/multiple-ignores.xml',
     'text!static/ignoreButRetain/multi-match.xml',
@@ -29,6 +30,7 @@ define([
     DELETE_BUG_BEFORE,
     EMPTY_PARENT,
     IGNORE_IN_HEAD,
+    IGNORED_DATA_NODE,
     IGNORED_TAG_FIRST,
     MULTIPLE_IGNORES,
     MUTLI_MATCH,
@@ -112,6 +114,12 @@ define([
         it("should preserve data node children", function () {
             util.loadXML(CASE_WITH_UPDATE);
             assertXmlEqual(call('createXML'), CASE_WITH_UPDATE);
+        });
+
+        it("should ignore binds and controls associated with ignored data node", function () {
+            util.loadXML(IGNORED_DATA_NODE);
+            util.assertJSTreeState("question");
+            assertXmlEqual(call('createXML'), IGNORED_DATA_NODE);
         });
     });
 });

--- a/tests/static/ignoreButRetain/case-with-update.xml
+++ b/tests/static/ignoreButRetain/case-with-update.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/4552C9DD-F297-49CD-8606-AB59AD2C4EA7" uiVersion="1" version="1" name="Untitled Form">
+					<question/>
+					<case vellum:ignore="retain" xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id="">
+						<update>
+							<case_name/>
+							<owner_id/>
+						</update>
+					</case>
+				</data>
+			</instance>
+			<bind nodeset="/data/question" type="xsd:string"/>
+			<itext>
+				<translation lang="en" default="">
+					<text id="question-label">
+						<value>question</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/question">
+			<label ref="jr:itext('question-label')"/>
+		</input>
+	</h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/common-ignored.xml
+++ b/tests/static/ignoreButRetain/common-ignored.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/B3D39778-3AF6-4163-8D51-52DC9A105662" uiVersion="1" version="1" name="Untitled Form">
+					<question1 />
+					<question9>
+						<question11 />
+					</question9>
+				</data>
+			</instance>
+			<bind nodeset="/data/question1" type="xsd:string" />
+			<bind nodeset="/data/question9" />
+			<bind nodeset="/data/question9/question11" type="xsd:int" />
+			
+			<setvalue event="xforms-revalidate" ref="/data/question1" value="0"/>
+			<setvalue event="xforms-ready" ref="/data/question3" value="3"/>
+			<itext>
+				<translation lang="en" default="">
+					<text id="question1-label">
+						<value>question1</value>
+					</text>
+					<text id="question9-label">
+						<value>question9</value>
+					</text>
+					<text id="question11-label">
+						<value>question11</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/question1">
+			<label ref="jr:itext('question1-label')" />
+		</input>
+		<group ref="/data/question9">
+			<label ref="jr:itext('question9-label')" />
+			<input ref="/data/question9/question11">
+				<label ref="jr:itext('question11-label')" />
+			</input>
+		</group>
+	</h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/common-ignored.xml
+++ b/tests/static/ignoreButRetain/common-ignored.xml
@@ -5,16 +5,19 @@
 		<model>
 			<instance>
 				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/B3D39778-3AF6-4163-8D51-52DC9A105662" uiVersion="1" version="1" name="Untitled Form">
-					<question1 />
+					<question1/>
 					<question9>
-						<question11 />
+						<question10 vellum:ignore="retain"/>
+						<question11/>
 					</question9>
+					<question4 vellum:ignore="retain"/>
 				</data>
 			</instance>
-			<bind nodeset="/data/question1" type="xsd:string" />
-			<bind nodeset="/data/question9" />
-			<bind nodeset="/data/question9/question11" type="xsd:int" />
-			
+			<bind nodeset="/data/question1" type="xsd:string"/>
+			<bind nodeset="/data/question9"/>
+			<bind nodeset="/data/question9/question10" type="xsd:int" vellum:ignore="retain"/>
+			<bind nodeset="/data/question9/question11" type="xsd:int"/>
+			<bind nodeset="/data/question4" vellum:ignore="retain"/>
 			<setvalue event="xforms-revalidate" ref="/data/question1" value="0"/>
 			<setvalue event="xforms-ready" ref="/data/question3" value="3"/>
 			<itext>
@@ -32,15 +35,31 @@
 			</itext>
 		</model>
 	</h:head>
+	<!-- body nodes, including nesting -->
 	<h:body>
 		<input ref="/data/question1">
-			<label ref="jr:itext('question1-label')" />
+			<label ref="jr:itext('question1-label')"/>
 		</input>
 		<group ref="/data/question9">
-			<label ref="jr:itext('question9-label')" />
+			<label ref="jr:itext('question9-label')"/>
+			<!-- ignored node after an inner label -->
+			<input ref="/data/question9/question10" vellum:ignore="retain">
+				<label ref="jr:itext('question10-label')"/>
+			</input>
 			<input ref="/data/question9/question11">
-				<label ref="jr:itext('question11-label')" />
+				<label ref="jr:itext('question11-label')"/>
 			</input>
 		</group>
+		<select1 ref="/data/question4" vellum:ignore="retain">
+			<label ref="jr:itext('question4-label')"/>
+			<item>
+				<label ref="jr:itext('question4-item5-label')"/>
+				<value>item5</value>
+			</item>
+			<item>
+				<label ref="jr:itext('question4-item6-label')"/>
+				<value>item6</value>
+			</item>
+		</select1>
 	</h:body>
 </h:html>

--- a/tests/static/ignoreButRetain/common.xml
+++ b/tests/static/ignoreButRetain/common.xml
@@ -5,19 +5,19 @@
 		<model>
 			<instance>
 				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/B3D39778-3AF6-4163-8D51-52DC9A105662" uiVersion="1" version="1" name="Untitled Form">
-					<question1 />
+					<question1/>
 					<question9>
-						<question10 vellum:ignore="retain" />
-						<question11 />
+						<question10 vellum:ignore="retain"/>
+						<question11/>
 					</question9>
-					<question4 vellum:ignore="retain" />
+					<question4 vellum:ignore="retain"/>
 				</data>
 			</instance>
-			<bind nodeset="/data/question1" type="xsd:string" />
-			<bind nodeset="/data/question9" />
-			<bind nodeset="/data/question9/question10" type="xsd:int" vellum:ignore="retain" />
-			<bind nodeset="/data/question9/question11" type="xsd:int" />
-			<bind nodeset="/data/question4" vellum:ignore="retain" />
+			<bind nodeset="/data/question1" type="xsd:string"/>
+			<bind nodeset="/data/question9"/>
+			<bind nodeset="/data/question9/question10" type="xsd:int" vellum:ignore="retain"/>
+			<bind nodeset="/data/question9/question11" type="xsd:int"/>
+			<bind nodeset="/data/question4" vellum:ignore="retain"/>
 			<setvalue event="xforms-revalidate" ref="/data/question1" value="0"/>
 			<setvalue event="xforms-ready" ref="/data/question1" value="1" vellum:ignore="retain"/>
 			<setvalue event="xforms-ready" ref="/data/question2" value="2" vellum:ignore="retain"/>
@@ -40,26 +40,26 @@
 	<!-- body nodes, including nesting -->
 	<h:body>
 		<input ref="/data/question1">
-			<label ref="jr:itext('question1-label')" />
+			<label ref="jr:itext('question1-label')"/>
 		</input>
 		<group ref="/data/question9">
-			<label ref="jr:itext('question9-label')" />
+			<label ref="jr:itext('question9-label')"/>
 			<!-- ignored node after an inner label -->
 			<input ref="/data/question9/question10" vellum:ignore="retain">
-				<label ref="jr:itext('question10-label')" />
+				<label ref="jr:itext('question10-label')"/>
 			</input>
 			<input ref="/data/question9/question11">
-				<label ref="jr:itext('question11-label')" />
+				<label ref="jr:itext('question11-label')"/>
 			</input>
 		</group>
 		<select1 ref="/data/question4" vellum:ignore="retain">
-			<label ref="jr:itext('question4-label')" />
+			<label ref="jr:itext('question4-label')"/>
 			<item>
-				<label ref="jr:itext('question4-item5-label')" />
+				<label ref="jr:itext('question4-item5-label')"/>
 				<value>item5</value>
 			</item>
 			<item>
-				<label ref="jr:itext('question4-item6-label')" />
+				<label ref="jr:itext('question4-item6-label')"/>
 				<value>item6</value>
 			</item>
 		</select1>

--- a/tests/static/ignoreButRetain/common.xml
+++ b/tests/static/ignoreButRetain/common.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/B3D39778-3AF6-4163-8D51-52DC9A105662" uiVersion="1" version="1" name="Untitled Form">
+					<question1 />
+					<question9>
+						<question10 vellum:ignore="retain" />
+						<question11 />
+					</question9>
+					<question4 vellum:ignore="retain" />
+				</data>
+			</instance>
+			<bind nodeset="/data/question1" type="xsd:string" />
+			<bind nodeset="/data/question9" />
+			<bind nodeset="/data/question9/question10" type="xsd:int" vellum:ignore="retain" />
+			<bind nodeset="/data/question9/question11" type="xsd:int" />
+			<bind nodeset="/data/question4" vellum:ignore="retain" />
+			<setvalue event="xforms-revalidate" ref="/data/question1" value="0"/>
+			<setvalue event="xforms-ready" ref="/data/question1" value="1" vellum:ignore="retain"/>
+			<setvalue event="xforms-ready" ref="/data/question2" value="2" vellum:ignore="retain"/>
+			<setvalue event="xforms-ready" ref="/data/question3" value="3"/>
+			<itext>
+				<translation lang="en" default="">
+					<text id="question1-label">
+						<value>question1</value>
+					</text>
+					<text id="question9-label">
+						<value>question9</value>
+					</text>
+					<text id="question11-label">
+						<value>question11</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<!-- body nodes, including nesting -->
+	<h:body>
+		<input ref="/data/question1">
+			<label ref="jr:itext('question1-label')" />
+		</input>
+		<group ref="/data/question9">
+			<label ref="jr:itext('question9-label')" />
+			<!-- ignored node after an inner label -->
+			<input ref="/data/question9/question10" vellum:ignore="retain">
+				<label ref="jr:itext('question10-label')" />
+			</input>
+			<input ref="/data/question9/question11">
+				<label ref="jr:itext('question11-label')" />
+			</input>
+		</group>
+		<select1 ref="/data/question4" vellum:ignore="retain">
+			<label ref="jr:itext('question4-label')" />
+			<item>
+				<label ref="jr:itext('question4-item5-label')" />
+				<value>item5</value>
+			</item>
+			<item>
+				<label ref="jr:itext('question4-item6-label')" />
+				<value>item6</value>
+			</item>
+		</select1>
+	</h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/delete-bug-after.xml
+++ b/tests/static/ignoreButRetain/delete-bug-after.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/4552C9DD-F297-49CD-8606-AB59AD2C4EA7" uiVersion="1" version="1" name="Untitled Form">
+					<before/>
+					<ignored vellum:ignore="retain"/>
+					<after/>
+				</data>
+			</instance>
+			<bind nodeset="/data/before" type="xsd:string"/>
+			<bind nodeset="/data/ignored" type="xsd:string" vellum:ignore="retain"/>
+			<bind nodeset="/data/after" type="xsd:string"/>
+			<setvalue event="when-youre-strange" ref="/data/ignored[inner]" value="super()/flip"/>
+			<itext>
+				<translation lang="en" default="">
+					<text id="before-label">
+						<value>before</value>
+					</text>
+					<text id="after-label">
+						<value>after</value>
+					</text>
+					<text id="ignored-label" vellum:ignore="retain">
+						<value>ignored</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/before">
+			<label ref="jr:itext('before-label')"/>
+		</input>
+		<input ref="/data/ignored" vellum:ignore="retain">
+			<label ref="jr:itext('ignored-label')"/>
+		</input>
+		<input ref="/data/after">
+			<label ref="jr:itext('after-label')"/>
+		</input>
+	</h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/delete-bug-after.xml
+++ b/tests/static/ignoreButRetain/delete-bug-after.xml
@@ -19,11 +19,11 @@
 					<text id="before-label">
 						<value>before</value>
 					</text>
-					<text id="after-label">
-						<value>after</value>
-					</text>
 					<text id="ignored-label" vellum:ignore="retain">
 						<value>ignored</value>
+					</text>
+					<text id="after-label">
+						<value>after</value>
 					</text>
 				</translation>
 			</itext>

--- a/tests/static/ignoreButRetain/delete-bug-before.xml
+++ b/tests/static/ignoreButRetain/delete-bug-before.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/4552C9DD-F297-49CD-8606-AB59AD2C4EA7" uiVersion="1" version="1" name="Untitled Form">
+					<before/>
+					<delete-me/>
+					<ignored vellum:ignore="retain"/>
+					<after/>
+				</data>
+			</instance>
+			<bind nodeset="/data/before" type="xsd:string"/>
+			<bind nodeset="/data/delete-me" type="xsd:string"/>
+			<bind nodeset="/data/ignored" type="xsd:string" vellum:ignore="retain"/>
+			<bind nodeset="/data/after" type="xsd:string"/>
+			<setvalue event="when-youre-strange" ref="/data/ignored[inner]" value="super()/flip"/>
+			<itext>
+				<translation lang="en" default="">
+					<text id="before-label">
+						<value>before</value>
+					</text>
+					<text id="delete-me-label">
+						<value>delete-me</value>
+					</text>
+					<text id="ignored-label" vellum:ignore="retain">
+						<value>ignored</value>
+					</text>
+					<text id="after-label">
+						<value>after</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/before">
+			<label ref="jr:itext('before-label')"/>
+		</input>
+		<input ref="/data/delete-me">
+			<label ref="jr:itext('delete-me-label')"/>
+		</input>
+		<input ref="/data/ignored" vellum:ignore="retain">
+			<label ref="jr:itext('ignored-label')"/>
+		</input>
+		<input ref="/data/after">
+			<label ref="jr:itext('after-label')"/>
+		</input>
+	</h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/ignore-in-head.xml
+++ b/tests/static/ignoreButRetain/ignore-in-head.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">
+					<question1 />
+				</data>
+			</instance>
+			<bind nodeset="/data/question1" type="xsd:string" />
+			<itext>
+				<translation lang="en" default=""/>
+			</itext>
+		</model>
+		<odkx:intent vellum:ignore="retain" xmlns:odkx="http://opendatakit.org/xforms" id="search" class="com.biometrac.core.PIPE">
+		</odkx:intent>
+	</h:head>
+	<h:body></h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/ignored-binds-with-extra-path.xml
+++ b/tests/static/ignoreButRetain/ignored-binds-with-extra-path.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/4552C9DD-F297-49CD-8606-AB59AD2C4EA7" uiVersion="1" version="1" name="Untitled Form">
+					<question vellum:ignore="retain"/>
+					<question2/>
+				</data>
+			</instance>
+			<bind nodeset="/data/question" type="xsd:string"/>
+			<bind nodeset="/data/question/extra/path" type="xsd:string"/>
+			<bind nodeset="/data/question[extra=path]" type="xsd:string"/>
+			<bind nodeset="/data/question[with][extra=path]" type="xsd:string"/>
+			<bind nodeset="/data/question2" type="xsd:string"/>
+			<itext>
+				<translation lang="en" default="">
+					<text id="question2-label">
+						<value>question2</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/question2">
+			<label ref="jr:itext('question2-label')"/>
+		</input>
+	</h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/ignored-control-node.xml
+++ b/tests/static/ignoreButRetain/ignored-control-node.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/4552C9DD-F297-49CD-8606-AB59AD2C4EA7" uiVersion="1" version="1" name="Untitled Form">
+					<question/>
+				</data>
+			</instance>
+			<bind nodeset="/data/question" type="xsd:string"/>
+			<itext>
+				<translation lang="en" default="">
+					<text id="question-label" vellum:ignore="retain">
+						<value>question</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/question" vellum:ignore="retain">
+			<label ref="jr:itext('question-label')"/>
+		</input>
+	</h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/ignored-data-node.xml
+++ b/tests/static/ignoreButRetain/ignored-data-node.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/4552C9DD-F297-49CD-8606-AB59AD2C4EA7" uiVersion="1" version="1" name="Untitled Form">
+					<question vellum:ignore="retain"/>
+				</data>
+			</instance>
+			<bind nodeset="/data/question" type="xsd:string"/>
+			<itext>
+				<translation lang="en" default="">
+					<text id="question-label" vellum:ignore="retain">
+						<value>question</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/question">
+			<label ref="jr:itext('question-label')"/>
+		</input>
+	</h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/ignored-tag-first.xml
+++ b/tests/static/ignoreButRetain/ignored-tag-first.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<ext vellum:ignore="retain"><content /></ext>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/4552C9DD-F297-49CD-8606-AB59AD2C4EA7" uiVersion="1" version="1" name="Untitled Form">
+					<question/>
+				</data>
+			</instance>
+			<bind nodeset="/data/question" type="xsd:string"/>
+			<itext>
+				<translation lang="en" default="">
+					<text id="question-label">
+						<value>question</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/question">
+			<label ref="jr:itext('question-label')"/>
+		</input>
+	</h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/multi-match.xml
+++ b/tests/static/ignoreButRetain/multi-match.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">
+					<question1 />
+				</data>
+			</instance>
+			<bind nodeset="/data/question1" type="xsd:string" />
+			<bind nodeset="/data/question1" vellum:ignore="retain" />
+			<bind nodeset="/data/question1" vellum:ignore="retain" />
+			<itext>
+				<translation lang="en" default=""/>
+			</itext>
+		</model>
+	</h:head>
+	<h:body></h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/multi-match.xml
+++ b/tests/static/ignoreButRetain/multi-match.xml
@@ -5,12 +5,12 @@
 		<model>
 			<instance>
 				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">
-					<question1 />
+					<question1/>
 				</data>
 			</instance>
-			<bind nodeset="/data/question1" type="xsd:string" />
-			<bind nodeset="/data/question1" vellum:ignore="retain" />
-			<bind nodeset="/data/question1" vellum:ignore="retain" />
+			<bind nodeset="/data/question1" type="xsd:string"/>
+			<bind nodeset="/data/question1" vellum:ignore="retain"/>
+			<bind nodeset="/data/question1" vellum:ignore="retain"/>
 			<itext>
 				<translation lang="en" default=""/>
 			</itext>

--- a/tests/static/ignoreButRetain/multiple-ignores.xml
+++ b/tests/static/ignoreButRetain/multiple-ignores.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">
+					<question1 />
+					<question9 vellum:ignore="retain" />
+					<question4 vellum:ignore="retain" />
+				</data>
+			</instance>
+			<bind nodeset="/data/question1" type="xsd:string" />
+			<bind nodeset="/data/question9" vellum:ignore="retain" />
+			<bind nodeset="/data/question4" vellum:ignore="retain" />
+			<itext>
+				<translation lang="en" default=""/>
+			</itext>
+		</model>
+	</h:head>
+	<h:body></h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/nested-ignored-nodes.xml
+++ b/tests/static/ignoreButRetain/nested-ignored-nodes.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/4552C9DD-F297-49CD-8606-AB59AD2C4EA7" uiVersion="1" version="1" name="Untitled Form">
+					<question/>
+				</data>
+			</instance>
+			<bind nodeset="/data/question" type="xsd:string"/>
+			<itext>
+				<translation lang="en" default="">
+					<text id="question-label">
+						<value>question</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+		<ext vellum:ignore="retain">
+			<one vellum:ignore="retain"/>
+			<x><two vellum:ignore="retain"/></x>
+		</ext>
+	</h:head>
+	<h:body>
+		<input ref="/data/question">
+			<label ref="jr:itext('question-label')"/>
+		</input>
+	</h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/referenced-renamed.xml
+++ b/tests/static/ignoreButRetain/referenced-renamed.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">
+					<foobar/>
+					<question9 vellum:ignore="retain"/>
+				</data>
+			</instance>
+			<bind nodeset="/data/foobar" type="xsd:string"/>
+			<bind nodeset="/data/question9" calculate="1 + /data/foobar" vellum:ignore="retain"/>
+			<itext>
+				<translation lang="en" default=""/>
+			</itext>
+		</model>
+	</h:head>
+	<h:body></h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/referenced-unrenamed.xml
+++ b/tests/static/ignoreButRetain/referenced-unrenamed.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">
+					<question1 />
+					<question9 vellum:ignore="retain" />
+				</data>
+			</instance>
+			<bind nodeset="/data/question1" type="xsd:string" />
+			<bind nodeset="/data/question9" calculate="1 + /data/question1" vellum:ignore="retain"/>
+		</model>
+	</h:head>
+	<h:body></h:body>
+</h:html>

--- a/tests/static/ignoreButRetain/renamed.xml
+++ b/tests/static/ignoreButRetain/renamed.xml
@@ -6,14 +6,18 @@
 			<instance>
 				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/398C9010-61DC-42D3-8A85-B857AC3A9CA0" uiVersion="1" version="1" name="Untitled Form">
 					<question1/>
-					<question9a><question10 vellum:ignore="retain"/>
+					<question9a>
+						<question10 vellum:ignore="retain"/>
 						<question11/>
-					</question9a><question4 vellum:ignore="retain"/>
+					</question9a>
+					<question4 vellum:ignore="retain"/>
 				</data>
 			</instance>
 			<bind nodeset="/data/question1" type="xsd:string"/>
-			<bind nodeset="/data/question9a"/><bind nodeset="/data/question9a/question10" type="xsd:int" vellum:ignore="retain"/>
-			<bind nodeset="/data/question9a/question11" type="xsd:int"/><bind nodeset="/data/question4" vellum:ignore="retain"/>
+			<bind nodeset="/data/question9a"/>
+			<bind nodeset="/data/question9a/question10" type="xsd:int" vellum:ignore="retain"/>
+			<bind nodeset="/data/question9a/question11" type="xsd:int"/>
+			<bind nodeset="/data/question4" vellum:ignore="retain"/>
 			<itext>
 				<translation lang="en" default="">
 					<text id="question1-label">
@@ -21,13 +25,15 @@
 					</text>
 					<text id="question9a-label">
 						<value>question9</value>
-					</text><text id="question10-label" vellum:ignore="retain">
-						<value>question10</value>
 					</text>
 					<text id="question11-label">
 						<value>question11</value>
-					</text><text id="question4-label" vellum:ignore="retain">
+					</text>
+					<text id="question4-label" vellum:ignore="retain">
 						<value>question4</value>
+					</text>
+					<text id="question10-label" vellum:ignore="retain">
+						<value>question10</value>
 					</text>
 				</translation>
 			</itext>
@@ -39,13 +45,15 @@
 		</input>
 		<group ref="/data/question9a">
 			<!-- todo: renaming of itext IDs without requiring UI layer -->
-			<label ref="jr:itext('question9a-label')"/><input ref="/data/question9a/question10" vellum:ignore="retain">
+			<label ref="jr:itext('question9a-label')"/>
+			<input ref="/data/question9a/question10" vellum:ignore="retain">
 				<label ref="jr:itext('question10-label')"/>
 			</input>
 			<input ref="/data/question9a/question11">
 				<label ref="jr:itext('question11-label')"/>
 			</input>
-		</group><select1 ref="/data/question4" vellum:ignore="retain">
+		</group>
+		<select1 ref="/data/question4" vellum:ignore="retain">
 			<label ref="jr:itext('question4-label')"/>
 			<item>
 				<label ref="jr:itext('question4-item5-label')"/>

--- a/tests/static/ignoreButRetain/renamed.xml
+++ b/tests/static/ignoreButRetain/renamed.xml
@@ -26,14 +26,14 @@
 					<text id="question9a-label">
 						<value>question9</value>
 					</text>
+					<text id="question10-label" vellum:ignore="retain">
+						<value>question10</value>
+					</text>
 					<text id="question11-label">
 						<value>question11</value>
 					</text>
 					<text id="question4-label" vellum:ignore="retain">
 						<value>question4</value>
-					</text>
-					<text id="question10-label" vellum:ignore="retain">
-						<value>question10</value>
 					</text>
 				</translation>
 			</itext>


### PR DESCRIPTION
This is a big overhaul of the ignore-but-retain plugin. It makes the plugin smarter about handling ignored things that look like questions. There is a notable UI change: ignored question fragments (data, bind, and control nodes) are now represented by a question-like object in the tree.

![screenshot 2015-05-04 16 07 08](https://cloud.githubusercontent.com/assets/464726/7461373/b479f7c0-f277-11e4-8309-b8f2ffe50cdd.png)

Fixes
http://manage.dimagi.com/default.asp?146253 - bind nodes moved to top of form
http://manage.dimagi.com/default.asp?149925 - can't rename questions when ignore/retain is active
http://manage.dimagi.com/default.asp?164398 - case block with nested/ignored update block

cc @wspride 