### PR TITLE
Upgrade to mocha-phantomjs 4.0.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 
     <script data-main="tests/main" src="bower_components/requirejs/require.js"></script>
     <script src="bower_components/xrayquire/xrayquire.js"></script>
+    <script>mocha.setup('bdd');</script>
 
     <style>
       .sidebar button,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "jshint": ">=1.1.0",
         "mocha": ">=1.9.0",
         "mocha-istanbul": ">=0.2.0",
-        "mocha-phantomjs": "3.5.3",
+        "mocha-phantomjs": "~4.0.1",
         "http-server": "*",
         "phantomjs": "~1.9.1",
 

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,5 +1,4 @@
-/* global console, mocha, mochaPhantomJS */
-mocha.setup('bdd');
+/* global console, mocha */
 mocha.reporter('html');
 
 // PhantomJS doesn't support bind yet
@@ -125,33 +124,28 @@ require(['jquery', 'jquery.vellum'], function ($) {
                 $(".sidebar .nav #resultsTab a").click();
                 return false;
             }
-            if (window.mochaPhantomJS) {
-                mochaPhantomJS.run();
-            } else {
-                $(".sidebar #mocha-stats").remove();
-                mocha.run();
-                // move progress indicator into sidebar
-                $("#mocha-stats").css({
-                    "margin-top": "3em",
-                    position: "relative",
-                    left: 0,
-                    top: 0
-                }).appendTo(".sidebar");
-                $("#mocha-stats li").css({display: "block"});
-                $("#mocha-stats li.progress").css({height: "40px"});
-                $("#mocha-stats li.passes a").click(showTestResults);
-                $("#mocha-stats li.failures a").click(showTestResults);
-            }
+            $(".sidebar #mocha-stats").remove();
+            mocha.run();
+            // move progress indicator into sidebar
+            $("#mocha-stats").css({
+                "margin-top": "3em",
+                position: "relative",
+                left: 0,
+                top: 0
+            }).appendTo(".sidebar");
+            $("#mocha-stats li").css({display: "block"});
+            $("#mocha-stats li.progress").css({height: "40px"});
+            $("#mocha-stats li.passes a").click(showTestResults);
+            $("#mocha-stats li.failures a").click(showTestResults);
         }
         $('#run-tests').click(runTests);
 
-        // ensure the normal first test instance is fully loaded before
-        // destroying it for tests
-        setTimeout(function () {
-            if (window.mochaPhantomJS) {
-                runTests();
-            }
-        }, 1000);
+        // mocha.env is an object when invoked by mocha-phantomjs
+        if (mocha.env) {
+            // ensure the normal first test instance is fully loaded before
+            // destroying it for tests
+            setTimeout(runTests, 0);
+        }
 
         function load(form) {
             $('#vellum').empty().vellum($.extend(true, {}, options.options, {


### PR DESCRIPTION
The `--bail` option did not work in v3.5.3. See https://github.com/nathanboktae/mocha-phantomjs/issues/215

Don't forget to run `npm update mocha-phantomjs` after merging this. And you'll need to run that command again when switching to branches made before this is merged.

@emord @orangejenny 
cc @sravfeyn 