### PR TITLE
Encapsulate xpath library

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -4,7 +4,7 @@ define([
     'require',
     'save-button',
     'underscore',
-    'xpathmodels',
+    'vellum/xpath',
     'jquery',
     'tpl!vellum/templates/main',
     'tpl!vellum/templates/question_type_group',
@@ -36,7 +36,7 @@ define([
     require,
     SaveButton,
     _,
-    xpathmodels,
+    xpath,
     $,
     main_template,
     question_type_group,
@@ -73,7 +73,7 @@ define([
     var isMac = /Mac/.test(navigator.platform);
 
     var DEBUG_MODE = false;
-    xpathmodels.DEBUG_MODE = DEBUG_MODE;
+    xpath.xpathmodels.DEBUG_MODE = DEBUG_MODE;
 
     var MESSAGE_TYPES = {
         "error": {

--- a/src/expressionEditor.js
+++ b/src/expressionEditor.js
@@ -4,8 +4,7 @@ define([
     'vellum/debugutil',
     'vellum/util',
     'vellum/atwho',
-    'xpath',
-    'xpathmodels',
+    'vellum/xpath',
     'vellum/richText',
     'tpl!vellum/templates/xpath_validation_errors',
     'tpl!vellum/templates/xpath_expression',
@@ -18,7 +17,6 @@ define([
     util,
     atwho,
     xpath,
-    xpathmodels,
     richText,
     xpath_validation_errors,
     xpath_expression,
@@ -27,13 +25,13 @@ define([
     // Handlers for the simple expression editor
     var simpleExpressions = {};
     var operationOpts = [];
-    var expTypes = xpathmodels.XPathExpressionTypeEnum;
+    var expTypes = xpath.xpathmodels.XPathExpressionTypeEnum;
     var BinOpHandler = {
         toString: function(op, left, right) {
             // make sure we wrap the vals in parens in case they were necessary
             // todo, construct manually, and validate individual parts.
             return "(" + left + ") " + 
-                xpathmodels.expressionTypeEnumToXPathLiteral(op) + 
+                xpath.xpathmodels.expressionTypeEnumToXPathLiteral(op) + 
                 " (" + right + ")";
         },
         typeLeftRight: function(expOp) {
@@ -54,7 +52,7 @@ define([
         }
     };
     function addOp(expr, value, label) {
-        value = xpathmodels.expressionTypeEnumToXPathLiteral(value);
+        value = xpath.xpathmodels.expressionTypeEnumToXPathLiteral(value);
         simpleExpressions[value] = expr;
         operationOpts.push([label, value]);
     }
@@ -158,7 +156,7 @@ define([
         var validate = function (expr) {
             if (expr) {
                 try {
-                    var parsed = xpath.parse(expr);
+                    var parsed = xpath.xpath.parse(expr);
                     return [true, parsed];
                 } catch (err) {
                     return [false, err];
@@ -179,13 +177,13 @@ define([
 
             var isJoiningOp = function (subElement) {
                 // something that joins expressions
-                return (subElement instanceof xpathmodels.XPathBoolExpr);
+                return (subElement instanceof xpath.xpathmodels.XPathBoolExpr);
             };
 
             var isExpressionOp = function (subElement) {
                 // something that can be put into an expression
-                return (subElement instanceof xpathmodels.XPathCmpExpr ||
-                        subElement instanceof xpathmodels.XPathEqExpr ||
+                return (subElement instanceof xpath.xpathmodels.XPathCmpExpr ||
+                        subElement instanceof xpath.xpathmodels.XPathEqExpr ||
                         simpleExpressions.hasOwnProperty(subElement.id));
             };
 
@@ -258,7 +256,7 @@ define([
                         if (!expOp) return false;
                     }
                     populateQuestionInputBox(getLeftQuestionInput(), expOp.left);
-                    $expUI.find('.op-select').val(xpathmodels.expressionTypeEnumToXPathLiteral(expOp.type));
+                    $expUI.find('.op-select').val(xpath.xpathmodels.expressionTypeEnumToXPathLiteral(expOp.type));
                     // the population of the left can affect the right,
                     // so we need to update the reference
                     populateQuestionInputBox(getRightQuestionInput(), expOp.right, expOp.left);

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -5,8 +5,7 @@
 define([
     'underscore',
     'jquery',
-    'xpath',
-    'xpathmodels',
+    'vellum/xpath',
     'tpl!vellum/templates/edit_source',
     'tpl!vellum/templates/language_selector',
     'tpl!vellum/templates/control_group',
@@ -23,7 +22,6 @@ define([
     _,
     $,
     xpath,
-    xpathmodels,
     edit_source,
     language_selector,
     control_group,
@@ -1585,8 +1583,8 @@ define([
 
             function getITextID(value) {
                 try {
-                    var parsed = xpath.parse(value);
-                    if (parsed instanceof xpathmodels.XPathFuncExpr &&
+                    var parsed = xpath.xpath.parse(value);
+                    if (parsed instanceof xpath.xpathmodels.XPathFuncExpr &&
                         parsed.id === "jr:itext")
                     {
                         return parsed.args[0].value;

--- a/src/logic.js
+++ b/src/logic.js
@@ -1,29 +1,28 @@
 define([
-    'xpath',
-    'xpathmodels',
+    'vellum/xpath',
     'jquery',
     'underscore'
 ], function (
     xpath,
-    xpathmodels,
     $,
     _
 ) {
     var XPATH_REFERENCES = [
-        "relevantAttr",
-        "calculateAttr",
-        "constraintAttr",
-        "dataParent",
-        "repeat_count",
-        "filter",
-        "defaultValue"
-    ], NO_SELF_REFERENCES = _.without(XPATH_REFERENCES, 'constraintAttr');
+            "relevantAttr",
+            "calculateAttr",
+            "constraintAttr",
+            "dataParent",
+            "repeat_count",
+            "filter",
+            "defaultValue"
+        ],
+        NO_SELF_REFERENCES = _.without(XPATH_REFERENCES, 'constraintAttr');
 
     function LogicExpression (exprText) {
         this._text = exprText || "";
         if ($.trim(exprText)) {
             try {
-                this.parsed = xpath.parse(exprText);
+                this.parsed = xpath.xpath.parse(exprText);
             } catch (err) {
                 this.parsed = null;
                 this.error = err;
@@ -37,9 +36,9 @@ define([
             var paths = [],
                 absolutePaths = [],
                 topLevelPaths = [],
-                ROOT = xpathmodels.XPathInitialContextEnum.ROOT,
-                RELATIVE = xpathmodels.XPathInitialContextEnum.RELATIVE,
-                EXPR = xpathmodels.XPathInitialContextEnum.EXPR,
+                ROOT = xpath.xpathmodels.XPathInitialContextEnum.ROOT,
+                RELATIVE = xpath.xpathmodels.XPathInitialContextEnum.RELATIVE,
+                EXPR = xpath.xpathmodels.XPathInitialContextEnum.EXPR,
                 predicates;
             this.paths = paths;
             this.absolutePaths = absolutePaths;
@@ -53,7 +52,7 @@ define([
                     k = queue.shift();
                     node = k.xpath;
                     insideFilter = k.insideFilter;
-                    if (node instanceof xpathmodels.XPathPathExpr) {
+                    if (node instanceof xpath.xpathmodels.XPathPathExpr) {
                         paths.push(node);
                         if (!insideFilter) {
                             topLevelPaths.push(node);
@@ -82,7 +81,7 @@ define([
                                 });
                             }
                         }
-                    } else if (node instanceof xpathmodels.XPathFuncExpr) {
+                    } else if (node instanceof xpath.xpathmodels.XPathFuncExpr) {
                         this._addInstanceRef(node);
                     }
                     children = node.getChildren();
@@ -106,7 +105,7 @@ define([
         },
         _addInstanceRef: function (expr) {
             if (expr.id === "instance" && expr.args.length === 1 &&
-                    expr.args[0] instanceof xpathmodels.XPathStringLiteral) {
+                    expr.args[0] instanceof xpath.xpathmodels.XPathStringLiteral) {
                 var id = expr.args[0].value;
                 this.instanceRefs[id] = null;
                 return true;
@@ -141,7 +140,7 @@ define([
             for (var i = 0; i < paths.length; i++) {
                 path = paths[i];
                 if (path.toXPath() === from) {
-                    replacePathInfo(xpath.parse(to), path);
+                    replacePathInfo(xpath.xpath.parse(to), path);
                 }
             }
         },

--- a/src/main.js
+++ b/src/main.js
@@ -140,7 +140,7 @@ requirejs.config({
         },
         'xpathmodels': {
             deps: ['scheme-number'],
-            exports: 'xpathmodels'
+            exports: 'makeXPathModels'
         },
         'scheme-number': {
             deps: ['biginteger'],

--- a/src/parser.js
+++ b/src/parser.js
@@ -4,16 +4,14 @@ define([
     'vellum/xml',
     'jquery',
     'underscore',
-    'xpath',
-    'xpathmodels'
+    'vellum/xpath'
 ], function (
     form_,
     util,
     xml,
     $,
     _,
-    xpath,
-    xpathmodels
+    xpath
 ) {
     var DEFAULT_FORM_ID = 'data';
 
@@ -596,14 +594,14 @@ define([
      */
     function processPath (path, rootNodeName) {
         var newPath;
-        var parsed = xpath.parse(path);
-        if (!(parsed instanceof xpathmodels.XPathPathExpr)) {
+        var parsed = xpath.xpath.parse(path);
+        if (!(parsed instanceof xpath.xpathmodels.XPathPathExpr)) {
             return null;
         }
 
-        if (parsed.initial_context === xpathmodels.XPathInitialContextEnum.RELATIVE) {
-            parsed.steps.splice(0, 0, xpathmodels.XPathStep({axis: "child", test: rootNodeName}));
-            parsed.initial_context = xpathmodels.XPathInitialContextEnum.ROOT;
+        if (parsed.initial_context === xpath.xpathmodels.XPathInitialContextEnum.RELATIVE) {
+            parsed.steps.splice(0, 0, xpath.xpathmodels.XPathStep({axis: "child", test: rootNodeName}));
+            parsed.initial_context = xpath.xpathmodels.XPathInitialContextEnum.ROOT;
         } else {
             return path;
         }

--- a/src/richText.js
+++ b/src/richText.js
@@ -36,7 +36,7 @@ define([
     'vellum/logic',
     'vellum/util',
     'vellum/xml',
-    'xpathmodels',
+    'vellum/xpath',
     'ckeditor',
     'ckeditor-jquery'
 ], function(
@@ -46,7 +46,7 @@ define([
     logic,
     util,
     xml,
-    xpathmodels,
+    xpath,
     CKEDITOR
 ){
     var bubbleWidgetDefinition = {
@@ -437,8 +437,8 @@ define([
      */
     function bubbleExpression(text, form) {
         var el = $('<div>').html(text);
-        var EXPR = xpathmodels.XPathInitialContextEnum.EXPR,
-            ROOT = xpathmodels.XPathInitialContextEnum.ROOT,
+        var EXPR = xpath.xpathmodels.XPathInitialContextEnum.EXPR,
+            ROOT = xpath.xpathmodels.XPathInitialContextEnum.ROOT,
             expr = new logic.LogicExpression(text),
             // Uses top level paths, because filters should not be made to bubbles
             paths = _.chain(expr.getTopLevelPaths())

--- a/src/xpath.js
+++ b/src/xpath.js
@@ -1,0 +1,17 @@
+define([
+    'xpath',
+    'xpathmodels'
+], function (
+    xpath,
+    makeXPathModels
+) {
+    /* global xpathmodels */
+    /*jshint -W020 */
+    xpathmodels = makeXPathModels();
+    /*jshint +W020 */
+    
+    return {
+        xpath: xpath,
+        xpathmodels: xpathmodels
+    };
+});


### PR DESCRIPTION
encapsulate xpath into it's own file so we can be sure that vellum uses the same xpath parser throughout. uses new js-xpath

Doesn't really make a difference at the moment, but pulling it out from my current dev branch

cc: @esoergel 