### PR TITLE
Preserve contiguous spaces in rich text widget

### DIFF
--- a/src/richText.js
+++ b/src/richText.js
@@ -434,10 +434,11 @@ define([
     /**
      * Convert plain text to HTML to be edited in CKEditor
      *
-     * Replace line breaks with <p> tags and &nbsp; with spaces.
+     * Replace line breaks with <p> tags and preserve contiguous spaces.
      */
     function toHtml(text) {
-        text = text.replace(/\n/g, "</p><p>");
+        text = text.replace(/\n/g, "</p><p>")
+                   .replace(/  /g, " &nbsp;");
         return "<p>" + text + "</p>";
     }
 
@@ -450,6 +451,7 @@ define([
         return html.replace(/<p>&nbsp;<\/p>/ig, "\n")
                    .replace(/<p>/ig,"")
                    .replace(/<\/p>/ig, "\n")
+                   .replace(/(&nbsp;|\xa0)/ig, " ")
                    // fixup final </p>, which is is not a newline
                    .replace(/\n$/, "");
     }

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -209,10 +209,13 @@ define([
                     "list\n\n\n* item\n* item",
                     "<p>list</p><p></p><p></p><p>* item</p><p>* item</p>"
                 ],
+                [" ", " "],
+                ["   ", " \xa0 "],
+                ["   ", " &nbsp; "],
             ];
 
             _.each(text, function(val){
-                it("from html to text: " + val[1], function() {
+                it("from html to text: " + JSON.stringify(val[1]), function() {
                     assert.strictEqual(richText.fromRichText(val[1]), val[0]);
                 });
             });

--- a/tests/widgets.js
+++ b/tests/widgets.js
@@ -99,22 +99,28 @@ require([
             });
         });
 
-        it("should preserve newlines", function(done) {
-            util.loadXML("");
-            util.paste([
-                ["id", "type", "labelItext:en-default"],
-                ["/text", "Text", "list\n\n* item\n* item\n"],
-            ]);
-            util.clickQuestion('text');
-            // NOTE async assert because ckEditor setData is async.
-            // Without this we get an empty string from getValue().
-            // This probably means there are bugs elsewhere because
-            // we depend on widget.getValue() returning the correct
-            // result immediately after widget.setValue(x) is called.
-            var richItext = util.getWidget('itext-en-label');
-            richItext.getValue(function (val) {
-                util.assertEqual(val, "list\n\n* item\n* item\n");
-                done();
+        describe("should preserve", function() {
+            var data = [
+                    ["id", "type", "labelItext:en-default"],
+                    ["/newlines", "Text", "list\n\n* item\n* item\n"],
+                    ["/spaces", "Text", "a  b   c    d"],
+                ];
+            before(function () {
+                util.loadXML("");
+                util.paste(data);
+            });
+
+            _.each(data.slice(1), function (row) {
+                var name = row[0].slice(1);
+                it(name, function (done) {
+                    util.clickQuestion(name);
+                    var widget = util.getWidget('itext-en-label');
+                    widget.getValue(function (val) {
+                        // async assert because ckEditor setData is async
+                        util.assertEqual(val, row[2]);
+                        done();
+                    });
+                });
             });
         });
 


### PR DESCRIPTION
Prior to this PR multiple contiguous spaces were collapsed into a single space by CKEditor. Additionally, adding multiple contiguous spaces with CKEditor resulted in non-breaking spaces to be encoded in the XForm, which broke expression validation at build/deploy time.

Fixes http://manage.dimagi.com/default.asp?185331

@emord cc @sravfeyn 