### PR TITLE
Witchcraft

### DIFF
--- a/src/less-style/structure.less
+++ b/src/less-style/structure.less
@@ -46,6 +46,9 @@
   overflow-x: hidden;
   overflow-y: auto;
   height: @containerHeight;
+
+  // Prevent scrollbars underneath the modal from bleeding through on OSX
+  transform: translate3d(0, 0, 0);
 }
 
 .fd-accessory-pane {
@@ -224,9 +227,6 @@
   left: 20px;
   margin-left: 0;
   height: 93%;
-
-  // Prevent scrollbars underneath the modal from bleeding through on OSX
-  transform: translate3d(0, 0, 0);
 
   &.fade.in { top: 20px;}
 

--- a/src/less-style/structure.less
+++ b/src/less-style/structure.less
@@ -225,6 +225,9 @@
   margin-left: 0;
   height: 93%;
 
+  // Prevent scrollbars underneath the modal from bleeding through on OSX
+  transform: translate3d(0, 0, 0);
+
   &.fade.in { top: 20px;}
 
   .modal-body {


### PR DESCRIPTION
In Chrome on OSX, the case properties panel's scroll bar is visible on top of the XML source modal.

http://stackoverflow.com/questions/16874546/strange-z-index-behavior-with-scrollbars-under-chrome

![screen shot 2016-02-03 at 4 54 39 pm](https://cloud.githubusercontent.com/assets/1486591/12798362/ff272c0a-ca96-11e5-9973-b2e694417e4f.png)

@emord 