### PR TITLE
Multiline widget

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1585,15 +1585,16 @@ define([
         }
     };
 
-    fn.warnOnCircularReference = function(property, mug, path, refName) {
+    fn.warnOnCircularReference = function(property, mug, path, refName, propName) {
         // TODO do this in the logic manager
+        var isLabel = property === 'label';
         if (path === "." && (
             property === "relevantAttr" ||
             property === "calculateAttr" ||
-            property === "label"
+            isLabel
         )) {
             var fieldName = mug.p.getDefinition(property).lstring;
-            mug.addMessage(property, {
+            mug.addMessage(isLabel ? propName : property, {
                 key: "core-circular-reference-warning",
                 level: mug.WARNING,
                 message: "The " + fieldName + " for a question " +

--- a/src/core.js
+++ b/src/core.js
@@ -712,14 +712,6 @@ define([
                     _this.data.core.currentlyEditedProperty
                 );
             }
-
-            if (mug && _this.data.core.currentlyEditedProperty) {
-                _this.warnOnCircularReference(
-                    _this.data.core.currentlyEditedProperty,
-                    mug,
-                    path,
-                    'period');
-            }
         }
 
         if (mug && ops && mug.options.defaultOperator) {
@@ -1586,15 +1578,10 @@ define([
     };
 
     fn.warnOnCircularReference = function(property, mug, path, refName, propName) {
-        // TODO do this in the logic manager
-        var isLabel = property === 'label';
-        if (path === "." && (
-            property === "relevantAttr" ||
-            property === "calculateAttr" ||
-            isLabel
-        )) {
+        // TODO track output refs in logic manager
+        if (path === "." && property === 'label') {
             var fieldName = mug.p.getDefinition(property).lstring;
-            mug.addMessage(isLabel ? propName : property, {
+            mug.addMessage(propName, {
                 key: "core-circular-reference-warning",
                 level: mug.WARNING,
                 message: "The " + fieldName + " for a question " +

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -560,10 +560,11 @@ define([
         block.refreshMessages = function () {
             // TODO improve this to display each message beside the
             // form and language to which it applies
-            if (options.messagesPath) {
-                var messages = widgets.util.getMessages(mug, options.messagesPath);
-                $messages.empty().append(messages);
-            }
+            _.each(block.languages, function(lang) {
+                var name = 'itext-' + lang + '-' + block.itextType,
+                    messages = widgets.util.getMessages(mug, name);
+                $('[name='+name+']').parent().parent().find('.messages').empty().append(messages);
+            });
         };
 
         mug.on("messages-changed",
@@ -1271,7 +1272,7 @@ define([
             form = vellum.data.core.form;
         util.insertTextAtCursor(target, output, true);
         if (mug) {
-            vellum.warnOnCircularReference('label', mug, path, 'output value');
+            vellum.warnOnCircularReference('label', mug, path, 'output value', target.attr('name'));
             warnOnNonOutputableValue(form, mug, path);
         }
     }

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -872,9 +872,6 @@ define([
             });
         }
 
-        // future proof for when widgets.base sets path
-        widget.path = widget.path || options.path;
-
         widget.displayName = options.displayName;
         widget.itextType = options.itextType;
         widget.form = form || "default";

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -826,20 +826,8 @@ define([
         }
         options.id = id;
 
-        var widget = widgets.base(mug, options);
-        var $input = $("<textarea></textarea>")
-            .attr("name", widget.id)
-            .attr("id", widget.id)
-            .attr("rows", "2")
-            .addClass('input-block-level itext-widget-input')
-            .on('change input', function (e) { widget.handleChange(); })
-            .focus(function() { this.select(); })
-            .keyup(function (e) {
-                // workaround for webkit: http://stackoverflow.com/a/12114908
-                if (e.which === 9) {
-                    this.select();
-                }
-            });
+        var widget = widgets.multilineText(mug, options),
+            $input = widget.input;
 
         if (options.path === 'labelItext') {
             util.questionAutocomplete($input, mug, {
@@ -898,10 +886,6 @@ define([
         widget.isDefaultLang = widget.language === widget.defaultLang;
         widget.isSyncedWithDefaultLang = false;
         widget.hasNodeIdAsDefault = options.path === 'labelItext';
-
-        widget.getControl = function () {
-            return $input;
-        };
 
         widget.getItextItem = function () {
             // Make sure the real itextItem is being updated at all times, not a stale one.
@@ -987,14 +971,6 @@ define([
 
         widget.toggleDefaultLangSync = function (val) {
             widget.isSyncedWithDefaultLang = !val && !widget.isDefaultLang;
-        };
-
-        widget.setValue = function (val) {
-            $input.val(val);
-        };
-
-        widget.getValue = function () {
-            return $input.val();
         };
 
         widget.getDefaultValue = function () {

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -558,11 +558,10 @@ define([
         };
 
         block.refreshMessages = function () {
-            _.each(block.languages, function(lang) {
-                var name = 'itext-' + lang + '-' + block.itextType,
-                    messages = widgets.util.getMessages(mug, name);
-                $('[name='+name+']').parent().parent().find('.messages').empty().append(messages);
-            });
+            if (options.messagesPath) {
+                var messages = widgets.util.getMessages(mug, options.messagesPath);
+                $messages.empty().append(messages);
+            }
         };
 
         mug.on("messages-changed",
@@ -1025,6 +1024,12 @@ define([
                     }
                 });
             }
+        };
+
+        widget.refreshMessages = function () {
+            widget.getMessagesContainer()
+                .empty()
+                .append(widget.getMessages(mug, widget.id));
         };
 
         widget.save = function () {

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -558,8 +558,6 @@ define([
         };
 
         block.refreshMessages = function () {
-            // TODO improve this to display each message beside the
-            // form and language to which it applies
             _.each(block.languages, function(lang) {
                 var name = 'itext-' + lang + '-' + block.itextType,
                     messages = widgets.util.getMessages(mug, name);

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -108,7 +108,7 @@ define([
 
     var normal = function(mug, options) {
         var path = options.widgetValuePath || options.path,
-            inputID = 'property-' + path,
+            inputID = options.id || 'property-' + path,
             disabled = options.disabled || false,
             widget = base(mug, options);
 
@@ -198,7 +198,7 @@ define([
     };
 
     var multilineText = function (mug, options) {
-        var widget = base(mug, options);
+        var widget = normal(mug, options);
 
         widget.input = $("<textarea></textarea>")
             .attr("name", widget.id)

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -197,6 +197,38 @@ define([
         return widget;
     };
 
+    var multilineText = function (mug, options) {
+        var widget = base(mug, options);
+
+        widget.input = $("<textarea></textarea>")
+            .attr("name", widget.id)
+            .attr("id", widget.id)
+            .attr("rows", "2")
+            .addClass('input-block-level itext-widget-input')
+            .on('change input', function (e) { widget.handleChange(); })
+            .focus(function() { this.select(); })
+            .keyup(function (e) {
+                // workaround for webkit: http://stackoverflow.com/a/12114908
+                if (e.which === 9) {
+                    this.select();
+                }
+            });
+
+        widget.getControl = function () { 
+            return widget.input;
+        };
+
+        widget.setValue = function (val) {
+            widget.input.val(val);
+        };
+
+        widget.getValue = function () {
+            return widget.input.val();
+        };
+
+        return widget;
+    };
+
     var identifier = function (mug, options) {
         var widget = text(mug, options),
             super_updateValue = widget.updateValue;
@@ -563,6 +595,7 @@ define([
         base: base,
         normal: normal,
         text: text,
+        multilineText: multilineText,
         identifier: identifier,
         droppableText: droppableText,
         checkbox: checkbox,

--- a/tests/core.js
+++ b/tests/core.js
@@ -377,12 +377,12 @@ require([
 
             function testValidationError (attr, property) {
                 property = property || attr;
-                assert.deepEqual(mug.messages.get(attr), []);
+                assert.deepEqual(mug.messages.get(property), []);
                 mug.form.vellum.warnOnCircularReference(attr, mug, ".", "period", property);
                 assert.equal(mug.messages.get(property).length, 1,
                              util.getMessages(mug));
                 mug.dropMessage(property, "core-circular-reference-warning");
-                assert.deepEqual(mug.messages.get(attr), []);
+                assert.deepEqual(mug.messages.get(property), []);
             }
 
             _.each(["relevantAttr", "calculateAttr"], function (attr) {

--- a/tests/core.js
+++ b/tests/core.js
@@ -375,7 +375,9 @@ require([
                 mug = util.addQuestion("Text", "text");
             });
 
-            function testValidationError (attr, property) {
+            it("in label", function () {
+                var attr = 'label',
+                    property = 'itext-en-label';
                 property = property || attr;
                 assert.deepEqual(mug.messages.get(property), []);
                 mug.form.vellum.warnOnCircularReference(attr, mug, ".", "period", property);
@@ -383,16 +385,6 @@ require([
                              util.getMessages(mug));
                 mug.dropMessage(property, "core-circular-reference-warning");
                 assert.deepEqual(mug.messages.get(property), []);
-            }
-
-            _.each(["relevantAttr", "calculateAttr"], function (attr) {
-                it("in " + attr, function () {
-                    testValidationError(attr);
-                });
-            });
-
-            it("in label", function () {
-                testValidationError('label', 'itext-en-label');
             });
         });
 

--- a/tests/core.js
+++ b/tests/core.js
@@ -375,15 +375,24 @@ require([
                 mug = util.addQuestion("Text", "text");
             });
 
-            _.each(["relevantAttr", "calculateAttr", "label"], function (attr) {
+            function testValidationError (attr, property) {
+                property = property || attr;
+                assert.deepEqual(mug.messages.get(attr), []);
+                mug.form.vellum.warnOnCircularReference(attr, mug, ".", "period", property);
+                assert.equal(mug.messages.get(property).length, 1,
+                             util.getMessages(mug));
+                mug.dropMessage(property, "core-circular-reference-warning");
+                assert.deepEqual(mug.messages.get(attr), []);
+            }
+
+            _.each(["relevantAttr", "calculateAttr"], function (attr) {
                 it("in " + attr, function () {
-                    assert.deepEqual(mug.messages.get(attr), []);
-                    mug.form.vellum.warnOnCircularReference(attr, mug, ".", "period");
-                    assert.equal(mug.messages.get(attr).length, 1,
-                                 util.getMessages(mug));
-                    mug.dropMessage(attr, "core-circular-reference-warning");
-                    assert.deepEqual(mug.messages.get(attr), []);
+                    testValidationError(attr);
                 });
+            });
+
+            it("in label", function () {
+                testValidationError('label', 'itext-en-label');
             });
         });
 

--- a/tests/logic.js
+++ b/tests/logic.js
@@ -79,6 +79,21 @@ require([
                     assert(util.isTreeNodeValid(mug), util.getMessages(mug));
                     assert.deepEqual(mug.messages.get(attr), []);
                 });
+
+                it("self referencing path in " + attr, function () {
+                    var mug = util.getMug(mugMap[attr] || "text");
+                    assert(util.isTreeNodeValid(mug), util.getMessages(mug));
+                    assert.deepEqual(mug.messages.get(attr), []);
+
+                    mug.p[attr] = ".";
+                    assert(!util.isTreeNodeValid(mug), "mug should not be valid");
+                    assert(mug.messages.get(attr).length,
+                           attr + " should have messages");
+
+                    mug.p[attr] = "";
+                    assert(util.isTreeNodeValid(mug), util.getMessages(mug));
+                    assert.deepEqual(mug.messages.get(attr), []);
+                });
             });
         });
     });


### PR DESCRIPTION
This does a couple of things. 
* generalizes the javarosa widget to a multilline widget
* multiline inherits from normal
* each language has it's own error container
* actually shows the error on label itexts now

Still broken: If you load an itext with <ouput value="."> or a display/calculate condition like `. = 'blah'`. There is no error shown. (It's always been like that)

code buddy: @gcapalbo 