### PR TITLE
Don't close all modals on ajaxstop

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1802,9 +1802,6 @@ define([
         $(document).ajaxStart(function () {
             _this.showWaitingModal();
         });
-        $(document).ajaxStop(function () {
-            _this.closeModal();
-        });
 
         if (saveType === 'patch') {
             var diff_match_patch = require('diff-match-patch'),


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?171867

@orangejenny 

https://github.com/dimagi/Vellum/commit/2e0168e13931bc9c34045c59677d26bbbd66f5e4

This was never actually needed but we never noticed because one was jquery ui and overwrite was bootstrap. It gets closed here anyways: https://github.com/dimagi/Vellum/blob/dc0256d6c545fbd902daec4bd725ab6369338982/src/core.js#L1853

cc: @biyeun 