### PR TITLE
Atwho improvement

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,7 @@
         "requirejs-plugins": "~1.0.2",
         "At.js": "emord/At.js#override-insert",
         "Caret.js": "0.2.2",
+        "fuse.js": "1.2.2",
 
         "jstree": "3.1.1",
         "langcodes": "dimagi/langcodes",

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -135,9 +135,12 @@ define([
             };
         }
 
+        var mugData = cachedMugData(mug.form),
+            fuse = new fusejs(mugData, { keys: ['label', 'name'] });
+
         $input.atwho({
             at: "/data/",
-            data: cachedMugData(mug.form),
+            data: mugData,
             displayTpl: '<li><i class="${icon}" /> ${name}<br /><span class="atwho-jrtext">${displayLabel}</span></li>',
             insertTpl: options.insertTpl,
             limit: 10,
@@ -152,7 +155,6 @@ define([
                 },
                 filter: function (query, data, searchKey) {
                     if (!query) { return data; }
-                    var fuse = new fusejs(data, { keys: ['label', 'name'] });
                     return fuse.search(query);
                 },
                 sorter: function (query, items, searchKey) {

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -34,9 +34,8 @@ define([
         return _.chain(form.getMugList())
                 .map(function(mug) {
                     // probably better to use text-overflow: ellipsis
-                    var defaultLanguage = mug.form.vellum.data.javaRosa.Itext.getDefaultLanguage(),
-                        itext = mug.p.labelItext,
-                        defaultLabel = itext ? itext.getForm('default').getValue(defaultLanguage) : '',
+                    var itext = mug.p.labelItext,
+                        defaultLabel = itext ? itext.get() : '',
                         displayLabel = defaultLabel;
 
                     if (displayLabel.length > 25) {

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -29,11 +29,21 @@ define([
     var cachedMugData = timed(function(form) {
         return _.chain(form.getMugList())
                 .map(function(mug) {
+                    // probably better to use text-overflow: ellipsis
+                    var defaultLanguage = mug.form.vellum.data.javaRosa.Itext.getDefaultLanguage(),
+                        defaultLabel = mug.p.labelItext.getForm('default').getValue(defaultLanguage),
+                        displayLabel = defaultLabel;
+
+                    if (displayLabel.length > 25) {
+                        displayLabel = defaultLabel.slice(0, 25) + '&hellip;';
+                    }
+
                     return {
                         id: mug.ufid,
                         name: mug.absolutePath,
                         icon: mug.options.icon,
                         questionId: mug.p.nodeID,
+                        displayLabel: displayLabel,
                     };
                 })
                 .filter(function(choice) { return choice.name; })
@@ -125,7 +135,7 @@ define([
         $input.atwho({
             at: "/data/",
             data: cachedMugData(mug.form),
-            displayTpl: '<li><i class="${icon}" /> ${name}</li>',
+            displayTpl: '<li><i class="${icon}" /> ${name}<br /><span class="atwho-jrtext">${displayLabel}</span></li>',
             insertTpl: options.insertTpl,
             limit: 10,
             maxLen: 30,

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -1,9 +1,11 @@
 define([
     'underscore',
-    'jquery'
+    'jquery',
+    'fusejs'
 ], function (
     _,
-    $
+    $,
+    fusejs
 ) {
     var that = {};
 
@@ -44,6 +46,7 @@ define([
                         icon: mug.options.icon,
                         questionId: mug.p.nodeID,
                         displayLabel: displayLabel,
+                        label: defaultLabel,
                     };
                 })
                 .filter(function(choice) { return choice.name; })
@@ -146,6 +149,17 @@ define([
                     regexp = new RegExp('(\\s+|^)' + RegExp.escape(flag) + '([\\w_/]*)$', 'gi');
                     match = regexp.exec(subtext);
                     return match ? match[2] : null;
+                },
+                filter: function (query, data, searchKey) {
+                    if (!query) { return data; }
+                    var fuse = new fusejs(data, { keys: ['label', 'name'] });
+                    return fuse.search(query);
+                },
+                sorter: function (query, items, searchKey) {
+                    return _.map(items, function(item, idx) {
+                        item.atwho_order = idx;
+                        return item;
+                    });
                 },
                 beforeInsert: function(value, $li) {
                     if (window.analytics) {

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -1,11 +1,13 @@
 define([
     'underscore',
     'jquery',
-    'fusejs'
+    'fusejs',
+    'tpl!vellum/templates/atwho_display'
 ], function (
     _,
     $,
-    fusejs
+    fusejs,
+    atwhoDisplay
 ) {
     var that = {};
 
@@ -33,7 +35,8 @@ define([
                 .map(function(mug) {
                     // probably better to use text-overflow: ellipsis
                     var defaultLanguage = mug.form.vellum.data.javaRosa.Itext.getDefaultLanguage(),
-                        defaultLabel = mug.p.labelItext.getForm('default').getValue(defaultLanguage),
+                        itext = mug.p.labelItext,
+                        defaultLabel = itext ? itext.getForm('default').getValue(defaultLanguage) : '',
                         displayLabel = defaultLabel;
 
                     if (displayLabel.length > 25) {
@@ -141,7 +144,7 @@ define([
         $input.atwho({
             at: "/data/",
             data: mugData,
-            displayTpl: '<li><i class="${icon}" /> ${name}<br /><span class="atwho-jrtext">${displayLabel}</span></li>',
+            displayTpl: atwhoDisplay,
             insertTpl: options.insertTpl,
             limit: 10,
             maxLen: 30,

--- a/src/less-style/question-props.less
+++ b/src/less-style/question-props.less
@@ -215,6 +215,16 @@
   overflow: hidden;
 }
 
+.atwho-jrtext {
+  padding-left: 1em;
+  color: gray;
+}
+
+.cur > .atwho-jrtext {
+  padding-left: 1em;
+  color: white;
+}
+
 .fd-input {
   -moz-appearance: textfield;
   -webkit-appearance: textfield;

--- a/src/main.js
+++ b/src/main.js
@@ -68,7 +68,8 @@ requirejs.config({
         'caretjs': '../bower_components/Caret.js/dist/jquery.caret',
         'atjs': '../bower_components/At.js/dist/js/jquery.atwho',
         'ckeditor': '../lib/ckeditor/ckeditor',
-        'ckeditor-jquery': '../lib/ckeditor/adapters/jquery'
+        'ckeditor-jquery': '../lib/ckeditor/adapters/jquery',
+        'fusejs': '../bower_components/fuse.js/src/fuse'
     },
     shim: {
         'codemirror': {
@@ -163,6 +164,9 @@ requirejs.config({
         'ckeditor-jquery': {
             deps: ['jquery', 'ckeditor'],
             exports: '$.fn.ckeditor'
+        },
+        'fusejs': {
+            exports: 'fusejs'
         }
     },
     less: {

--- a/src/templates/atwho_display.html
+++ b/src/templates/atwho_display.html
@@ -1,0 +1,7 @@
+<li>
+  <i class="<%= icon %>" /> <%= name %>
+    <% if (displayLabel) { %>
+      <br />
+      <span class="atwho-jrtext"><%= displayLabel %></span>
+    <% } %>
+</li>,


### PR DESCRIPTION
![tooltip_058](https://cloud.githubusercontent.com/assets/1471773/10317392/3339abd0-6c32-11e5-8db0-9db307fbebbb.png)

@dimagi/product I think I recall someone mentioning that seeing the label in the dropdown would be nice. The gray text under the question id is the default lanugage's label. This also allows searching by that label

This PR also introduces some fuzzy searching so that you don't need to type exactly the right text. Notice qustion4 matches question4 in the screenshot. The values are ranked by closeness of text.

Any of this can be pulled into separate PRs.

@millerdev I started to test atwho stuff earlier, but when running the tests, the atwho containers did not clean up quickly enough. (can sync on this separately)