### PR TITLE
Fix button alignment in lookup table data

### DIFF
--- a/src/widgets.js
+++ b/src/widgets.js
@@ -692,17 +692,20 @@ define([
 
         var button = $('<button />')
             .addClass("fd-edit-button")
-            .text("Edit")
+            .html("<i class='fa fa-edit'></i>")
             .stopLink()
-            .addClass('btn btn-default')
+            .addClass('btn btn-default btn-block')
             .attr('type', 'button')
             .prop('disabled', isDisabled)
-            .click(editFn);
+            .click(editFn),
+            buttonContainer = $("<div />")
+            .addClass("col-sm-1")
+            .append(button);
 
         $uiElem.css('position', 'relative');
         $uiElem.find('.controls')
             .removeClass("col-sm-9").addClass("col-sm-8")
-            .after(button);
+            .after(buttonContainer);
         return $uiElem;
     };
     

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -162,7 +162,7 @@ require([
 
             function testEditButton(bool) {
                 clickQuestion(bool ? "value_locked" : "normal");
-                var $but = getInput('relevantAttr').parents('.form-group').find('button:contains(Edit)');
+                var $but = getInput('relevantAttr').parents('.form-group').find('button.fd-edit-button');
                 assert.equal(1, $but.length);
                 assert.equal(bool, $but.prop('disabled'));
             }


### PR DESCRIPTION
@emord 

before
<img width="763" alt="screen shot 2016-02-17 at 12 41 31 pm" src="https://cloud.githubusercontent.com/assets/1486591/13118772/dbc93144-d573-11e5-9ae0-a6b21fdc68ed.png">

after
<img width="759" alt="screen shot 2016-02-17 at 12 41 39 pm" src="https://cloud.githubusercontent.com/assets/1486591/13118775/e017bc02-d573-11e5-9b53-68f98c924d08.png">

Switched to icon because "Edit" padding changed & "Edit" no longer fits cleanly (on my screen, which isn't all that small).