### PR TITLE
Upgrade jstree

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
         "At.js": "1.3.0",
         "Caret.js": "0.2.2",
 
-        "jstree": "vakata/jstree#110b6681ffd5fc7206c27ea174d87ce1b348776d",
+        "jstree": "3.1.1",
         "langcodes": "dimagi/langcodes",
         "XMLWriter": "dimagi/XMLWriter#master",
         "MediaUploader": "dimagi/MediaUploader#master",


### PR DESCRIPTION
This was tagged since this: https://github.com/vakata/jstree/issues/869

There's no changelog on jstree, so it's hard to see exactly what has changed since that commit. I think it follows major.minor even though there are two numbers https://github.com/vakata/jstree/commit/a0767ceb3fffe1c0b2774d28c811116892a071b8.

I did some quick tests and it still functions as expected