### PR TITLE
Add B3 selector to multimedia modal

### DIFF
--- a/src/templates/multimedia_modal.html
+++ b/src/templates/multimedia_modal.html
@@ -19,7 +19,7 @@
             <label class="control-label">
                 Current <%= mediaType %>
             </label>
-            <div class="controls">
+            <div class="controls hqm-existing-controls">
             </div>
         </div>
         <div class="hqm-upload-form">


### PR DESCRIPTION
Necessary because of https://github.com/dimagi/MediaUploader/pull/11

@emord this needs to go into today's deploy

cc @sravfeyn 