### PR TITLE
Support attachments

### DIFF
--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -701,9 +701,6 @@ define([
                     if (mug && mug.__className === "SaveToCase") {
                         var attachProperties = mug.p.attachmentProperty,
                             nodeName = attachRet[1];
-                        if (!attachProperties) {
-                            attachProperties = {};
-                        }
                         if (!attachProperties[nodeName]) {
                             attachProperties[nodeName] = {};
                         }

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -46,6 +46,11 @@ define([
         return mug ? mug.p.useAttachment : false;
     }
 
+    function usesCases(mug) {
+        return createsCase(mug) || closesCase(mug) || updatesCase(mug) ||
+            indexesCase(mug) || attachmentCase(mug);
+    }
+
     function addSetValue(mug) {
         var path = mug.absolutePath;
 
@@ -456,7 +461,7 @@ define([
                     );
                 }
 
-                if (createsCase(mug) || updatesCase(mug) || closesCase(mug) || indexesCase(mug) || attachmentCase(mug)) {
+                if (usesCases(mug)) {
                     ret.push({
                         nodeset: mug.absolutePath + "/case/@date_modified",
                         calculate: mug.p.date_modified,
@@ -688,7 +693,7 @@ define([
                     }
                 }
                 
-                var attachmentRegex = /\/case\/attachment\/(\w+)\/@src/,
+                var attachmentRegex = /\/case\/attachment\/(\w+)\/@src$/,
                     attachRet = path.match(attachmentRegex);
                 if (attachRet) {
                     basePath = path.replace(attachmentRegex, "");

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -307,18 +307,41 @@ define([
                     presence: 'optional',
                     widget: attachmentCaseWidget,
                     validationFunc: function (mug) {
-                        if (mug.p.use_attachment) {
-                            var props = _.without(_.keys(mug.p.attachment_property), ""),
-                                invalidProps = _.filter(props, function(p) {
-                                    return !VALID_PROP_REGEX.test(p);
-                                });
-
-                            if (invalidProps.length > 0) {
-                                return invalidProps.join(", ") + 
-                                    " are invalid properties";
-                            }
+                        if (!mug.p.use_attachment) {
+                            return "pass";
                         }
-                        return 'pass';
+
+                        var props = _.without(_.keys(mug.p.attachment_property), ""),
+                            invalidProps = _.filter(props, function(p) {
+                                return !VALID_PROP_REGEX.test(p);
+                            }),
+                            invalidFroms = _.filter(props, function(p) {
+                                return !_.contains(['local', 'remote', 'inline'],
+                                                   mug.p.attachment_property[p].from);
+                            }),
+                            invalidInlines = _.filter(props, function(p) {
+                                var prop = mug.p.attachment_property[p],
+                                    from = prop.from,
+                                    name = prop.name;
+                                return from === 'inline' && !name;
+                            });
+
+                        if (invalidProps.length > 0) {
+                            return invalidProps.join(", ") + 
+                                " are invalid properties";
+                        }
+
+                        if (invalidFroms.length > 0) {
+                            return "The from attribute must be one of: " + 
+                                "local, remote, or inline";
+                        }
+                        
+                        if (invalidInlines.length > 0) {
+                            return "Inlined attachments must have an " +
+                                "attachment name";
+                        }
+
+                        return "pass";
                     }
                 }
             },

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -27,23 +27,23 @@ define([
     widget_save_to_case
 ){
     function createsCase(mug) {
-        return mug ? mug.p.use_create : false;
+        return mug ? mug.p.useCreate : false;
     }
 
     function closesCase(mug) {
-        return mug ? mug.p.use_close : false;
+        return mug ? mug.p.useClose : false;
     }
 
     function updatesCase(mug) {
-        return mug ? mug.p.use_update : false;
+        return mug ? mug.p.useUpdate : false;
     }
 
     function indexesCase(mug) {
-        return mug ? mug.p.use_index : false;
+        return mug ? mug.p.useIndex : false;
     }
 
     function attachmentCase(mug) {
-        return mug ? mug.p.use_attachment : false;
+        return mug ? mug.p.useAttachment : false;
     }
 
     function addSetValue(mug) {
@@ -192,20 +192,20 @@ define([
                     presence: 'required',
                     widget: widgets.xPath,
                 },
-                "use_create": {
+                useCreate: {
                     lstring: "Create Case",
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.checkbox
                 },
-                "create_property": {
+                createProperty: {
                     lstring: "Properties To Create",
                     visibility: 'visible',
                     presence: 'optional',
                     widget: saveCasePropWidget,
                     validationFunc: function (mug) {
-                        if (mug.p.use_create) {
-                            var props = _.without(_.keys(mug.p.create_property), ""),
+                        if (mug.p.useCreate) {
+                            var props = _.without(_.keys(mug.p.createProperty), ""),
                                 required = ["case_type", "case_name"],
                                 optional = ["owner_id"],
                                 legal = _.union(required, optional),
@@ -231,32 +231,32 @@ define([
                         return 'pass';
                     }
                 },
-                "use_close": {
+                useClose: {
                     lstring: "Close Case",
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.checkbox
                 },
-                "close_condition": {
+                closeCondition: {
                     lstring: "Close Condition",
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.xPath
                 },
-                "use_update": {
+                useUpdate: {
                     lstring: "Update Case",
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.checkbox
                 },
-                "update_property": {
+                updateProperty: {
                     lstring: "Properties To Update",
                     visibility: 'visible',
                     presence: 'optional',
                     widget: saveCasePropWidget,
                     validationFunc: function (mug) {
-                        if (mug.p.use_update) {
-                            var props = _.without(_.keys(mug.p.update_property), ""),
+                        if (mug.p.useUpdate) {
+                            var props = _.without(_.keys(mug.p.updateProperty), ""),
                                 invalidProps = _.filter(props, function(p) {
                                     return !VALID_PROP_REGEX.test(p);
                                 });
@@ -269,20 +269,20 @@ define([
                         return 'pass';
                     }
                 },
-                "use_index": {
+                useIndex: {
                     lstring: "Use Index",
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.checkbox
                 },
-                "index_property": {
+                indexProperty: {
                     lstring: "Index Properties",
                     visibility: 'visible',
                     presence: 'optional',
                     widget: indexCaseWidget,
                     validationFunc: function (mug) {
-                        if (mug.p.use_index) {
-                            var props = _.without(_.keys(mug.p.index_property), ""),
+                        if (mug.p.useIndex) {
+                            var props = _.without(_.keys(mug.p.indexProperty), ""),
                                 invalidProps = _.filter(props, function(p) {
                                     return !VALID_PROP_REGEX.test(p);
                                 });
@@ -295,32 +295,32 @@ define([
                         return 'pass';
                     }
                 },
-                "use_attachment": {
+                useAttachment: {
                     lstring: "Use Attachments",
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.checkbox
                 },
-                "attachment_property": {
+                attachmentProperty: {
                     lstring: "Attachment Properties",
                     visibility: 'visible',
                     presence: 'optional',
                     widget: attachmentCaseWidget,
                     validationFunc: function (mug) {
-                        if (!mug.p.use_attachment) {
+                        if (!mug.p.useAttachment) {
                             return "pass";
                         }
 
-                        var props = _.without(_.keys(mug.p.attachment_property), ""),
+                        var props = _.without(_.keys(mug.p.attachmentProperty), ""),
                             invalidProps = _.filter(props, function(p) {
                                 return !VALID_PROP_REGEX.test(p);
                             }),
                             invalidFroms = _.filter(props, function(p) {
                                 return !_.contains(['local', 'remote', 'inline'],
-                                                   mug.p.attachment_property[p].from);
+                                                   mug.p.attachmentProperty[p].from);
                             }),
                             invalidInlines = _.filter(props, function(p) {
-                                var prop = mug.p.attachment_property[p],
+                                var prop = mug.p.attachmentProperty[p],
                                     from = prop.from,
                                     name = prop.name;
                                 return from === 'inline' && !name;
@@ -378,11 +378,11 @@ define([
 
                 var actions = [];
                 if (createsCase(mug)) {
-                    actions.push(simpleNode('create', makeColumns(mug.p.create_property)));
+                    actions.push(simpleNode('create', makeColumns(mug.p.createProperty)));
                 }
 
                 if (updatesCase(mug)) {
-                    actions.push(simpleNode('update', makeColumns(mug.p.update_property)));
+                    actions.push(simpleNode('update', makeColumns(mug.p.updateProperty)));
                 }
 
                 if (closesCase(mug)) {
@@ -391,13 +391,13 @@ define([
 
                 if (indexesCase(mug)) {
                     actions.push(simpleNode('index', 
-                                            makeColumns(mug.p.index_property, 
+                                            makeColumns(mug.p.indexProperty, 
                                                         ['case_type', 'relationship'])));
                 }
 
                 if (attachmentCase(mug)) {
                     actions.push(simpleNode('attachment', 
-                                            makeColumns(mug.p.attachment_property, 
+                                            makeColumns(mug.p.attachmentProperty, 
                                                         ['from', 'name'])));
                 }
 
@@ -429,23 +429,23 @@ define([
                 }
 
                 if (createsCase(mug)) {
-                    ret = ret.concat(generateBinds('create', mug.p.create_property));
+                    ret = ret.concat(generateBinds('create', mug.p.createProperty));
                 }
                 if (updatesCase(mug)) {
-                    ret = ret.concat(generateBinds('update', mug.p.update_property));
+                    ret = ret.concat(generateBinds('update', mug.p.updateProperty));
                 }
                 if (closesCase(mug)) {
                     ret.push({
                         nodeset: mug.absolutePath + "/case/close",
-                        relevant: mug.p.close_condition
+                        relevant: mug.p.closeCondition
                     });
                 }
                 if (indexesCase(mug)) {
-                    ret = ret.concat(generateBinds('index', mug.p.index_property));
+                    ret = ret.concat(generateBinds('index', mug.p.indexProperty));
                 }
                 if (attachmentCase(mug)) {
                     ret = ret.concat(
-                        _.chain(mug.p.attachment_property)
+                        _.chain(mug.p.attachmentProperty)
                          .omit("")
                          .map(function(v, k) {
                              return {
@@ -484,33 +484,33 @@ define([
                     index = case_.find('index'),
                     attach = case_.find('attachment');
                 if (create && create.length !== 0) {
-                    mug.p.use_create = true;
+                    mug.p.useCreate = true;
                 }
                 if (update && update.length !== 0) {
-                    mug.p.use_update = true;
+                    mug.p.useUpdate = true;
                 }
                 if (close && close.length !== 0) {
-                    mug.p.use_close = true;
+                    mug.p.useClose = true;
                 }
                 if (index && index.length !== 0) {
-                    mug.p.use_index = true;
-                    mug.p.index_property = {};
+                    mug.p.useIndex = true;
+                    mug.p.indexProperty = {};
                     _.each(index.children(), function(child) {
                         var prop = $(child);
-                        mug.p.index_property[prop.prop('tagName')] = {
+                        mug.p.indexProperty[prop.prop('tagName')] = {
                             case_type: prop.attr('case_type'),
                             relationship: prop.attr('relationship')
                         };
                     });
                 }
                 if (attach && attach.length !== 0) {
-                    mug.p.use_attachment = true;
-                    if (!mug.p.attachment_property) {
-                        mug.p.attachment_property = {};
+                    mug.p.useAttachment = true;
+                    if (!mug.p.attachmentProperty) {
+                        mug.p.attachmentProperty = {};
                     }
                     _.each(attach.children(), function(child) {
                         var prop = $(child);
-                        mug.p.attachment_property[prop.prop('tagName')] = {
+                        mug.p.attachmentProperty[prop.prop('tagName')] = {
                             from: prop.attr('from'),
                             name: prop.attr('name')
                         };
@@ -535,8 +535,8 @@ define([
                     slug: "create",
                     displayName: "Create",
                     properties: [
-                        "use_create",
-                        "create_property",
+                        "useCreate",
+                        "createProperty",
                     ],
                     isCollapsed: function (mug) {
                         return !createsCase(mug);
@@ -546,8 +546,8 @@ define([
                     slug: "update",
                     displayName: "Update",
                     properties: [
-                        "use_update",
-                        "update_property",
+                        "useUpdate",
+                        "updateProperty",
                     ],
                     isCollapsed: function (mug) {
                         return !updatesCase(mug);
@@ -557,8 +557,8 @@ define([
                     slug: "close",
                     displayName: "Close",
                     properties: [
-                        "use_close",
-                        "close_condition",
+                        "useClose",
+                        "closeCondition",
                     ],
                     isCollapsed: function (mug) {
                         return !closesCase(mug);
@@ -568,8 +568,8 @@ define([
                     slug: "index",
                     displayName: "Index",
                     properties: [
-                        "use_index",
-                        "index_property",
+                        "useIndex",
+                        "indexProperty",
                     ],
                     isCollapsed: function (mug) {
                         return !indexesCase(mug);
@@ -579,8 +579,8 @@ define([
                     slug: "attachment",
                     displayName: "Attachments",
                     properties: [
-                        "use_attachment",
-                        "attachment_property",
+                        "useAttachment",
+                        "attachmentProperty",
                     ],
                     isCollapsed: function (mug) {
                         return !attachmentCase(mug);
@@ -641,10 +641,10 @@ define([
                         if (matchRet[2]) {
                             var prop = matchRet[2],
                                 pKey = {
-                                    create: "create_property",
-                                    update: "update_property",
-                                    index: "index_property",
-                                    attachment: "attachment_property",
+                                    create: "createProperty",
+                                    update: "updateProperty",
+                                    index: "indexProperty",
+                                    attachment: "attachmentProperty",
                                 }[matchRet[1]];
 
                             if (!mug.p[pKey]) {
@@ -661,7 +661,7 @@ define([
                         } else {
                             var attr = {
                                 close: {
-                                    mugProp: 'close_condition',
+                                    mugProp: 'closeCondition',
                                     elAttr: 'relevant'
                                 },
                                 '@date_modified': {
@@ -694,7 +694,7 @@ define([
                     basePath = path.replace(attachmentRegex, "");
                     mug = form.getMugByPath(basePath);
                     if (mug && mug.__className === "SaveToCase") {
-                        var attachProperties = mug.p.attachment_property,
+                        var attachProperties = mug.p.attachmentProperty,
                             nodeName = attachRet[1];
                         if (!attachProperties) {
                             attachProperties = {};
@@ -702,7 +702,7 @@ define([
                         if (!attachProperties[nodeName]) {
                             attachProperties[nodeName] = {};
                         }
-                        mug.p.attachment_property[nodeName].calculate = el.attr('calculate');
+                        mug.p.attachmentProperty[nodeName].calculate = el.attr('calculate');
                         return;
                     }
                 }

--- a/src/templates/widget_attachment_case.html
+++ b/src/templates/widget_attachment_case.html
@@ -1,0 +1,35 @@
+<% props[""] = {calculate: "", relevant: ""}; %>
+
+<% _.each(props, function (v, k) { %>
+  <div class="fd-attachment-property control-row clearfix" style="margin-bottom: 5px">
+    <div class="control-row">
+      <div class="span11">
+        <input class="fd-attachment-property-name input-block-level"
+               value="<%-k%>" type="text" placeholder="Node Name"/>
+      </div>
+      <div class="span1">
+        <a href="#" class="btn fd-remove-property btn-small btn-danger">
+          <i class="icon-remove"></i>
+        </a>
+      </div>
+    </div>
+    <div class="control-row">
+      <div class="span11">
+        <input class="fd-attachment-property-source input-block-level"
+               value="<%-v['calculate']%>" type="text" placeholder="Source" />
+      </div>
+    </div>
+    <div class="control-row">
+      <div class="span11">
+        <input class="fd-attachment-property-from input-block-level"
+               value="<%-v['from']%>" type="text" placeholder="From"/>
+      </div>
+    </div>
+    <div class="control-row">
+      <div class="span11">
+        <input class="fd-attachment-name input-block-level"
+               value="<%-v['name']%>" type="text" placeholder="Attachment Name"/>
+      </div>
+    </div>
+  </div>
+<% }); %>

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -108,6 +108,30 @@ define([
             util.assertXmlEqual(call("createXML"), ATTACHMENT_PROPERTY_XML);
         });
 
+        _.each({
+            "inline attachments": {
+                inline_prop: {
+                    calculate: "/data/question1",
+                    from: "inline",
+                }
+            },
+            "from strings": {
+                from_strings: {
+                    calculate: "/data/question1",
+                    from: "blah"
+                }
+            }
+        }, function(v, k) {
+            it("should validate " + k, function() {
+                util.loadXML("");
+                var save = util.addQuestion("SaveToCase", "save"),
+                    spec = save.spec.attachment_property;
+                save.p.use_attachment = true;
+                save.p.attachment_property = v;
+                assert.notEqual(spec.validationFunc(save), "pass");
+            });
+        });
+
         it("should load 2 create setvalues", function () {
             util.loadXML(CREATE_2_PROPERTY_XML);
             var create1 = util.getMug("create1"),

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -8,6 +8,7 @@ define([
     'text!static/saveToCase/close_property.xml',
     'text!static/saveToCase/update_property.xml',
     'text!static/saveToCase/index_property.xml',
+    'text!static/saveToCase/attachment_property.xml',
     'text!static/saveToCase/create_2_property.xml',
 ], function (
     util,
@@ -19,6 +20,7 @@ define([
     CLOSE_PROPERTY_XML,
     UPDATE_PROPERTY_XML,
     INDEX_PROPERTY_XML,
+    ATTACHMENT_PROPERTY_XML,
     CREATE_2_PROPERTY_XML
 ) {
     var assert = chai.assert,
@@ -87,6 +89,23 @@ define([
             assert.equal(index.p.user_id, "/data/meta/userID");
             assert.equal(index.p.case_id, "/data/meta/caseID");
             util.assertXmlEqual(call("createXML"), INDEX_PROPERTY_XML);
+        });
+
+        it("should load and save a attachment property", function () {
+            util.loadXML(ATTACHMENT_PROPERTY_XML);
+            var attach = util.getMug("save_to_case");
+            assert.equal(attach.p.use_attachment, true);
+            assert(_.isEqual(attach.p.attachment_property, {
+                attach: {
+                    calculate: "/data/question1",
+                    from: "local",
+                    name: "name",
+                }
+            }));
+            assert.equal(attach.p.date_modified, '/data/meta/timeEnd');
+            assert.equal(attach.p.user_id, "/data/meta/userID");
+            assert.equal(attach.p.case_id, "/data/meta/caseID");
+            util.assertXmlEqual(call("createXML"), ATTACHMENT_PROPERTY_XML);
         });
 
         it("should load 2 create setvalues", function () {

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -37,10 +37,10 @@ define([
         it("should load and save a create property", function () {
             util.loadXML(CREATE_PROPERTY_XML);
             var create = util.getMug("save_to_case"),
-                props = create.p.create_property;
+                props = create.p.createProperty;
             assert.equal(props.case_type.calculate, "caseType");
             assert.equal(props.case_name.calculate, "/data/name");
-            assert.equal(create.p.use_create, true);
+            assert.equal(create.p.useCreate, true);
             assert.equal(props.owner_id.calculate, '/data/meta/userID');
             assert.equal(create.p.date_modified, '/data/meta/timeEnd');
             assert.equal(create.p.user_id, "/data/meta/userID");
@@ -50,8 +50,8 @@ define([
         it("should load and save a close property", function () {
             util.loadXML(CLOSE_PROPERTY_XML);
             var close = util.getMug("save_to_case");
-            assert.equal(close.p.use_close, true);
-            assert.equal(close.p.close_condition, "1=1");
+            assert.equal(close.p.useClose, true);
+            assert.equal(close.p.closeCondition, "1=1");
             assert.equal(close.p.date_modified, '/data/meta/timeEnd');
             assert.equal(close.p.user_id, "/data/meta/userID");
             assert.equal(close.p.case_id, "/data/meta/caseID");
@@ -61,8 +61,8 @@ define([
         it("should load and save a update property", function () {
             util.loadXML(UPDATE_PROPERTY_XML);
             var update = util.getMug("save_to_case");
-            assert.equal(update.p.use_update, true);
-            assert(_.isEqual(update.p.update_property, {
+            assert.equal(update.p.useUpdate, true);
+            assert(_.isEqual(update.p.updateProperty, {
                 name: {
                     relevant: "/data/name != ''",
                     calculate: "/data/name"
@@ -77,8 +77,8 @@ define([
         it("should load and save a index property", function () {
             util.loadXML(INDEX_PROPERTY_XML);
             var index = util.getMug("save_to_case");
-            assert.equal(index.p.use_index, true);
-            assert(_.isEqual(index.p.index_property, {
+            assert.equal(index.p.useIndex, true);
+            assert(_.isEqual(index.p.indexProperty, {
                 extension: {
                     calculate: "/data/meta/caseID",
                     case_type: "extension_case",
@@ -94,8 +94,8 @@ define([
         it("should load and save a attachment property", function () {
             util.loadXML(ATTACHMENT_PROPERTY_XML);
             var attach = util.getMug("save_to_case");
-            assert.equal(attach.p.use_attachment, true);
-            assert(_.isEqual(attach.p.attachment_property, {
+            assert.equal(attach.p.useAttachment, true);
+            assert(_.isEqual(attach.p.attachmentProperty, {
                 attach: {
                     calculate: "/data/question1",
                     from: "local",
@@ -125,9 +125,9 @@ define([
             it("should validate " + k, function() {
                 util.loadXML("");
                 var save = util.addQuestion("SaveToCase", "save"),
-                    spec = save.spec.attachment_property;
-                save.p.use_attachment = true;
-                save.p.attachment_property = v;
+                    spec = save.spec.attachmentProperty;
+                save.p.useAttachment = true;
+                save.p.attachmentProperty = v;
                 assert.notEqual(spec.validationFunc(save), "pass");
             });
         });

--- a/tests/static/saveToCase/attachment_property.xml
+++ b/tests/static/saveToCase/attachment_property.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/2F7E3113-5827-455B-B5E0-2E8856FE23E8" uiVersion="1" version="1" name="Untitled Form">
+					<question1 />
+					<save_to_case vellum:role="SaveToCase">
+						<c:case xmlns:c="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id="">
+							<attachment>
+								<attach from="local" name="name" />
+							</attachment>
+						</c:case>
+					</save_to_case>
+				</data>
+			</instance>
+			<bind nodeset="/data/question1" type="binary" />
+			<bind nodeset="/data/save_to_case/case/attachment/attach/@src" calculate="/data/question1" />
+			<bind nodeset="/data/save_to_case/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />
+			<bind nodeset="/data/save_to_case/case/@user_id" calculate="/data/meta/userID" />
+			<bind nodeset="/data/save_to_case/case/@case_id" calculate="/data/meta/caseID" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="question1-label">
+						<value>question1</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<upload mediatype="image/*" ref="/data/question1">
+			<label ref="jr:itext('question1-label')" />
+		</upload>
+	</h:body>
+</h:html>


### PR DESCRIPTION
This adds attachments to save to a case. Follows the pattern set by the other widgets. Could probably be cleaned up, but I think it would be more reasonable to wait until we  do case management in the form builder.

enchantress @czue 