### PR TITLE
Form comments hacked together

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1661,7 +1661,7 @@ define([
             form = this.data.core.form,
             mugs = multiselect ? mug : [mug],
             $baseToolbar = $(question_toolbar({
-                comment: mug.p.comment,
+                comment: multiselect ? '' : mug.p.comment,
                 isDeleteable: mugs && mugs.length && _.every(mugs, function (mug) {
                     return _this.isMugRemoveable(mug, form.getAbsolutePath(mug));
                 }),

--- a/src/core.js
+++ b/src/core.js
@@ -1661,6 +1661,7 @@ define([
             form = this.data.core.form,
             mugs = multiselect ? mug : [mug],
             $baseToolbar = $(question_toolbar({
+                comment: mug.p.comment,
                 isDeleteable: mugs && mugs.length && _.every(mugs, function (mug) {
                     return _this.isMugRemoveable(mug, form.getAbsolutePath(mug));
                 }),
@@ -1997,6 +1998,7 @@ define([
             "constraintMsgAttr",
             "dataParent",
             'appearance',
+            'comment',
         ];
     };
 

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -914,6 +914,11 @@ define([
                     return 'pass';
                 }
             },
+            comment: {
+                lstring: 'Comment',
+                visibility: 'visible',
+                widget: widgets.multilineText,
+            }
         },
 
         control: {

--- a/src/parser.js
+++ b/src/parser.js
@@ -173,7 +173,8 @@ define([
         var $el = $(el),
             nodeID = el.nodeName, 
             nodeVal = $el.children().length ? null : $el.text(),
-            extraXMLNS = $el.popAttr('xmlns') || null;
+            extraXMLNS = $el.popAttr('xmlns') || null,
+            comment = $el.popAttr('vellum:comment') || null;
         role = role || $el.attr('vellum:role');
 
         if (role && form.mugTypes.allTypes.hasOwnProperty(role) &&
@@ -189,6 +190,9 @@ define([
 
         if (extraXMLNS && (extraXMLNS !== form.formUuid)) {
             mug.p.xmlnsAttr = extraXMLNS;
+        }
+        if (comment) {
+            mug.p.comment = comment;
         }
         // add arbitrary attributes
         mug.p.rawDataAttributes = getAttributes(el);

--- a/src/templates/question_toolbar.html
+++ b/src/templates/question_toolbar.html
@@ -8,3 +8,9 @@
     </div>
     <% } %>
 </div>
+<% if (comment) { %>
+<div class="alert alert-info">
+  <button type="button" class="close" data-dismiss="alert">&times;</button>
+  <%= comment %>
+</div>
+<% } %>

--- a/src/writer.js
+++ b/src/writer.js
@@ -149,6 +149,9 @@ define([
                 if (mug.options.writeDataNodeXML) {
                     mug.options.writeDataNodeXML(xmlWriter, mug);
                 }
+                if (mug.p.comment) {
+                    xmlWriter.writeAttributeString('vellum:comment', mug.p.comment);
+                }
                 if (xmlnsAttr){
                     xmlWriter.writeAttributeString("xmlns", xmlnsAttr);
                 }


### PR DESCRIPTION
@czue threw this together in a couple minutes. Is this something like you were talking about?

![image](https://cloud.githubusercontent.com/assets/1471773/9832374/e9c72a02-5946-11e5-9d7d-fa7cedadc554.png)

Would need some cleanup/tests. Could also probably throw it in itext just as easily if we wanted it to be able to have different languages (assuming somethign like `value=comment` doesn't mean anything to mobile)