### PR TITLE
Upgrade underscore

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
         "tests"
     ],
     "dependencies": {
-        "underscore": "~1.4.4",
+        "underscore": "~1.6.0",
         "jquery": "~1.11.1",
         "requirejs": "~2.1.11",
         "requirejs-text": "~2.0.12",

--- a/build.js
+++ b/build.js
@@ -69,7 +69,8 @@
             name: 'global-deps',
             include: [
                 'jquery',
-                'jquery.bootstrap'
+                'jquery.bootstrap',
+                'underscore'
             ],
             exclude: [
                 'exclude'
@@ -114,7 +115,6 @@
             create: true,
             name: 'local-deps',
             include: [
-                'underscore',
                 'jquery.jstree',
                 'save-button',
                 'ckeditor',

--- a/tests/form.js
+++ b/tests/form.js
@@ -361,7 +361,7 @@ define([
                 [{id: "old", src: "new://3"}, "old-1", "src"],
                 [{id: "old", src: "old://"}, "old", "src"],
                 [{id: "any", src: "old://"}, "old", "src"],
-                [{id: "known", src: null}, "known", "known://"],
+                [{id: "known", src: undefined}, "known", "known://"],
                 [{id: "blank", src: "blank://"}, "blank", "src"],
                 [{id: null, src: "new://5"}, "data-1", "src"],
                 //[{id: null, src: null}, "data-1", "src"],     Error!

--- a/tests/main.js
+++ b/tests/main.js
@@ -28,6 +28,7 @@ console.log("loading Vellum from " + baseUrl);
 // comment these to use built versions
 define("jquery", [testBase + 'bower_components/jquery/dist/jquery'], function () { return window.jQuery; });
 define("jquery.bootstrap", ["jquery", testBase + 'lib/bootstrap'], function () {});
+define("underscore", [testBase + 'bower_components/underscore/underscore'], function () { return window._; });
 
 require.config({
     baseUrl: baseUrl,


### PR DESCRIPTION
@millerdev @orangejenny 

Right now vellum is overridding HQ's underscore (1.6.0) with our own packged one (1.4.4) changes here (look at 1.5.0 through 1.6.0): http://underscorejs.org/#1.6.0

This upgrades underscore and stops it from being packaged in local-deps

As far as I know there's no bugs that this causes yet.

cc: @benrudolph 