### PR TITLE
Add alternate copy/paste method for Safari

### DIFF
--- a/src/copy-paste.js
+++ b/src/copy-paste.js
@@ -389,7 +389,7 @@ define([
                 });
             }).keyup(function (e) {
                 // workaround for webkit: http://stackoverflow.com/a/12114908
-                if(e.which === 9) {
+                if(e.which === 9) { // tab
                     copyPasteArea.select();
                 }
             });

--- a/src/copy-paste.js
+++ b/src/copy-paste.js
@@ -357,7 +357,19 @@ define([
         },
         displayMultipleSelectionView: function () {
             this.__callOld();
-            var html = $(copy_paste_help({"metachar": (isMac ? "\u2318" : "Ctrl+")}));
+            var html = $(copy_paste_help({"metachar": (isMac ? "\u2318" : "Ctrl+")})),
+                showCopyArea = html.find(".show-copy-area"),
+                copyArea = html.find(".copy-area"),
+                insertQuestions = html.find(".insert-questions");
+            showCopyArea.click(function () {
+                showCopyArea.hide();
+                copyArea.parent().removeClass("hide");
+                copyArea.val(copy()).focus().select();
+                insertQuestions.removeClass("hide").click(function () {
+                    paste(copyArea.val());
+                });
+                return false;
+            });
             this.$f.find(".fd-props-content").html(html);
         }
     });

--- a/src/copy-paste.js
+++ b/src/copy-paste.js
@@ -372,13 +372,9 @@ define([
                 // HACK show textarea for copy/paste because the hidden
                 // textarea dance doesn't work in Safari
                 showCopyPasteBox();
-            }
-            html.find(".insert-questions").click(function () {
-                paste(copyPasteArea.val());
-            });
-            this.$f.find(".fd-props-content").html(html);
-            if (isSafari) {
-                copyPasteArea.focus().select();
+                setTimeout(function () {
+                    copyPasteArea.focus().select();
+                }, 1);
             } else {
                 // hidden feature: show copy/paste box on click help div
                 copyPasteHelp.click(function () {
@@ -386,6 +382,21 @@ define([
                     copyPasteArea.focus().select();
                 });
             }
+            copyPasteArea.focus(function () {
+                copyPasteArea.select().mouseup(function() {
+                    copyPasteArea.off('mouseup');
+                    return false;
+                });
+            }).keyup(function (e) {
+                // workaround for webkit: http://stackoverflow.com/a/12114908
+                if(e.which === 9) {
+                    copyPasteArea.select();
+                }
+            });
+            html.find(".insert-questions").click(function () {
+                paste(copyPasteArea.val());
+            });
+            this.$f.find(".fd-props-content").html(html);
         }
     });
 

--- a/src/copy-paste.js
+++ b/src/copy-paste.js
@@ -20,7 +20,9 @@ define([
             width: 0,
             height: 0
         }).css(offScreen).appendTo('body'),
