### PR TITLE
Move warnOnCircularReference

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1604,21 +1604,6 @@ define([
         }
     };
 
-    fn.warnOnCircularReference = function(property, mug, path, refName, propName) {
-        // TODO track output refs in logic manager
-        if (path === "." && property === 'label') {
-            var fieldName = mug.p.getDefinition(property).lstring;
-            mug.addMessage(propName, {
-                key: "core-circular-reference-warning",
-                level: mug.WARNING,
-                message: "The " + fieldName + " for a question " +
-                    "is not allowed to reference the question itself. " +
-                    "Please remove the " + refName + " from the " +
-                    fieldName +" or your form will have errors."
-            });
-        }
-    };
-
     fn.getSectionDisplay = function (mug, options) {
         var _this = this,
             $sec = $(question_fieldset({

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -1270,12 +1270,27 @@ define([
         }
     }
 
+    function warnOnCircularReference(property, mug, path, refName, propName) {
+        // TODO track output refs in logic manager
+        if (path === "." && property === 'label') {
+            var fieldName = mug.p.getDefinition(property).lstring;
+            mug.addMessage(propName, {
+                key: "core-circular-reference-warning",
+                level: mug.WARNING,
+                message: "The " + fieldName + " for a question " +
+                    "is not allowed to reference the question itself. " +
+                    "Please remove the " + refName + " from the " +
+                    fieldName +" or your form will have errors."
+            });
+        }
+    }
+
     function insertOutputRef(vellum, target, path, mug, dateFormat) {
         var output = getOutputRef(path, dateFormat),
             form = vellum.data.core.form;
         util.insertTextAtCursor(target, output, true);
         if (mug) {
-            vellum.warnOnCircularReference('label', mug, path, 'output value', target.attr('name'));
+            warnOnCircularReference('label', mug, path, 'output value', target.attr('name'));
             warnOnNonOutputableValue(form, mug, path);
         }
     }

--- a/tests/core.js
+++ b/tests/core.js
@@ -368,26 +368,6 @@ require([
             });
         });
 
-        describe("should show validation error on circular reference", function () {
-            var mug;
-            before(function () {
-                util.loadXML("");
-                mug = util.addQuestion("Text", "text");
-            });
-
-            it("in label", function () {
-                var attr = 'label',
-                    property = 'itext-en-label';
-                property = property || attr;
-                assert.deepEqual(mug.messages.get(property), []);
-                mug.form.vellum.warnOnCircularReference(attr, mug, ".", "period", property);
-                assert.equal(mug.messages.get(property).length, 1,
-                             util.getMessages(mug));
-                mug.dropMessage(property, "core-circular-reference-warning");
-                assert.deepEqual(mug.messages.get(property), []);
-            });
-        });
-
         describe("type changer", function () {
             function test(srcType, dstType, allowed) {
                 var show = allowed ? "show " : "not show ";

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -774,6 +774,21 @@ require([
             assert(!$("[name='itext-en-constraintMsg']").is(":visible"));
         });
 
+        it("should show a validation error when dropping a self reference", function() {
+            util.loadXML("");
+            var mug = util.addQuestion("Text", "question1"),
+                property = 'itext-en-label';
+            util.clickQuestion("question1");
+
+            assert.deepEqual(mug.messages.get(property), []);
+            mug.form.vellum.handleDropFinish($('[name='+property+']'), '.', mug);
+            assert.equal(mug.messages.get(property).length, 1,
+                         util.getMessages(mug));
+
+                mug.dropMessage(property, "core-circular-reference-warning");
+                assert.deepEqual(mug.messages.get(property), []);
+        });
+
     });
 
     describe("The javaRosa plugin language selector", function() {


### PR DESCRIPTION
@millerdev https://github.com/dimagi/Vellum/pull/485#commitcomment-12074636

I also noticed that these sort of checks should check for the absolute path as well. It's pretty easy to implement, except for itemsets as their `mug.absolutePath` is  `undefined` (It affects them with filters) Am I missing a better way to do that?

code buddy @gcapalbo 