### PR TITLE
Cleanup atwho containers

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -825,6 +825,7 @@ define([
             data.node.icon = mug.getIcon();
             _this.refreshCurrentMug();
         }).bind("deselect_all.jstree deselect_node.jstree", function (e, data) {
+            $('.atwho-container').remove();
             _this.resetQuestionTypeGroups();
         }).bind('model.jstree', function (e, data) {
             // Dynamically update node icons. This is unnecessary for

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -826,6 +826,7 @@ define([
         var widget = widgets.base(mug, options);
         var $input = $("<textarea></textarea>")
             .attr("name", widget.id)
+            .attr("id", widget.id)
             .attr("rows", "2")
             .addClass('input-block-level itext-widget-input')
             .on('change input', function (e) { widget.handleChange(); })

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -117,6 +117,7 @@ define([
 
         widget.input = $("<input />")
             .attr("name", inputID)
+            .attr("id", inputID)
             .prop('disabled', disabled);
 
         widget.getControl = function () {


### PR DESCRIPTION
This cleans up the atwho-containers that will show up at the bottom of the body tag.

A nicer solution would be to PR something to at.js that cleans this stuff up automatically, but I would need to go a little more in depth with the library and how it keeps references (and brush up on coffeescript)

cc: @gcapalbo 