### PR TITLE
Fix regex for complex itemset filters

### DIFF
--- a/src/itemset.js
+++ b/src/itemset.js
@@ -25,7 +25,7 @@ define([
 ) {
     var mugTypes = mugs.baseMugTypes.normal,
         Itemset, isAdvancedItemsetEnabled, opts,
-        END_FILTER = /\[[^\[]*\]$/;
+        END_FILTER = /\[[^\[\]]*\]$/;
 
     Itemset = util.extend(mugs.defaultOptions, {
         isControlOnly: true,

--- a/tests/form.js
+++ b/tests/form.js
@@ -12,7 +12,8 @@ define([
     'text!static/form/nested-groups.xml',
     'text!static/form/select-questions.xml',
     'text!static/form/mismatch-tree-order.xml',
-    'text!static/form/hidden-value-tree-order.xml'
+    'text!static/form/hidden-value-tree-order.xml',
+    'text!static/form/instance-reference.xml'
 ], function (
     util,
     chai,
@@ -27,7 +28,8 @@ define([
     NESTED_GROUPS_XML,
     SELECT_QUESTIONS,
     MISMATCH_TREE_ORDER_XML,
-    HIDDEN_VALUE_TREE_ORDER
+    HIDDEN_VALUE_TREE_ORDER,
+    INSTANCE_REFERENCE_XML
 ) {
     var assert = chai.assert,
         call = util.call;
@@ -39,7 +41,6 @@ define([
                 core: {onReady: done}
             });
         });
-
         it("should get and fix serialization errors for mugs with matching paths", function () {
             var form = util.loadXML(""),
                 one = util.addQuestion("Text", "question"),
@@ -320,6 +321,13 @@ define([
             assertInstanceSrc("some-fixture", form,
                 "jr://fixture/item-list:some-fixture",
                 "some-fixture instance not found");
+        });
+
+        it("should not delete instance from itemsets with nested filters", function() {
+            var form = util.loadXML(INSTANCE_REFERENCE_XML);
+            assertInstanceSrc("groups", form,
+                "jr://fixture/user-groups",
+                "groups instance not found");
         });
 
         describe("instance tracker", function () {

--- a/tests/static/form/instance-reference.xml
+++ b/tests/static/form/instance-reference.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/38975ec8a2d227893fa2ef64793d2afb4cb94dc7" uiVersion="1" version="1" name="Untitled Form">
+					<contact_chiefdom />
+				</data>
+			</instance>
+			<instance id="groups" src="jr://fixture/user-groups"/>
+			<bind nodeset="/data/contact_chiefdom" required="true()" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="question7-label">
+						<value>Contact's Chiefdom</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<select1 ref="/data/contact_chiefdom">
+			<label ref="jr:itext('question7-label')" />
+			<itemset nodeset="instance('groups')/groups/group[count(group_data/data[@key = 'group_type'][. = 'chiefdom']) &gt; 0]">
+				<label ref="name" />
+				<value ref="@id" />
+			</itemset>
+		</select1>
+	</h:body>
+</h:html>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?179723#1000297

This bug only occured in nested filters:
`[count(group_data/data[@key = 'group_type'][. = 'chiefdom']) &gt; 0]`

Also caused a bad UI for the fitler:
![image](https://cloud.githubusercontent.com/assets/1471773/9447772/18cb6dd4-4a67-11e5-9ea2-92ea80fd9963.png)

@orangejenny 
code buddies: @esoergel @proteusvacuum 