### PR TITLE
Fix fieldset overflow

### DIFF
--- a/src/less-style/question-props.less
+++ b/src/less-style/question-props.less
@@ -39,6 +39,8 @@
 .fd-question-fieldset {
   border: none;
   position: relative;
+  min-width: 0px; /* for chrome */
+  display: table-column; /* for firefox */
 
   .accordion-heading {
     margin-bottom: 0;


### PR DESCRIPTION
Found this while working on changing to editable divs, but it also applies to master.

Before:
![selection_011](https://cloud.githubusercontent.com/assets/1471773/8090492/39219958-0f7c-11e5-9bdb-a2b6094b2f5c.png)

After:
![selection_012](https://cloud.githubusercontent.com/assets/1471773/8090495/3d6b9d4c-0f7c-11e5-90c2-4660c68473ad.png)

It's probably a small edge case. Could also use word-wrap: break-word on the alert box, but I think that's unnecessary.

code buddy: @gcapalbo 