### PR TITLE
populate extra fields after html upload

### DIFF
--- a/src/intentManager.js
+++ b/src/intentManager.js
@@ -154,22 +154,27 @@ define([
         }
     }
 
+    function parseFields (html) {
+        var field_regex = /{{\s*([^}\s]+)\s*}}/gm,
+            match = field_regex.exec(html),
+            fields = {};
+
+        while (match) {
+            _.each(match.splice(1), function(field) {
+                fields[field] = field;
+            });
+            match = field_regex.exec(html);
+        }
+
+        return fields;
+    }
+
     function printTemplate(mug, options) {
         var widget = widgets.media(mug, options),
-            uploadComplete = widget.handleUploadComplete,
-            field_regex = /{{\s*(.+)\s*}}/gm;
+            uploadComplete = widget.handleUploadComplete;
 
         widget.handleUploadComplete = function (event, data, objectMap) {
-            mug.p.androidIntentExtra = {};
-            var html = data.text,
-                match = field_regex.exec(html);
-
-            while (match) {
-                _.each(match.splice(1), function(field) {
-                    mug.p.androidIntentExtra[field] = field;
-                });
-                match = field_regex.exec(html);
-            }
+            mug.p.androidIntentExtra = parseFields(data.text);
 
             uploadComplete(event, data, objectMap);
 
@@ -305,4 +310,10 @@ define([
             return this.__callOld().concat(INTENT_SPECIFIC_SPECS);
         }
     });
+
+    return {
+        test: {
+            parseFields: parseFields,
+        }
+    };
 });

--- a/tests/intentManager.js
+++ b/tests/intentManager.js
@@ -3,6 +3,7 @@ define([
     'chai',
     'underscore',
     'jquery',
+    'vellum/intentManager',
     'text!static/intentManager/intent-with-unknown-attrs.xml',
     'text!static/intentManager/intent-with-no-mug.xml',
     'text!static/intentManager/printing-intent.xml'
@@ -11,6 +12,7 @@ define([
     chai,
     _,
     $,
+    intentManager,
     INTENT_WITH_UNKNOWN_ATTRS_XML,
     INTENT_WITH_NO_MUG_XML,
     PRINTING_INTENT_XML
@@ -52,6 +54,36 @@ define([
             it("should correctly parse filename", function() {
                 assert.strictEqual(util.getMug('/data/print_data').p.docTemplate,
                                    'jr://file/commcare/doc/data/print_data.doc');
+            });
+        });
+
+        describe("field parsing", function() {
+            var tests = [
+                ['{{ } }}', {}],
+                ['{{field1}}', { field1: 'field1' }],
+                ['{{ field1 }}', { field1: 'field1' }],
+                ['field1 }}', {}],
+                ['{{ field1', {}],
+                ['field1', {}],
+                ['{{ field1 }} {{ field2 }}', {
+                    field1: 'field1',
+                    field2: 'field2',
+                }],
+                ['{{ field1 }}\n{{ field2 }}', {
+                    field1: 'field1',
+                    field2: 'field2',
+                }],
+                ['{{ field1 }}\n{{ field2 }} {{ field3 }}', {
+                    field1: 'field1',
+                    field2: 'field2',
+                    field3: 'field3',
+                }],
+            ];
+
+            _.each(tests, function(testcase) {
+                it(testcase[0] + " should be parsed as " + JSON.stringify(testcase[1]), function() {
+                    assert.deepEqual(intentManager.test.parseFields(testcase[0]), testcase[1]);
+                });
             });
         });
     });


### PR DESCRIPTION
Not tested as it relies on the uploader and that's a hole in vellum's tests right now.

Relies on https://github.com/dimagi/commcare-hq/pull/7620 and https://github.com/dimagi/MediaUploader/pull/9

cc: @czue 