### PR TITLE
Allow duplicate intent response keys

### DIFF
--- a/src/intentManager.js
+++ b/src/intentManager.js
@@ -79,11 +79,21 @@ define([
         var store = {};
         _.each(tagObj.find(innerTag), function (inner) {
             var $innerTag = $(inner),
-                key = $innerTag.attr('key');
+                key = $innerTag.attr('key'),
+                value;
             if (key === 'cc:print_template_reference') {
-                store[key] = $innerTag.text();
+                value = $innerTag.text();
             } else {
-                store[key] = $innerTag.attr('ref');
+                value = $innerTag.attr('ref');
+            }
+            if (store.hasOwnProperty(key)) {
+                if (_.isArray(store[key])) {
+                    store[key].push(value);
+                } else {
+                    store[key] = [store[key], value];
+                }
+            } else {
+                store[key] = value;
             }
         });
         return store;
@@ -93,13 +103,15 @@ define([
         if (store) {
             _.each(store, function (ref, key) {
                 if (key) {
-                    xmlWriter.writeStartElement(innerTag);
-                    xmlWriter.writeAttributeString("key", key);
-                    xmlWriter.writeAttributeString("ref", ref);
-                    if (value) {
-                        xmlWriter.writeXML(value);
-                    }
-                    xmlWriter.writeEndElement();
+                    _.each(_.isArray(ref) ? ref : [ref], function (ref) {
+                        xmlWriter.writeStartElement(innerTag);
+                        xmlWriter.writeAttributeString("key", key);
+                        xmlWriter.writeAttributeString("ref", ref);
+                        if (value) {
+                            xmlWriter.writeXML(value);
+                        }
+                        xmlWriter.writeEndElement();
+                    });
                 }
             });
         }

--- a/src/templates/widget_control_keyvalue.html
+++ b/src/templates/widget_control_keyvalue.html
@@ -1,12 +1,12 @@
 <div class="well well-small form form-inline clearfix">
     <% pairs[""] = ""; %>
-    <% _.each(pairs, function (v, k) { %>
+    <% _.each(pairs, function (v, k) { _.each(_.isArray(v) ? v : [v], function (v) { %>
         <div class="fd-kv-pair control-row clearfix" style="margin-bottom: 5px;">
             <div class="span3"><input class="fd-kv-key input-block-level" type="text" value="<%=k%>" placeholder="key" /></div>
             <div class="span1" style="text-align:center;">&rarr;</div>
             <div class="span7"><input class="fd-kv-val input-block-level jstree-drop" type="text" value="<%=v%>" placeholder="value" /></div>
             <div class="span1"><a href="#" class="btn fd-kv-remove-pair btn-small btn-danger<% if (k =='') { %> hide<% } %>"><i class="icon-remove"></i></a></div>
         </div>
-    <% }); %>
+    <% }); }); %>
     <a href="#" class="btn fd-kv-add-pair hide"><i class="icon-plus"></i> Add Key&rarr;Value Pair</a>
 </div>

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -381,7 +381,7 @@ define([
 
         widget.setValue = function (value) {
             widget.kvInput.html(widget_control_keyvalue({
-                pairs: value
+                pairs: _.clone(value)
             }));
             widget.kvInput.find('input').bind('change keyup', function () {
                 widget.handleChange();
@@ -401,8 +401,18 @@ define([
         function getValues() {
             var currentValues = {};
             _.each(widget.kvInput.find('.fd-kv-pair'), function (kvPair) {
-                var $pair = $(kvPair);
-                currentValues[$pair.find('.fd-kv-key').val()] = $pair.find('.fd-kv-val').val();
+                var $pair = $(kvPair),
+                    key = $pair.find('.fd-kv-key').val(),
+                    value = $pair.find('.fd-kv-val').val();
+                if (currentValues.hasOwnProperty(key)) {
+                    if (_.isArray(currentValues[key])) {
+                        currentValues[key].push(value);
+                    } else {
+                        currentValues[key] = [currentValues[key], value];
+                    }
+                } else {
+                    currentValues[key] = value;
+                }
             });
             return currentValues;
         }

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -422,8 +422,7 @@ define([
         };
 
         widget.updateValue = function () {
-            var currentValues = widget.getValue();
-            if (!("" in currentValues)) {
+            if (!getValues().hasOwnProperty("")) {
                 widget.kvInput.find('.btn').removeClass('hide');
                 widget.kvInput.find('.fd-kv-remove-pair').removeClass('hide');
             }

--- a/tests/intentManager.js
+++ b/tests/intentManager.js
@@ -40,6 +40,47 @@ define([
             util.assertXmlEqual(util.call("createXML"), INTENT_WITH_NO_MUG_XML);
         });
 
+        describe("with multiple response pairs with matching keys", function () {
+            var mug, xml, $xml;
+            before(function () {
+                util.loadXML("");
+                mug = util.addQuestion("AndroidIntent", "intent");
+                mug.p.androidIntentResponse = {name: ["/data/node1", "/data/node2"]};
+                xml = util.call("createXML");
+                $xml = $(xml);
+            });
+
+            it("should show all pairs in UI", function () {
+                util.clickQuestion("intent");
+                assert.equal($(".fd-kv-key[value=name]").length, 2);
+                assert.deepEqual(
+                    $(".fd-kv-key[value=name]").map(function (i, el) {
+                        return $(el).parent().parent().find(".fd-kv-val").val();
+                    }).toArray(),
+                    ["/data/node1", "/data/node2"]
+                );
+            });
+
+            it("should write multiple response nodes in XML", function () {
+                var responses = $xml.find("response[key=name]");
+                assert.equal(responses.length, 2, xml);
+                assert.deepEqual(
+                    responses.map(function (i, node) {
+                        return $(node).attr("ref");
+                    }).toArray(),
+                    ["/data/node1", "/data/node2"], xml
+                );
+            });
+
+            it("should load generated XML", function () {
+                util.loadXML(xml);
+                assert.deepEqual(
+                    util.getMug("intent").p.androidIntentResponse,
+                    {name: ["/data/node1", "/data/node2"]}
+                );
+            });
+        });
+
         describe("printing mug", function() {
             before(function() {
                 util.loadXML(PRINTING_INTENT_XML);


### PR DESCRIPTION
@dannyroberts @emord cc @sravfeyn 

Note that this also allows duplicate "extra" keys, and I'm not sure how the mobile app would handle that. But this new feature does not seem worse than what we had before, which was that one of the duplicate key/value pairs was silently discarded.