### PR TITLE
close dialog after save completes

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1851,7 +1851,7 @@ define([
             _this.showWaitingDialog();
         });
         $(document).ajaxStop(function () {
-            _this._hideConfirmDialog();
+            _this.$f.find('.fd-modal-generic-container .modal').modal("hide");
         });
 
         if (saveType === 'patch') {


### PR DESCRIPTION
Bug in https://github.com/dimagi/Vellum/pull/435: new dialog doesn't close when ajax request completes.