### PR TITLE
protect against undefined markdown

### DIFF
--- a/src/markdown.js
+++ b/src/markdown.js
@@ -1,7 +1,9 @@
 define([
-    'markdown-it'
+    'markdown-it',
+    'underscore'
 ], function(
-    markdownIt
+    markdownIt,
+    _
 ) {
     var md = markdownIt('zero')
              .enable(['link', 'emphasis', 'strikethrough', 'heading', 'list']),
@@ -25,8 +27,11 @@ define([
     };
 
     function markdown(text) {
-        text = text.replace(/\\\\n/g, '\n');
-        return md.render(text);
+        if (_.isString(text)) {
+            text = text.replace(/\\\\n/g, '\n');
+            return md.render(text);
+        }
+        return "";
     }
 
     return markdown;


### PR DESCRIPTION
Haven't been able to replicate this on standalone vellum (I can when loading the form through HQ though) yet, but this protects markdown from non string values. 

I think this was made obvious due to my recent changes in javaRosa to no-placeholder branch

@orangejenny saw that sheel's non working form was missing a translation. I'm going to dig deeper through javarosa to try to fix it there as well, but figured this should be done anyways.

cc: @biyeun 