### PR TITLE
Don't delete instances on dereference

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "devDependencies": {
         "bower": "~1.3.3",
         "istanbul": ">=0.1.34",
-        "jshint": ">=1.1.0",
+        "jshint": "~2.8.0",
         "mocha": ">=1.9.0",
         "mocha-istanbul": ">=0.2.0",
         "mocha-phantomjs": "~4.0.1",

--- a/src/form.js
+++ b/src/form.js
@@ -154,7 +154,6 @@ define([
                     refs[mug.ufid] = {};
                 }
                 refs[mug.ufid][property || "."] = null;
-                that.internal = false;
             }
         };
 
@@ -309,11 +308,6 @@ define([
                         meta = null;
                     }
                     this.knownInstances[attrs.id] = attrs.src;
-                } else if (meta.attributes.id !== attrs.id) {
-                    // support renaming when there is no reference
-                    if (meta.internal) {
-                        meta.attributes.id = attrs.id;
-                    }
                 }
             } else if (attrs.id) {
                 // attrs has no src, find by id
@@ -471,7 +465,7 @@ define([
                 });
             if (meta) {
                 if (meta.dropReference(mug, property)) {
-                    meta.internal = true;
+                    this.instanceMetadata = _.without(this.instanceMetadata, meta);
                     return true;
                 }
             }
@@ -481,10 +475,8 @@ define([
          * Drop all instance references from the given mug/property
          */
         dropAllInstanceReferences: function (mug, property) {
-            _.each(this.instanceMetadata, function (meta) {
-                if (meta.dropReference(mug, property)) {
-                    meta.internal = true;
-                }
+            this.instanceMetadata = _.filter(this.instanceMetadata, function (meta) {
+                return !meta.dropReference(mug, property);
             });
         },
         // todo: update references on rename

--- a/src/form.js
+++ b/src/form.js
@@ -211,7 +211,8 @@ define([
             _this.fireChange(e.mug);
         });
         this.instanceMetadata = [InstanceMetadata({})];
-        this.knownInstances = {}; // {<instance id>: <instance src or children>}
+        // {<instance id>: { src or children: <instance src or children>}
+        this.knownInstances = {};
         this.enableInstanceRefCounting = opts.enableInstanceRefCounting;
         this.errors = [];
         this.question_counter = 1;
@@ -307,7 +308,7 @@ define([
                         attrs.id = getUniqueId(attrs.id, ids);
                         meta = null;
                     }
-                    this.knownInstances[attrs.id] = attrs.src;
+                    this.knownInstances[attrs.id] = { src: attrs.src };
                 }
             } else if (attrs.id) {
                 // attrs has no src, find by id
@@ -317,13 +318,13 @@ define([
                 if (meta) {
                     if (meta.internal && this.knownInstances.hasOwnProperty(attrs.id)) {
                         meta.internal = false;
-                        meta.attributes.src = this.knownInstances[attrs.id];
+                        meta.attributes.src = this.knownInstances[attrs.id].src;
                     }
                 } else if (this.knownInstances.hasOwnProperty(attrs.id)) {
-                    if (_.isObject(this.knownInstances[attrs.id]))
-                        attrs.children = this.knownInstances[attrs.id];
-                    else {
-                        attrs.src = this.knownInstances[attrs.id];
+                    if (_.isString(this.knownInstances[attrs.id].src)) {
+                        attrs.src = this.knownInstances[attrs.id].src;
+                    } else {
+                        attrs.children = this.knownInstances[attrs.id].children;
                     }
                 }
             } else {
@@ -436,7 +437,11 @@ define([
                     .value();
                 _.each(map, function (src, id) {
                     if (src && !instances.hasOwnProperty(id)) {
-                        instances[id] = src;
+                        if (src.src) {
+                            instances[id] = src;
+                        } else {
+                            instances[id] = { src: src };
+                        }
                         var meta = metas[id];
                         if (meta && meta.internal) {
                             meta.internal = false;
@@ -450,9 +455,9 @@ define([
                         return;
                     }
                     if (meta.attributes.src) {
-                        instances[meta.attributes.id] = meta.attributes.src;
+                        instances[meta.attributes.id] = { src: meta.attributes.src };
                     } else if (meta.children) {
-                        instances[meta.attributes.id] = meta.children;
+                        instances[meta.attributes.id] = { children: meta.children };
                     }
                 });
             }

--- a/src/form.js
+++ b/src/form.js
@@ -154,6 +154,7 @@ define([
                     refs[mug.ufid] = {};
                 }
                 refs[mug.ufid][property || "."] = null;
+                that.internal = false;
             }
         };
 
@@ -308,6 +309,11 @@ define([
                         meta = null;
                     }
                     this.knownInstances[attrs.id] = attrs.src;
+                } else if (meta.attributes.id !== attrs.id) {
+                    // support renaming when there is no reference
+                    if (meta.internal) {
+                        meta.attributes.id = attrs.id;
+                    }
                 }
             } else if (attrs.id) {
                 // attrs has no src, find by id
@@ -465,7 +471,7 @@ define([
                 });
             if (meta) {
                 if (meta.dropReference(mug, property)) {
-                    this.instanceMetadata = _.without(this.instanceMetadata, meta);
+                    meta.internal = true;
                     return true;
                 }
             }
@@ -475,8 +481,10 @@ define([
          * Drop all instance references from the given mug/property
          */
         dropAllInstanceReferences: function (mug, property) {
-            this.instanceMetadata = _.filter(this.instanceMetadata, function (meta) {
-                return !meta.dropReference(mug, property);
+            _.each(this.instanceMetadata, function (meta) {
+                if (meta.dropReference(mug, property)) {
+                    meta.internal = true;
+                }
             });
         },
         // todo: update references on rename

--- a/src/form.js
+++ b/src/form.js
@@ -323,9 +323,7 @@ define([
                         meta.attributes.src = this.knownInstances[attrs.id].src;
                     }
                 } else if (this.knownInstances.hasOwnProperty(attrs.id)) {
-                    _.each(this.knownInstances[attrs.id], function(v, k) {
-                        attrs[k] = v;
-                    });
+                    _.defaults(attrs, this.knownInstances[attrs.id]);
                 }
             } else {
                 throw new Error("unsupported: non-primary instance without id or src");
@@ -440,12 +438,14 @@ define([
                     .value();
                 _.each(map, function (instance, id) {
                     if (instance && !instances.hasOwnProperty(id)) {
-                        if (instance.src) {
-                            instances[id] = instance;
-                        } else if (instance.children) {
+                        if (instance.children) {
                             instances[id] = { children: $(instance.children)};
-                        } else {
+                        } else if (_.isString(instance)){
+                            // assume a string is the src
                             instances[id] = { src: instance };
+                        } else {
+                            // assume we are fed a correct instance dict
+                            instances[id] = instance;
                         }
                         var meta = metas[id];
                         if (meta && meta.internal) {

--- a/src/writer.js
+++ b/src/writer.js
@@ -97,9 +97,10 @@ define([
     }
 
     var _writeInstanceAttributes = function (writer, instanceMetadata) {
-        for (var attrId in instanceMetadata.attributes) {
-            if (instanceMetadata.attributes.hasOwnProperty(attrId)) {
-                writer.writeAttributeString(attrId, instanceMetadata.attributes[attrId]);
+        var attrs = instanceMetadata.attributes;
+        for (var attrId in attrs) {
+            if (attrs.hasOwnProperty(attrId) && attrs[attrId]) {
+                writer.writeAttributeString(attrId, attrs[attrId]);
             }
         }
     };

--- a/tests/copy-paste.js
+++ b/tests/copy-paste.js
@@ -8,6 +8,7 @@ require([
     'text!static/copy-paste/text-question.xml',
     'text!static/copy-paste/two-choices.xml',
     'text!static/copy-paste/two-questions.xml',
+    'text!static/form/manual-instance-reference.xml',
     'vellum/copy-paste',
     'vellum/tsv'
 ], function (
@@ -20,6 +21,7 @@ require([
     TEXT_QUESTION_XML,
     TWO_CHOICES_XML,
     TWO_QUESTIONS_XML,
+    MANUAL_INSTANCE_REFERENCE_XML,
     mod,
     tsv
 ) {
@@ -982,6 +984,43 @@ require([
             var input = $("[name=property-nodeID]");
             input.val("other").change();
             assert.equal(input.val(), "other");
+        });
+
+        describe("with instances without src", function() {
+            before(function (done) {
+                util.init({
+                    features: { rich_text: false },
+                    javaRosa: { langs: ['en'] },
+                    core: {
+                        onReady: function () {
+                            assert(this.isPluginEnabled("copyPaste"),
+                                   "copyPaste plugin should be enabled");
+                            done();
+                        }
+                    }
+                });
+            });
+
+            var data = [
+                ['id', 'type', 'labelItext:en-default', 'appearance', 'calculateAttr', 'instances'],
+                ['/score', 'Int', 'What was your score', 'null', 'null', 'null'],
+                ['/output', 'DataBindOnly', 'null', 'null',
+                    "instance('scores')/score[@high > /data/score][@low < /data/score]",
+                    '{"scores":{"children":"<score low=\\"0.0\\" high=\\"500.0\\">You\'re really bad</score><score low=\\"500.0\\" high=\\"99999999.0\\">You\'re really good</score>"}}'],
+                ['/result', 'Trigger', '<output value="/data/output"/>', 'minimal', 'null', 'null'],
+            ];
+
+            it("should properly paste", function() {
+                util.loadXML("");
+                paste(data);
+                util.assertXmlEqual(call("createXML"), MANUAL_INSTANCE_REFERENCE_XML, {normalize_xmlns: true});
+            });
+
+            it("should properly copy", function() {
+                util.loadXML(MANUAL_INSTANCE_REFERENCE_XML);
+                util.selectAll();
+                eq(mod.copy(), data);
+            });
         });
 
         describe("with multimedia", function () {

--- a/tests/copy-paste.js
+++ b/tests/copy-paste.js
@@ -712,7 +712,7 @@ require([
         it("should copy dynamic select with itemset data and instance", function () {
             var data = [
                 ["id", "type", "labelItext:en-default", "labelItext:hin-default", "instances", "itemsetData"],
-                ["/select", "SelectDynamic", "select", "select", '{"foo":"jr://foo"}',
+                ["/select", "SelectDynamic", "select", "select", '{"foo":{"src":"jr://foo"}}',
                  '[{"instance":{"id":"foo","src":"jr://foo"},' +
                    '"nodeset":"instance(\'foo\')/foo/items","labelRef":"@name","valueRef":"@id"}]'],
             ];
@@ -727,7 +727,7 @@ require([
                 ["id", "type", "labelItext:en-default", "labelItext:hin-default", "filter", "instances", "itemsetData"],
                 ["/select", "SelectDynamic", "select", "select",
                  '["type = instance(\'fum\')/fum/@type"]',
-                 '{"foo":"jr://foo","fum":"jr://fum"}',
+                 '{"foo":{"src":"jr://foo"},"fum":{"src":"jr://fum"}}',
                  '[{"instance":{"id":"foo","src":"jr://foo"},' +
                    '"nodeset":"instance(\'foo\')/foo/items","labelRef":"@name","valueRef":"@id"}]'],
             ];
@@ -846,7 +846,7 @@ require([
                 ['id', 'type', 'labelItext:en-default', 'labelItext:hin-default', 'dataSource', 'instances'],
                 ['/repeat/item', 'Repeat', 'repeat', 'repeat',
                     '{"idsQuery":"instance(\'products\')/products/product/@id"}',
-                    '{"products":"jr://commtrack:products"}'],
+                    '{"products":{"src":"jr://commtrack:products"}}'],
             ];
             util.loadXML("");
             paste(data);
@@ -869,7 +869,7 @@ require([
                 ['id', 'type', 'labelItext:en-default', 'labelItext:hin-default', 'dataSource', 'instances'],
                 ['/repeat/item', 'Repeat', 'repeat', 'repeat',
                     '{"idsQuery":"instance(\'products\')/products/product/@id"}',
-                    '{"products":"jr://commtrack:products"}'],
+                    '{"products":{"src":"jr://commtrack:products"}}'],
             ]);
             assert(util.isTreeNodeValid("repeat/item"), util.getMessages("repeat/item"));
         });

--- a/tests/form.js
+++ b/tests/form.js
@@ -13,7 +13,8 @@ define([
     'text!static/form/select-questions.xml',
     'text!static/form/mismatch-tree-order.xml',
     'text!static/form/hidden-value-tree-order.xml',
-    'text!static/form/instance-reference.xml'
+    'text!static/form/instance-reference.xml',
+    'text!static/form/manual-instance-reference.xml'
 ], function (
     util,
     chai,
@@ -29,7 +30,8 @@ define([
     SELECT_QUESTIONS,
     MISMATCH_TREE_ORDER_XML,
     HIDDEN_VALUE_TREE_ORDER,
-    INSTANCE_REFERENCE_XML
+    INSTANCE_REFERENCE_XML,
+    MANUAL_INSTANCE_REFERENCE_XML
 ) {
     var assert = chai.assert,
         call = util.call;
@@ -329,6 +331,13 @@ define([
             assertInstanceSrc("groups", form,
                 "jr://fixture/user-groups",
                 "groups instance not found");
+        });
+
+        it("should not delete manual instances when it's reference is updated", function() {
+            util.loadXML(MANUAL_INSTANCE_REFERENCE_XML);
+            util.clickQuestion('output');
+            $('[name=property-calculateAttr]').change();
+            util.assertXmlEqual(call('createXML'), MANUAL_INSTANCE_REFERENCE_XML);
         });
 
         describe("instance tracker", function () {

--- a/tests/static/form/manual-instance-reference.xml
+++ b/tests/static/form/manual-instance-reference.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/C1D14B65-7FA3-4A88-B5C6-217B6DBB3BB2" uiVersion="1" version="1" name="Untitled Form">
+					<score />
+					<output />
+					<result />
+				</data>
+			</instance>
+			<instance id="scores">
+				<score low="0.0" high="500.0">You're really bad</score>
+				<score low="500.0" high="99999999.0">You're really good</score>
+			</instance>
+			<bind nodeset="/data/score" type="xsd:int" />
+			<bind nodeset="/data/output" calculate="instance('scores')/score[@high &gt; /data/score][@low &lt; /data/score]" />
+			<bind nodeset="/data/result" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="score-label">
+						<value>What was your score</value>
+					</text>
+					<text id="result-label">
+						<value><output value="/data/output" /></value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/score">
+			<label ref="jr:itext('score-label')" />
+		</input>
+		<trigger ref="/data/result" appearance="minimal">
+			<label ref="jr:itext('result-label')" />
+		</trigger>
+	</h:body>
+</h:html>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?186582#1044106

Original issue: https://github.com/dimagi/Vellum/blob/624473daf7b71ab85058ad0603d346826be00361/src/logic.js#L248-L249

Before it would delete the reference if there was only reference to the instance and then try to re-add it, but this isn't possible with manually written instances to support growth charts and it deleted all the data.

This expands `instanceMetadata.internal` definition to mean "not referenced in the form"

@millerdev 

cc: @gcapalbo 