### PR TITLE
Don't register ajax start

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1799,9 +1799,7 @@ define([
 
         var url = saveType === 'patch' ?  opts.patchUrl : opts.saveUrl;
 
-        $(document).ajaxStart(function () {
-            _this.showWaitingModal();
-        });
+        _this.showWaitingModal();
 
         if (saveType === 'patch') {
             var diff_match_patch = require('diff-match-patch'),
@@ -1837,7 +1835,6 @@ define([
                             // unconditionally overwrite if no xform to compare
                             _this.send(formText, 'full');
                         } else {
-                            _this.closeModal();
                             _this.showOverwriteWarning(_this.send.bind(_this),
                                                        formText, data.xform);
                         }


### PR DESCRIPTION
@orangejenny 

This was the bug Noah ran into:

1. load form
2. make change to form
3. save
4. click lookup table data
5. ajaxstart calls show waiting modal and there's nothing to close it.

I'm reluctant to reintroduce the waiting dialog to datasources since it's going to be refactored heavily soon by @millerdev 

cc: @biyeun 