### PR TITLE
Rename analytics events

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -154,8 +154,8 @@ define([
                     return; // abort
                 }
                 _this.ensureCurrentMugIsSaved(function () {
-                    if (!_.isUndefined(window.analytics)) {
-                        window.analytics.track("Clicked Save in Formbuilder");
+                    if (!_.isUndefined(window._kmq)) {
+                        window._kmq.push(["record", "Clicked Save in Formbuilder"]);
                     }
                     _this.validateAndSaveXForm(forceFullSave);
                 });
@@ -1346,8 +1346,8 @@ define([
             if (!foo) {
                 throw new Error("cannot add " + qType + " at the current position");
             }
-            if (!_.isUndefined(window.analytics)) {
-                window.analytics.track("Added a question");
+            if (!_.isUndefined(window._kmq)) {
+                window._kmq.push(["record", "Added a question"]);
             }
             mug = _this.data.core.form.createQuestion(foo.mug, foo.position, qType);
             var $firstInput = _this.$f.find(".fd-question-properties input:text:visible:first");

--- a/src/core.js
+++ b/src/core.js
@@ -154,8 +154,8 @@ define([
                     return; // abort
                 }
                 _this.ensureCurrentMugIsSaved(function () {
-                    if (!_.isUndefined(window._kmq)) {
-                        window._kmq.push(["record", "Clicked Save in Formbuilder"]);
+                    if (!_.isUndefined(window.analytics)) {
+                        window.analytics.track("Clicked Save in form builder");
                     }
                     _this.validateAndSaveXForm(forceFullSave);
                 });
@@ -1346,8 +1346,8 @@ define([
             if (!foo) {
                 throw new Error("cannot add " + qType + " at the current position");
             }
-            if (!_.isUndefined(window._kmq)) {
-                window._kmq.push(["record", "Added a question"]);
+            if (!_.isUndefined(window.analytics)) {
+                window.analytics.track("Added question in form builder");
             }
             mug = _this.data.core.form.createQuestion(foo.mug, foo.position, qType);
             var $firstInput = _this.$f.find(".fd-question-properties input:text:visible:first");


### PR DESCRIPTION
This is part of a conversion of our analytics tracking from Segment to KISSmetrics. This needs to be released at the same time as the corresponding changes to HQ are changed, which is why I put the don't merge tag on it. @millerdev How does the vellum deploy process work exactly? I've seen the vellum-to-hq script, but I'm not sure when exactly that gets run.