-        isMac = /Mac/.test(navigator.platform);
+        isMac = /Mac/.test(navigator.platform),
+        isChrome = /Chrome/.test(navigator.userAgent),
+        isSafari = /Safari/.test(navigator.userAgent) && !isChrome;
 
     function focusTextarea($focus, value) {
         if ($focus.length === 0) {
@@ -357,20 +359,33 @@ define([
         },
         displayMultipleSelectionView: function () {
             this.__callOld();
+            function showCopyPasteBox() {
+                copyPasteHelp.hide();
+                copyPasteBox.removeClass("hide");
+                copyPasteArea.val(copy(true));
+            }
             var html = $(copy_paste_help({"metachar": (isMac ? "\u2318" : "Ctrl+")})),
-                showCopyArea = html.find(".show-copy-area"),
-                copyArea = html.find(".copy-area"),
-                insertQuestions = html.find(".insert-questions");
-            showCopyArea.click(function () {
-                showCopyArea.hide();
-                copyArea.parent().removeClass("hide");
-                copyArea.val(copy()).focus().select();
-                insertQuestions.removeClass("hide").click(function () {
-                    paste(copyArea.val());
-                });
-                return false;
+                copyPasteHelp = html.find(".copy-paste-help"),
+                copyPasteBox = html.find(".copy-paste-box"),
+                copyPasteArea = copyPasteBox.find("textarea");
+            if (isSafari) {
+                // HACK show textarea for copy/paste because the hidden
+                // textarea dance doesn't work in Safari
+                showCopyPasteBox();
+            }
+            html.find(".insert-questions").click(function () {
+                paste(copyPasteArea.val());
             });
             this.$f.find(".fd-props-content").html(html);
+            if (isSafari) {
+                copyPasteArea.focus().select();
+            } else {
+                // hidden feature: show copy/paste box on click help div
+                copyPasteHelp.click(function () {
+                    showCopyPasteBox();
+                    copyPasteArea.focus().select();
+                });
+            }
         }
     });
 

--- a/src/core.js
+++ b/src/core.js
@@ -793,10 +793,12 @@ define([
             // plugin needs to stay enabled because it adds CSS selectors to
             // themeable items, which it would be hard to adapt the existing
             // selectors to if they didn't exist.
-        }).bind("select_node.jstree", function (e, data) {
+        }).bind("select_node.jstree deselect_node.jstree", function (e, data) {
             var selected = _this.jstree('get_selected');
-            if (selected.length < 2) {
-                var mug = _this.data.core.form.getMugByUFID(data.node.id);
+            if (!selected.length) {
+                _this.hideQuestionProperties();
+            } else if (selected.length < 2) {
+                var mug = _this.data.core.form.getMugByUFID(selected[0]);
                 _this.displayMugProperties(mug);
                 _this.activateQuestionTypeGroup(mug);
             } else {

--- a/src/less-style/question-props.less
+++ b/src/less-style/question-props.less
@@ -153,7 +153,13 @@
   }
 }
 
-.fd-copy-paste-help .row {
-  padding: 0 2em;
-  margin-bottom: 2em;
+.fd-copy-paste-help {
+  .row {
+    padding: 0 2em;
+    margin-bottom: 2em;
+  }
+  .copy-paste-box textarea {
+    width: 100%;
+    height: 100px;
+  }
 }

--- a/src/templates/copy_paste_help.html
+++ b/src/templates/copy_paste_help.html
@@ -18,13 +18,8 @@
         </div>
     </div>
     <div class="copy-paste-box hide">
-        <p>
-            Copy from or Paste into this text box:
-            <textarea style="width: 100%; height: 100px;"></textarea>
-        </p>
-        <p>
-            <button class="btn insert-questions">Insert Questions</button>
-        </p>
+        <p>Copy from or Paste into this text box: <textarea></textarea></p>
+        <p><button class="btn insert-questions">Insert Questions</button></p>
     </div>
     <h3>Selecting Multiple Questions</h3>
     <div class="row">

--- a/src/templates/copy_paste_help.html
+++ b/src/templates/copy_paste_help.html
@@ -26,4 +26,14 @@
     </div>
     <h3>Other Tips</h3>
     <p>Questions can be copied between forms, and even to other apps.</p>
+    <div>
+        <button class="btn show-copy-area">Alternative Method: Plain Text Copy/Paste</button>
+        <p class="hide">
+            Copy from or paste into this text box:
+            <textarea class="copy-area" style="width: 100%; height: 100px;"></textarea>
+        </p>
+        <p>
+            <button class="btn insert-questions hide">Insert Questions</button>
+        </p>
+    </div>
 </div>

--- a/src/templates/copy_paste_help.html
+++ b/src/templates/copy_paste_help.html
@@ -1,19 +1,30 @@
 <div class="fd-copy-paste-help">
     <h3>Copying and Pasting Questions</h3>
-    These actions are available via the browser's Edit menu, and you can also use:
-    <div class="row">
-        <div class="span3">
-            <h1><%=metachar%>C</h1>
-            <span>for copy</span>
+    <div class="copy-paste-help">
+        These actions are available via the browser's Edit menu, and you can also use:
+        <div class="row">
+            <div class="span3">
+                <h1><%=metachar%>C</h1>
+                <span>for copy</span>
+            </div>
+            <!--div class="span3">
+                <h1><%=metachar%>X</h1>
+                <span>for cut</span>
+            </div-->
+            <div class="span3">
+                <h1><%=metachar%>V</h1>
+                <span>for paste</span>
+            </div>
         </div>
-        <!--div class="span3">
-            <h1><%=metachar%>X</h1>
-            <span>for cut</span>
-        </div-->
-        <div class="span3">
-            <h1><%=metachar%>V</h1>
-            <span>for paste</span>
-        </div>
+    </div>
+    <div class="copy-paste-box hide">
+        <p>
+            Copy from or Paste into this text box:
+            <textarea style="width: 100%; height: 100px;"></textarea>
+        </p>
+        <p>
+            <button class="btn insert-questions">Insert Questions</button>
+        </p>
     </div>
     <h3>Selecting Multiple Questions</h3>
     <div class="row">
@@ -26,14 +37,4 @@
     </div>
     <h3>Other Tips</h3>
     <p>Questions can be copied between forms, and even to other apps.</p>
-    <div>
-        <button class="btn show-copy-area">Alternative Method: Plain Text Copy/Paste</button>
-        <p class="hide">
-            Copy from or paste into this text box:
-            <textarea class="copy-area" style="width: 100%; height: 100px;"></textarea>
-        </p>
-        <p>
-            <button class="btn insert-questions hide">Insert Questions</button>
-        </p>
-    </div>
 </div>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?170523

Safari is a real pain when it comes to copy/paste, so I implemented a stupid workaround that should work in any situation where the keydown-copy-paste-event-hidden-textarea dance does not work, which seems potentially useful.

I ran out of energy when it came to implementing the UI. Ideas for improvements are welcome.

![screenshot 2015-06-09 15 46 26](https://cloud.githubusercontent.com/assets/464726/8068313/17398870-0ec1-11e5-86ba-118fa8903694.png)

Clicking this new button reveals a text box containing the serialized text for the selected questions.

![screenshot 2015-06-09 15 46 47](https://cloud.githubusercontent.com/assets/464726/8068196/6342e276-0ec0-11e5-8690-618c3f1fd9a1.png)

Finally, an *Insert Questions* button at the bottom to deserialize the text and insert questions into the form.