### PR TITLE
Replace label elements with divs

### DIFF
--- a/src/templates/control_group.html
+++ b/src/templates/control_group.html
@@ -1,4 +1,4 @@
 <div class="control-group">
-    <label class="control-label"><%=label%></label>
+    <div class="control-label"><%=label%></div>
     <div class="controls"></div>
 </div>

--- a/src/templates/control_group_stdInput.html
+++ b/src/templates/control_group_stdInput.html
@@ -1,8 +1,8 @@
 <div class="control-group">
-    <label class="control-label">
+    <div class="control-label">
         <%=label%>
         <div class="controls">
             <input type="text" />
         </div>
-    </label>
+    </div>
 </div>

--- a/src/templates/custom_data_source.html
+++ b/src/templates/custom_data_source.html
@@ -9,13 +9,13 @@
       </div>
       <form class="form-horizontal">
           <div class="control-group">
-              <label class="control-label">Source URI</label>
+              <div class="control-label">Source URI</div>
               <div class="controls">
                   <input type="text" name="source_uri" placeholder="jr://path/to/instance">
               </div>
           </div>
           <div class="control-group">
-              <label class="control-label">Level name hierarchy</label>
+              <div class="control-label">Level name hierarchy</div>
               <div class="controls">
                   <input type="text" name="node_levels" placeholder="root/level1/level2/leaf">
               </div>

--- a/src/templates/data_source_editor.html
+++ b/src/templates/data_source_editor.html
@@ -5,9 +5,9 @@
             <i class="icon-cog"></i> Edit Data Source (Advanced)
         </legend>
         <div class="control-group">
-            <label class="control-label">
+            <div class="control-label">
                 Query Expression:
-            </label>
+            </div>
             <div class="controls">
                 <textarea rows="5"
                           name="query"
@@ -23,17 +23,17 @@
         </div>
         <div class="fd-data-source-validation-summary">Optional Instance Properties</div>
         <div class="control-group">
-            <label class="control-label">
+            <div class="control-label">
                 Instance ID:
-            </label>
+            </div>
             <div class="controls">
                 <input name="instance-id" type="text" class="input-block-level jstree-drop" />
             </div>
         </div>
         <div class="control-group">
-            <label class="control-label">
+            <div class="control-label">
                 Instance URI:
-            </label>
+            </div>
             <div class="controls">
                 <input name="instance-src" type="text" class="input-block-level jstree-drop" />
             </div>

--- a/src/templates/multimedia_modal.html
+++ b/src/templates/multimedia_modal.html
@@ -5,9 +5,9 @@
     </div>
     <div class="modal-body form form-horizontal">
         <div class="control-group">
-            <label class="control-label">
+            <div class="control-label">
                 Select New <%= mediaType %>
-            </label>
+            </div>
             <div class="controls">
                 <div class="hqm-select-files-container">
                     <button class="hqm-select btn btn-primary" type="button">Select File</button>
@@ -16,9 +16,9 @@
             </div>
         </div>
         <div class="control-group hqm-existing hide">
-            <label class="control-label">
+            <div class="control-label">
                 Current <%= mediaType %>
-            </label>
+            </div>
             <div class="controls">
             </div>
         </div>
@@ -26,7 +26,7 @@
             <fieldset class="hqm-sharing hide">
                 <legend>Multimedia Sharing Options</legend>
                 <div class="control-group">
-                    <label class="control-label" for="fd-mm-<%= mediaType %>-license">License</label>
+                    <div class="control-label" for="fd-mm-<%= mediaType %>-license">License</div>
                     <div class="controls">
                         <select name="license" id="fd-mm-<%= mediaType %>-license">
                             <option value="cc-nc">Creative Commons Attribution, Non-Commercial</option>
@@ -39,7 +39,7 @@
                     </div>
                 </div>
                 <div class="control-group">
-                    <label class="control-label" for="fd-mm-<%= mediaType %>-author">Author</label>
+                    <div class="control-label" for="fd-mm-<%= mediaType %>-author">Author</div>
                     <div class="controls">
                         <input type="text"
                                name="author"
@@ -48,7 +48,7 @@
                     </div>
                 </div>
                 <div class="control-group">
-                    <label class="control-label" for="fd-mm-<%= mediaType %>-attribution">Attribution Notes</label>
+                    <div class="control-label" for="fd-mm-<%= mediaType %>-attribution">Attribution Notes</div>
                     <div class="controls">
                         <textarea name="attribution-notes"
                                id="fd-mm-<%= mediaType %>-attribution"

--- a/src/templates/select_data_source.html
+++ b/src/templates/select_data_source.html
@@ -1,25 +1,25 @@
 <div class="fd-data-source-container">
     <fieldset>
         <div class="control-group">
-            <label class="control-label">
+            <div class="control-label">
                 Data Source Type:
-            </label>
+            </div>
             <div class="controls">
                 <select name="type-selector" class="input-block-level" />
             </div>
         </div>
         <div class="control-group">
-            <label class="control-label">
+            <div class="control-label">
                 Data Source:
-            </label>
+            </div>
             <div class="controls">
                 <select name="source-selector" class="input-block-level" />
             </div>
         </div>
         <div class="control-group">
-            <label class="control-label">
+            <div class="control-label">
                 ID Query:
-            </label>
+            </div>
             <div class="controls">
                 <input name="source-query" type="text" class="input-block-level jstree-drop" />
             </div>

--- a/src/templates/xpath.html
+++ b/src/templates/xpath.html
@@ -12,9 +12,9 @@
             You are currently in Advanced Mode because your logic is too complicated for the Expression Editor.
         </div>
         <div class="control-group">
-            <label class="control-label">
+            <div class="control-label">
                 XPath Expression:
-            </label>
+            </div>
             <div class="controls">
                 <textarea rows="5"
                           class="input-block-level fd-xpath-editor-text jstree-drop"></textarea>
@@ -37,7 +37,7 @@
             </button>
         </legend>
         <div class="control-group">
-            <label class="control-label">Result is:</label>
+            <div class="control-label">Result is:</div>
             <div class="controls">
                 <select class="input-block-level top-level-join-select">
                     <% _.each(topLevelJoinOpts, function (opt) { %>
@@ -47,7 +47,7 @@
             </div>
         </div>
         <div class="control-group">
-            <label class="control-label">Expression:</label>
+            <div class="control-label">Expression:</div>
             <div class="controls">
                 <div class="fd-xpath-editor-expressions"></div>
                 <p class="help-block pull-right">

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -331,7 +331,7 @@ define([
     var getUIElement = function($input, labelText, isDisabled, help) {
         var uiElem = $("<div />").addClass("widget control-group"),
             $controls = $('<div class="controls" />'),
-            $label = $("<label />").text(labelText);
+            $label = $("<div />").text(labelText);
         $label.addClass('control-label');
         if (help) {
             var $help = $("<a />").attr({


### PR DESCRIPTION
The label elements in vellum aren't really labels in the HTML sense, which is a minor semantic quibble, but being labels makes them appear clickable, and then clicking them does nothing. Swapped them for divs.