### PR TITLE
Fix no placeholder

### DIFF
--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -961,7 +961,7 @@ define([
 
                 if (!_.isString(value)) {
                     if (!widget.isDefaultLang) {
-                        value = widget.getItextValue(widget.defaultLang);
+                        value = widget.getItextValue(widget.defaultLang) || "";
                     } else {
                         value = widget.hasNodeIdAsDefault ? widget.mug.p.nodeID : "";
                     }

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -22,7 +22,8 @@ require([
     'text!static/javaRosa/test-xml-1.xml',
     'text!static/javaRosa/test-xml-2.xml',
     'text!static/javaRosa/test-xml-3.xml',
-    'text!static/javaRosa/test-xml-4.xml'
+    'text!static/javaRosa/test-xml-4.xml',
+    'text!static/javaRosa/non-default-lang-first.xml'
 ], function (
     chai,
     $,
@@ -46,7 +47,8 @@ require([
     TEST_XML_1,
     TEST_XML_2,
     TEST_XML_3,
-    TEST_XML_4
+    TEST_XML_4,
+    NON_DEFAULT_LANG_FIRST_XML
 ) {
     var assert = chai.assert,
         call = util.call;
@@ -56,6 +58,19 @@ require([
             util.init({
                 javaRosa: {langs: ['en', 'hin']},
                 core: {onReady: function () { done(); }}
+            });
+        });
+
+        describe("and non default language is first", function () {
+            before(function (done) {
+                util.init({
+                    javaRosa: {langs: ['hin', 'en']},
+                    core: {onReady: function () { done(); }}
+                });
+            });
+
+            it("should load xml", function() {
+                util.loadXML(NON_DEFAULT_LANG_FIRST_XML);
             });
         });
 

--- a/tests/static/javaRosa/non-default-lang-first.xml
+++ b/tests/static/javaRosa/non-default-lang-first.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/D6EA20CE-34CD-47A5-B783-A827F5E7DA86" uiVersion="1" version="1" name="Untitled Form">
+					<text />
+				</data>
+			</instance>
+			<bind nodeset="/data/text" type="xsd:string" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="text-label">
+						<value>test</value>
+					</text>
+				</translation>
+				<translation lang="hin">
+					<text id="text-label">
+						<value>test</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/text">
+			<label ref="jr:itext('text-label')" />
+		</input>
+	</h:body>
+</h:html>


### PR DESCRIPTION
The bug:
The non-default language is given in the langs array first
There is no constraint message (or if there is, there is no hint message or help message, etc)
The `constraintMsg` will have an `ItextItem`, but the value will be `undefined`.
If it's the default language it will be set to `nodeID || ""`.
If it's not the default language it will be set to `ItextValue` which is `undefined`
This then trickles down to markdown which expects a string and not undefined.

https://github.com/dimagi/Vellum/blob/bec373a/src/javaRosa.js#L953-L978

In the old javarosa before #458 itext the value was guaranteed to be set to a string. 

cc: @biyeun 