### PR TITLE
adding csrf token to save button

### DIFF
--- a/lib/SaveButton.js
+++ b/lib/SaveButton.js
@@ -4,11 +4,13 @@ var SaveButton = {
         options: {
             save: "Function to call when the user clicks Save",
             unsavedMessage: "Message to display when there are unsaved changes and the user leaves the page"
+            csrftoken: "Token required in headers of AJAX request to prevent CSRF"
         }
     */
     init: function (options) {
         var button = {
             disabled: false,
+            csrftoken: options.csrftoken,
             $save: $('<span/>').text(SaveButton.message.SAVE).click(function (e) {
                 button.fire('save', e);
             }).addClass('btn btn-success'),
@@ -51,7 +53,10 @@ var SaveButton = {
                     success = options.success || function () {},
                     error = options.error || function () {},
                     that = this;
-                options.beforeSend = function () {
+                options.beforeSend = function (xhr) {
+                    if (that.csrftoken && !this.crossdomain) {
+                        xhr.setRequestHeader("X-CSRFToken", that.csrftoken);
+                    }
                     that.setState('saving');
                     that.nextState = 'saved';
                     beforeSend.apply(this, arguments);

--- a/lib/SaveButton.js
+++ b/lib/SaveButton.js
@@ -54,7 +54,7 @@ var SaveButton = {
                     error = options.error || function () {},
                     that = this;
                 options.beforeSend = function (xhr) {
-                    if (that.csrftoken && !this.crossdomain) {
+                    if (that.csrftoken && !this.crossDomain) {
                         xhr.setRequestHeader("X-CSRFToken", that.csrftoken);
                     }
                     that.setState('saving');

--- a/src/core.js
+++ b/src/core.js
@@ -166,7 +166,8 @@ define([
                     _this.validateAndSaveXForm(forceFullSave);
                 });
             },
-            unsavedMessage: 'Are you sure you want to exit? All unsaved changes will be lost!'
+            unsavedMessage: 'Are you sure you want to exit? All unsaved changes will be lost!',
+            csrftoken: _this.opts().csrftoken
         });
         var setFullscreenIcon = function () {
             var $i = $('i', _this.data.core.$fullscreenButton);


### PR DESCRIPTION
@orangejenny @millerdev @emord cc: @gcapalbo 
This modifies the save button to add CSRF header to its post request if one exists. As soon as CSRF protection on hq goes live, it wont be possible to save forms in the formbuilder without this. The token will be passed in through the options object.
If there is not a csrf token passed to the save button, no behavior will change.
Merging is not urgent because it will be a bit before the CSRF protection is up but I do not see a downside to merging early.