### PR TITLE
style tweaks

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1404,6 +1404,7 @@ define([
         refreshMessages();
 
         $props.show();
+        this.data.windowManager.adjustToWindow();
         this.$f.find('.fd-help a').fdHelp();
 
         this.toggleConstraintItext(mug);

--- a/src/templates/question_fieldset.html
+++ b/src/templates/question_fieldset.html
@@ -1,8 +1,8 @@
 <fieldset class="accordion-group fd-question-fieldset">
     <legend class="accordion-heading">
         <% if (help) { %>
-        <div class="fd-help">
-            <a href="#" class="help pull-right"
+        <div class="fd-help pull-right">
+            <a href="#" class="help"
                 data-title="<%=help.title%>"
                 data-content="<%=help.text%><p><a target='_blank' href='<%=help.link%>'>See More</a></p>"
                 data-placement="left">


### PR DESCRIPTION
Two minor tweaks
- scrolling panel too tall in initial load, making it hard to get at the "Advanced link"
- section-level help appearing above section titles instead of in line with them

old
![screen shot 2015-07-07 at 11 52 19 am](https://cloud.githubusercontent.com/assets/1486591/8550558/40e43dfc-249f-11e5-91cb-fec076fc23d6.png)

new
![screen shot 2015-07-07 at 12 00 41 pm](https://cloud.githubusercontent.com/assets/1486591/8550657/ddd3fe68-249f-11e5-8f26-ebae3e720727.png)
