### PR TITLE
Speed up tests

### DIFF
--- a/src/atwho.js
+++ b/src/atwho.js
@@ -17,21 +17,23 @@ define([
 
     // stripped down version of http://codepen.io/ImagineProgramming/storydump/javascript-memoization-timeout
     var timed = function timed(f, timeout) {
-        var cache = {}, time = 0;
+        var time = 0;
 
         return function TimedMemoizedFunction() {
             var now = +new Date(),
                 timedOut = (now - time) >= timeout,
-                form = arguments[0];
+                form = arguments[0],
+                cache = form.vellum.data.atwho;
+            // atwho isn't actually defined anywhere, but data is an object from core
 
-            if(timedOut || _.isUndefined(cache[form.formUuid])) {
-                cache[form.formUuid] = f.apply(f, arguments);
+            if(timedOut || _.isUndefined(cache)) {
+                cache = f.apply(f, arguments);
                 if (timedOut) {
                     time = now;
                 }
             }
 
-            return cache[form.formUuid];
+            return cache;
         };
     };
 

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -23,17 +23,17 @@ define([
             var now = +new Date(),
                 timedOut = (now - time) >= timeout,
                 form = arguments[0],
-                cache = form.vellum.data.atwho;
-            // atwho isn't actually defined anywhere, but data is an object from core
+                atwhoData = form.vellum.data.atwho,
+                cache = atwhoData.cache;
 
             if(timedOut || _.isUndefined(cache)) {
-                cache = f.apply(f, arguments);
+                cache = atwhoData.cache = f.apply(f, arguments);
                 if (timedOut) {
                     time = now;
                 }
             }
 
-            return cache;
+            return atwhoData.cache;
         };
     };
 

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -35,27 +35,28 @@ define([
         };
     };
 
-    var cachedMugData = function(cacheTime) {
-        return timed(function(form) {
-            return _.chain(form.getMugList())
-                    .map(function(mug) {
-                        var defaultLabel = form.vellum.getMugDisplayName(mug);
+    var _cachedMugData = function(cacheTime) {
+            return timed(function(form) {
+                return _.chain(form.getMugList())
+                        .map(function(mug) {
+                            var defaultLabel = form.vellum.getMugDisplayName(mug);
 
-                        return {
-                            id: mug.ufid,
-                            name: mug.absolutePath,
-                            icon: mug.options.icon,
-                            questionId: mug.p.nodeID,
-                            displayLabel: util.truncate(defaultLabel),
-                            label: defaultLabel,
-                        };
-                    })
-                    .filter(function(choice) {
-                        return choice.name && !_.isUndefined(choice.displayLabel);
-                    })
-                    .value();
-        }, cacheTime || 500);
-    };
+                            return {
+                                id: mug.ufid,
+                                name: mug.absolutePath,
+                                icon: mug.options.icon,
+                                questionId: mug.p.nodeID,
+                                displayLabel: util.truncate(defaultLabel),
+                                label: defaultLabel,
+                            };
+                        })
+                        .filter(function(choice) {
+                            return choice.name && !_.isUndefined(choice.displayLabel);
+                        })
+                        .value();
+            }, cacheTime || 500);
+        },
+        cachedMugData = _cachedMugData();
 
     /**
      * Turn a given input into an autocomplete, which will be populated
@@ -130,7 +131,7 @@ define([
         }
 
         var _atWhoOptions = function() {
-            var mugData = cachedMugData()(mug.form),
+            var mugData = cachedMugData(mug.form),
                 fuse = new fusejs(mugData, { keys: ['label', 'name'] });
     
             return {
@@ -187,7 +188,7 @@ define([
         });
     };
 
-    that.cachedMugData = cachedMugData;
+    that.cachedMugData = _cachedMugData;
 
     $.vellum.plugin("atwho", {},
         {

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -17,20 +17,21 @@ define([
 
     // stripped down version of http://codepen.io/ImagineProgramming/storydump/javascript-memoization-timeout
     var timed = function timed(f, timeout) {
-        var cache, time = 0;
+        var cache = {}, time = 0;
 
         return function TimedMemoizedFunction() {
             var now = +new Date(),
-                timedOut = (now - time) >= timeout;
+                timedOut = (now - time) >= timeout,
+                form = arguments[0];
 
-            if(timedOut || _.isUndefined(cache)) {
-                cache = f.apply(f, arguments);
+            if(timedOut || _.isUndefined(cache[form.formUuid])) {
+                cache[form.formUuid] = f.apply(f, arguments);
                 if (timedOut) {
                     time = now;
                 }
             }
 
-            return cache;
+            return cache[form.formUuid];
         };
     };
 

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -64,7 +64,7 @@ define([
      * @param $input - jQuery object, the input to turn into an autocomplete
      * @param choices - An array of strings with which to populate the autocomplete
      */
-    that.dropdownAutocomplete = function ($input, choices) {
+    that._dropdownAutocomplete = function ($input, choices) {
         $input.atwho({
             at: "",
             data: choices,
@@ -104,6 +104,10 @@ define([
      *                  outputValue: use output value in the template
      */
     that.questionAutocomplete = function ($input, mug, options) {
+        mug.form.vellum.addAutocomplete($input, mug, options) ;
+    };
+
+    that._questionAutocomplete = function ($input, mug, options) {
         options = _.defaults(options || {}, {
             category: 'Question Reference',
             insertTpl: '${name}',
@@ -184,6 +188,18 @@ define([
     };
 
     that.cachedMugData = cachedMugData;
+
+    $.vellum.plugin("atwho", {},
+        {
+            addAutocomplete: function ($input, mug, options) {
+                if (options && options.choices) {
+                   that._dropdownAutocomplete($input, options.choices);
+                } else {
+                    that._questionAutocomplete($input, mug, options);
+                }
+            }
+        }
+    );
 
     return that;
 });

--- a/src/core.js
+++ b/src/core.js
@@ -2120,6 +2120,8 @@ define([
 
     fn.contributeToHeadXML = function (xmlWriter, form) {}; 
 
+    fn.addAutocomplete = function (input, form, options) {};
+
     fn.initWidget = function (widget) {};
 
     fn.destroy = function () {};

--- a/src/expressionEditor.js
+++ b/src/expressionEditor.js
@@ -108,7 +108,7 @@ define([
                 if (_.isFunction(choices)) {
                     choices = choices();
                 }
-                atwho.dropdownAutocomplete(input, choices);
+                atwho.questionAutocomplete(input, options.mug, {choices: choices});
             }
             else {
                 atwho.questionAutocomplete(input, options.mug, {

--- a/src/itemset.js
+++ b/src/itemset.js
@@ -346,8 +346,8 @@ define([
         function updateAutocomplete(data) {
             var value = super_getValue(),
                 choices = datasourceWidgets.autocompleteChoices(data, value ? value.src : "");
-            atwho.dropdownAutocomplete(valueRef(), choices);
-            atwho.dropdownAutocomplete(labelRef(), choices);
+            atwho.questionAutocomplete(valueRef(), mug, {choices: choices});
+            atwho.questionAutocomplete(labelRef(), mug, {choices: choices});
             return choices;
         }
 
@@ -465,7 +465,7 @@ define([
             src = instance ? instance.src : "",
             choices = datasourceWidgets.autocompleteChoices(getDataSources(), src);
 
-        atwho.dropdownAutocomplete(widget.input, choices);
+        atwho.questionAutocomplete(widget.input, mug, {choices: choices});
 
         return widget;
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -155,6 +155,7 @@ define([
 
         if (!form.formUuid) {
             form.parseWarnings.push('Form does not have a unique xform XMLNS (in data block). Will be added automatically');
+            form.formUuid = "http://openrosa.org/formdesigner/" + util.generate_xmlns_uuid();
         }
         if (!form.formJRM) {
             form.parseWarnings.push('Form JRM namespace attribute was not found in data block. One will be added automatically');

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -371,6 +371,7 @@ define([
                 }
                 delete control.value;
             });
+            this.__callOld();
         }
     });
 });

--- a/src/writer.js
+++ b/src/writer.js
@@ -68,9 +68,6 @@ define([
         }
 
         uuid = form.formUuid; //gets set at parse time/by UI
-        if(!uuid) {
-            uuid = "http://openrosa.org/formdesigner/" + util.generate_xmlns_uuid();
-        }
 
         xmlWriter.writeAttributeString("xmlns:jrm",jrm);
         xmlWriter.writeAttributeString("xmlns", uuid);

--- a/tests/atwho.js
+++ b/tests/atwho.js
@@ -70,6 +70,7 @@ require([
                     return mug.displayName;
                 }
             },
+            formUuid: 'test',
             getMugList: function () { return mugs; },
         };
     _.each(mugs, function(mug) {
@@ -117,7 +118,7 @@ require([
                 $('.atwho-container').remove();
                 $("body").append(el);
                 input = el.children().first();
-                atwho.questionAutocomplete(input, mug);
+                atwho._questionAutocomplete(input, mug);
                 input.val('/data/');
                 input.keyup();
                 atwhoview = getDisplayedAtwhoViews();

--- a/tests/atwho.js
+++ b/tests/atwho.js
@@ -68,7 +68,8 @@ require([
             vellum: {
                 getMugDisplayName: function (mug) {
                     return mug.displayName;
-                }
+                },
+                data: {},
             },
             formUuid: 'test',
             getMugList: function () { return mugs; },

--- a/tests/atwho.js
+++ b/tests/atwho.js
@@ -69,7 +69,9 @@ require([
                 getMugDisplayName: function (mug) {
                     return mug.displayName;
                 },
-                data: {},
+                data: {
+                    atwho: {}
+                },
             },
             formUuid: 'test',
             getMugList: function () { return mugs; },

--- a/tests/options.js
+++ b/tests/options.js
@@ -174,6 +174,7 @@ define(["underscore"], function (_) {
             'modeliteration',
             'commtrack',
             'saveToCase',
+            'atwho',
         ],
         features: {
             'lookup_tables': true,

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -169,6 +169,7 @@ define([
         if (opts.plugins) {
             vellum_options.plugins = opts.plugins;
         }
+        vellum_options.plugins = _.without(vellum_options.plugins, "atwho");
         vellum_options.core = vellum_options.core || {};
         var originalSaveUrl = vellum_options.core.saveUrl || function () {};
         vellum_options.core.saveUrl = function (data) {


### PR DESCRIPTION
Turns out cool features slow down tests

Before: `./test  103.82s user 1.18s system 96% cpu 1:48.64 total`
After: `./test  60.94s user 1.32s system 95% cpu 1:05.35 total`

Removes atwho from vellum tests. Atwho is currently tested by creating it's own input and has a mock form.

Depends on https://github.com/dimagi/commcare-hq/pull/9859

@millerdev 

cc: @sravfeyn 