### PR TITLE
Convert == to =

### DIFF
--- a/src/expressionEditor.js
+++ b/src/expressionEditor.js
@@ -48,9 +48,11 @@ define([
         }
     };
     function addOp(expr, value, label) {
+        value = xpathmodels.expressionTypeEnumToXPathLiteral(value);
         simpleExpressions[value] = expr;
         operationOpts.push([label, value]);
     }
+
     addOp(BinOpHandler, expTypes.EQ, "is equal to");
     addOp(BinOpHandler, expTypes.NEQ, "is not equal to");
     addOp(BinOpHandler, expTypes.LT, "is less than");


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?170516#955370

Technically it only works in chrome because whenever you do val('blah') to a select it just defaults to the first option.

I think the real bug is here: https://github.com/dimagi/js-xpath/blob/master/models.js#L341 as I don't think == is a valid xpath operator.

This: https://github.com/dimagi/js-xpath/blob/master/models.js#L359 makes me think that whoever wrote this knows that. @czue I think?

Anyways, I tested this in firefox and chrome on linux and it worked on both.

code buddy: @gcapalbo 