### PR TITLE
Fix atwho scrolling

### DIFF
--- a/src/less-style/question-props.less
+++ b/src/less-style/question-props.less
@@ -166,6 +166,6 @@
   }
 }
 
-.atwho-view {
+.atwho-container .atwho-view {
   overflow: hidden;
 }


### PR DESCRIPTION
.atwho-view is styled by at.js css that's included in bower-components, so less just ignores this without the added .atwho-container. Can't do much else since atwho-containers are appended directly to the body (unless there's some magic less thing I couldn't find).