### PR TITLE
🍌

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,7 +31,7 @@ module.exports = function(grunt)  {
     mocha_phantomjs: {
         all: {
             options: {
-                urls: ['http://localhost:8000/index.html'],
+                urls: ['http://localhost:8081/index.html'],
                 reporter: 'nyan', // the only one that gives # of tests completed
                 config: {
                     'bail': true,
@@ -43,7 +43,7 @@ module.exports = function(grunt)  {
     connect: {
         server: {
             options: {
-                port: grunt.option('port') || 8000,
+                port: grunt.option('port') || 8081,
                 base: '.',
             }
         }

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -40,6 +40,19 @@ define([
 
     var _cachedMugData = function(cacheTime) {
             return timed(function(form) {
+                var caseData = [];
+                if (form.vellum.data.core.databrowser) {
+                    caseData = _.chain(form.vellum.data.core.databrowser.dataHashtags)
+                     .map(function(absolutePath, hashtag) {
+                         return {
+                             name: hashtag,
+                             absolutePath: absolutePath,
+                             icon: 'fcc fcc-fd-external-case-data',
+                             displayLabel: null,
+                         };
+                     })
+                     .value();
+                }
                 return _.chain(form.getMugList())
                         .map(function(mug) {
                             var defaultLabel = form.vellum.getMugDisplayName(mug);
@@ -57,7 +70,7 @@ define([
                         .filter(function(choice) {
                             return choice.name && !_.isUndefined(choice.displayLabel);
                         })
-                        .value();
+                        .value().concat(caseData);
             }, cacheTime || 500);
         },
         cachedMugData = _cachedMugData();
@@ -179,7 +192,7 @@ define([
 
             $input.atwho(_atWhoOptions('/data/'));
             if (options.useRichText) {
-                $input.atwho(_atWhoOptions('#form'));
+                $input.atwho(_atWhoOptions('#'));
             }
         }
 

--- a/src/bananas.js
+++ b/src/bananas.js
@@ -134,9 +134,23 @@ define([
         return output;
     }
 
+    function Parser(xpathParser) {
+        return {
+            parse: function (input) {
+                var parsed = xpathParser.parse(toXPath(input, xpathParser));
+                parsed.toBanana = function() {
+                    return toBanana(input, xpathParser);
+                };
+                return parsed;
+            },
+            models: xpathParser.models,
+        };
+    }
+
     return {
         toBanana: toBanana,
         toXPath: toXPath,
         transform: transform,
+        Parser: Parser,
     };
 });

--- a/src/bananas.js
+++ b/src/bananas.js
@@ -1,0 +1,76 @@
+define([], function() {
+    var OUTSIDE_BANANA = 0,
+        INSIDE_BANANA = 1,
+        DELIMITER = "🍌";
+
+    function getSymbols(string) {
+        var index = 0;
+        var length = string.length;
+        var output = [];
+        for (; index < length - 1; ++index) {
+            var charCode = string.charCodeAt(index);
+            if (charCode >= 0xD800 && charCode <= 0xDBFF) {
+                charCode = string.charCodeAt(index + 1);
+                if (charCode >= 0xDC00 && charCode <= 0xDFFF) {
+                    output.push(string.slice(index, index + 2));
+                    ++index;
+                    continue;
+                }
+            }
+            output.push(string.charAt(index));
+        }
+        output.push(string.charAt(index));
+        return output;
+    }
+
+    function parse(input, transform) {
+        input = getSymbols(input);
+        transform = transform || function (input) { return input; };
+
+        var state = OUTSIDE_BANANA,
+            strLen = input.length,
+            text = "",
+            references = [],
+            currentReference = "";
+
+        for (var i = 0; i < strLen; i++) {
+            var current = input[i],
+                next = input[i+1];
+
+            if (state === OUTSIDE_BANANA) {
+                if (current === DELIMITER && next === DELIMITER) {
+                    text += DELIMITER;
+                    i++;
+                } else if (current === DELIMITER) {
+                    state = INSIDE_BANANA;
+                } else {
+                    text += current;
+                }
+            } else if (state === INSIDE_BANANA) {
+                if (current === DELIMITER && next === DELIMITER) {
+                    currentReference += DELIMITER;
+                    i++;
+                } else if (current === DELIMITER) {
+                    state = OUTSIDE_BANANA;
+                    references.push(currentReference);
+                    text += transform(currentReference);
+                    currentReference = "";
+                } else if (next !== undefined){
+                    currentReference += current;
+                } else {
+                    // end of string, shouldn't happen, but will not
+                    // overestimate users or Vellum devs
+                    text += DELIMITER + currentReference;
+                    currentReference = "";
+                }
+            }
+        }
+
+        return {
+            text: text,
+            references: references,
+        };
+    }
+
+    return parse;
+});

--- a/src/bananas.js
+++ b/src/bananas.js
@@ -1,7 +1,117 @@
-define([], function() {
+define([
+    'vellum/xpath',
+], function(
+    xpath
+) {
     var OUTSIDE_BANANA = 0,
         INSIDE_BANANA = 1,
-        DELIMITER = "🍌";
+        DELIMITER = "🍌",
+        defaultParser = xpath.createParser(xpath.makeXPathModels({}));
+
+    function parse(input, transformFn, xpathParser) {
+        input = getSymbols(input);
+        xpathParser = xpathParser || defaultParser;
+
+        // I hope no one used multiple 🍌 in their forms before..
+        var parsedBanana = parseBananas(input, transformFn);
+
+        try {
+            // we should really only accept bananas, but if they supply a nice
+            // looking xpath. let's turn them into pretty bananas
+            var parsed = xpathParser.parse(parsedBanana.nontransformedText);
+            // success! now let's turn that input into bananas
+            parsed = xpathParser.parse(parsed.toHashtag());
+            return transformHashtags(parsed, xpathParser.models, function(input) {
+                return transformFn(input);
+            });
+        } catch (err) {
+            // a bad xpath. let's just return the transformed bananas
+            return parsedBanana.text;
+        }
+    }
+
+    function transformHashtags(parsedHashtags, models, transformFn) {
+        var queue = [parsedHashtags],
+            EXPR = models.XPathInitialContextEnum.EXPR,
+            node, i, children, j, predicates;
+        while (queue.length > 0) {
+            node = queue.shift();
+            if (node instanceof models.XPathPathExpr) {
+                if (node.initial_context === EXPR) {
+                    queue.push(node.filter.expr);
+                    predicates = node.filter.predicates;
+                    for (i = 0; i < predicates.length; i++) {
+                        queue.push(predicates[i]);
+                    }
+                }
+            } else if (node instanceof models.HashtagExpr) {
+                node.toHashtag = function() {
+                    return transformFn(node.toHashtag());
+                };
+            }
+            children = node.getChildren();
+            for (i = 0; i < children.length; i++) {
+                queue.push(children[i]);
+                if (children[i].predicates && children[i].predicates.length) {
+                    predicates = children[i].predicates;
+                    for (j = 0; j < predicates.length; j++) {
+                        queue.push(predicates[j]);
+                    }
+                }
+            }
+        }
+        return parsedHashtags.toHashtag();
+    }
+
+    function parseBananas(input, transformFn) {
+        transformFn = transformFn || function (input) { return input; };
+        var state = OUTSIDE_BANANA,
+            strLen = input.length,
+            text = "",
+            nontransformedText = "",
+            currentReference = "";
+
+        for (var i = 0; i < strLen; i++) {
+            var current = input[i],
+                next = input[i+1];
+
+            if (state === OUTSIDE_BANANA) {
+                if (current === DELIMITER && next === DELIMITER) {
+                    text += DELIMITER;
+                    nontransformedText += DELIMITER;
+                    i++;
+                } else if (current === DELIMITER) {
+                    state = INSIDE_BANANA;
+                } else {
+                    text += current;
+                    nontransformedText += current;
+                }
+            } else if (state === INSIDE_BANANA) {
+                if (current === DELIMITER && next === DELIMITER) {
+                    currentReference += DELIMITER;
+                    i++;
+                } else if (current === DELIMITER) {
+                    state = OUTSIDE_BANANA;
+                    text += transformFn(currentReference);
+                    nontransformedText += currentReference;
+                    currentReference = "";
+                } else if (next !== undefined){
+                    currentReference += current;
+                } else {
+                    // end of string, shouldn't happen, but will not
+                    // overestimate users or Vellum devs
+                    text += DELIMITER + currentReference;
+                    nontransformedText += DELIMITER + currentReference;
+                    currentReference = "";
+                }
+            }
+        }
+
+        return {
+            text: text,
+            nontransformedText: nontransformedText,
+        };
+    }
 
     function getSymbols(string) {
         var index = 0;
@@ -21,55 +131,6 @@ define([], function() {
         }
         output.push(string.charAt(index));
         return output;
-    }
-
-    function parse(input, transform) {
-        input = getSymbols(input);
-        transform = transform || function (input) { return input; };
-
-        var state = OUTSIDE_BANANA,
-            strLen = input.length,
-            text = "",
-            references = [],
-            currentReference = "";
-
-        for (var i = 0; i < strLen; i++) {
-            var current = input[i],
-                next = input[i+1];
-
-            if (state === OUTSIDE_BANANA) {
-                if (current === DELIMITER && next === DELIMITER) {
-                    text += DELIMITER;
-                    i++;
-                } else if (current === DELIMITER) {
-                    state = INSIDE_BANANA;
-                } else {
-                    text += current;
-                }
-            } else if (state === INSIDE_BANANA) {
-                if (current === DELIMITER && next === DELIMITER) {
-                    currentReference += DELIMITER;
-                    i++;
-                } else if (current === DELIMITER) {
-                    state = OUTSIDE_BANANA;
-                    references.push(currentReference);
-                    text += transform(currentReference);
-                    currentReference = "";
-                } else if (next !== undefined){
-                    currentReference += current;
-                } else {
-                    // end of string, shouldn't happen, but will not
-                    // overestimate users or Vellum devs
-                    text += DELIMITER + currentReference;
-                    currentReference = "";
-                }
-            }
-        }
-
-        return {
-            text: text,
-            references: references,
-        };
     }
 
     return parse;

--- a/src/bananas.js
+++ b/src/bananas.js
@@ -51,10 +51,12 @@ define([
                     }
                 }
             } else if (node instanceof models.HashtagExpr) {
-                var blah = transformFn(node.toHashtag());
-                node.toHashtag = function() {
-                    return blah;
-                };
+                (function() {
+                    var oldToHashtag = node.toHashtag();
+                    node.toHashtag = function() {
+                        return transformFn(oldToHashtag());
+                    };
+                })();
             }
             children = node.getChildren();
             for (i = 0; i < children.length; i++) {

--- a/src/bananas.js
+++ b/src/bananas.js
@@ -16,6 +16,7 @@ define([
     }
 
     function toBanana(input, xpathParser) {
+        if (!input) { return input; }
         xpathParser = xpathParser || defaultParser;
 
         var parsedBanana = transform(input);
@@ -70,6 +71,7 @@ define([
     }
 
     function transform(input, transformFn) {
+        if (!input) { return input; }
         input = getSymbols(input);
         transformFn = transformFn || function (input) { return input; };
         var state = OUTSIDE_BANANA,

--- a/src/bananas.js
+++ b/src/bananas.js
@@ -22,6 +22,10 @@ define([
         });
     }
 
+    /*
+     * hopefully robust parser that transforms any input (whether hashtag,
+     * xpath, or banana) into banana used by internal structures
+     */
     function toBanana(input, xpathParser) {
         if (!input) { return input; }
         xpathParser = xpathParser || defaultParser;
@@ -43,6 +47,10 @@ define([
         }
     }
 
+    /*
+     * This takes in a parsed hashtag (from xpathParser.parse) and transforms
+     * each hashtag into whatever is defined by transformFn
+     */
     function transformHashtags(parsedHashtags, models, transformFn) {
         var queue = [parsedHashtags],
             EXPR = models.XPathInitialContextEnum.EXPR,
@@ -79,6 +87,9 @@ define([
         return parsedHashtags.toHashtag();
     }
 
+    /*
+     * transforms bananas based on transformFn
+     */
     function transform(input, transformFn) {
         if (!input) { return input; }
         input = getSymbols(input);
@@ -143,6 +154,9 @@ define([
         return output;
     }
 
+    /*
+     * extends xpath parser to be banana aware
+     */
     function Parser(hashtagDictionary) {
         var xpathParser = xpath.createParser(xpath.makeXPathModels(hashtagDictionary));
         return {

--- a/src/bananas.js
+++ b/src/bananas.js
@@ -134,7 +134,8 @@ define([
         return output;
     }
 
-    function Parser(xpathParser) {
+    function Parser(hashtagDictionary) {
+        var xpathParser = xpath.createParser(xpath.makeXPathModels(hashtagDictionary));
         return {
             parse: function (input) {
                 var parsed = xpathParser.parse(toXPath(input, xpathParser));

--- a/src/bananas.js
+++ b/src/bananas.js
@@ -15,6 +15,13 @@ define([
         });
     }
 
+    function toHashtag(input, xpathParser) {
+        xpathParser = xpathParser || defaultParser;
+        return transform(input, function(input) {
+            return xpathParser.parse(input).toHashtag();
+        });
+    }
+
     function toBanana(input, xpathParser) {
         if (!input) { return input; }
         xpathParser = xpathParser || defaultParser;
@@ -52,7 +59,7 @@ define([
                 }
             } else if (node instanceof models.HashtagExpr) {
                 (function() {
-                    var oldToHashtag = node.toHashtag();
+                    var oldToHashtag = node.toHashtag;
                     node.toHashtag = function() {
                         return transformFn(oldToHashtag());
                     };
@@ -140,9 +147,9 @@ define([
         var xpathParser = xpath.createParser(xpath.makeXPathModels(hashtagDictionary));
         return {
             parse: function (input) {
-                var parsed = xpathParser.parse(toXPath(input, xpathParser));
+                var parsed = xpathParser.parse(toHashtag(input, xpathParser));
                 parsed.toBanana = function() {
-                    return toBanana(input, xpathParser);
+                    return toBanana(this.toHashtag(), xpathParser);
                 };
                 return parsed;
             },

--- a/src/core.js
+++ b/src/core.js
@@ -2004,7 +2004,8 @@ define([
             "requiredAttr",
             "relevantAttr",
             "constraintAttr",
-            "repeat_count"
+            "repeat_count",
+            'defaultValue',
         ];
     };
 
@@ -2012,7 +2013,6 @@ define([
         return [
             "dataSource",
             "dataValue",
-            'defaultValue',
             "xmlnsAttr",
             "label",
             "hintLabel",

--- a/src/core.js
+++ b/src/core.js
@@ -1879,6 +1879,8 @@ define([
             data = {xform: formText};
         }
 
+        data.references = JSON.stringify(this.data.core.form._logicManager.caseReferences());
+
         this.data.core.saveButton.ajax({
             type: "POST",
             url: url,

--- a/src/databrowser.js
+++ b/src/databrowser.js
@@ -226,6 +226,14 @@ define([
             });
         });
 
+        // done here for performance reasons. would be nice to be done after
+        // every new hashtag, but only for the mugs that reference that hashtag
+        var form = vellum.data.core.form;
+        if (form) {
+            _.each(form.getMugList(), function(mug) {
+                form.fixBrokenReferences(mug);
+            });
+        }
         return nodes.concat(siblings);
     }
 
@@ -260,9 +268,6 @@ define([
         }
         if (form && form.addHashtag) {
             form.addHashtag(hashtag, fullPath, true);
-            _.each(form.getMugList(), function(mug) {
-                form.fixBrokenReferences(mug);
-            });
         }
     }
 

--- a/src/databrowser.js
+++ b/src/databrowser.js
@@ -146,7 +146,7 @@ define([
                 if (source) {
                     info = _.extend(_.omit(source, "structure"), {_parent: info});
                     path = "instance('" + source.id + "')" + source.path +
-                           "[" + ref.key + "=" + path + "]";
+                           "[" + ref.key + " = " + path + "]";
                     if (source.subsets && ref.subset) {
                         // magic: match key: "@case_type"
                         source = _.findWhere(

--- a/src/databrowser.js
+++ b/src/databrowser.js
@@ -253,15 +253,16 @@ define([
     function addHashtag(hashtag, fullPath, vellum) {
         var form = vellum.data.core.form,
             dataHashtags = vellum.data.core.databrowser.dataHashtags;
+
+        // if we get the same hashtag it will be due to recursive references
+        if (!dataHashtags.hasOwnProperty(hashtag)) {
+            dataHashtags[hashtag] = fullPath;
+        }
         if (form && form.addHashtag) {
-            // don't overwrite since if we get the same hashtag it will be due
-            // to recursive references
             form.addHashtag(hashtag, fullPath, true);
             _.each(form.getMugList(), function(mug) {
                 form.fixBrokenReferences(mug);
             });
-        } else {
-            dataHashtags[hashtag] = fullPath;
         }
     }
 

--- a/src/databrowser.js
+++ b/src/databrowser.js
@@ -5,7 +5,6 @@ define([
     'jquery',
     'underscore',
     'vellum/datasources',
-    'vellum/xpath',
     'vellum/widgets',
     'vellum/window',
     'tpl!vellum/templates/external_sources_tree',
@@ -13,7 +12,6 @@ define([
     $,
     _,
     datasources,
-    xpath,
     widgets,
     window_,
     external_sources_tree

--- a/src/databrowser.js
+++ b/src/databrowser.js
@@ -257,6 +257,9 @@ define([
             // don't overwrite since if we get the same hashtag it will be due
             // to recursive references
             form.addHashtag(hashtag, fullPath, true);
+            _.each(form.getMugList(), function(mug) {
+                form.fixBrokenReferences(mug);
+            });
         } else {
             dataHashtags[hashtag] = fullPath;
         }

--- a/src/form.js
+++ b/src/form.js
@@ -140,6 +140,9 @@ define([
     }
 
     Form.prototype = {
+        validHashtags: function() {
+            return _.keys(this.hashtagDictionary);
+        },
         addHashtag: function(hashtag, xpath, dontOverwrite) {
             if (!dontOverwrite || !this.hashtagDictionary.hasOwnProperty(hashtag)) {
                 this.hashtagDictionary[hashtag] = xpath;

--- a/src/form.js
+++ b/src/form.js
@@ -4,7 +4,6 @@ define([
     'jquery',
     'vellum/tree',
     'vellum/logic',
-    'vellum/xpath',
     'vellum/bananas',
     'vellum/util'
 ], function (
@@ -13,7 +12,6 @@ define([
     $,
     Tree,
     logic,
-    xpath,
     bananas,
     util
 ) {
@@ -159,7 +157,7 @@ define([
         },
         normalize: function (methodName, xpath) {
              // try catch is needed as workaround for having an itemset without
-             // the itemset plugin enabled
+             // the itemset plugin enabled and invalid xpaths
              try {
                 return xpath ? this.xpath.parse(xpath)[methodName]() : xpath;
              } catch (err) {

--- a/src/form.js
+++ b/src/form.js
@@ -140,8 +140,10 @@ define([
     }
 
     Form.prototype = {
-        addHashtag: function(hashtag, xpath) {
-            this.hashtagDictionary[hashtag] = xpath;
+        addHashtag: function(hashtag, xpath, dontOverwrite) {
+            if (!dontOverwrite || !this.hashtagDictionary.hasOwnProperty(hashtag)) {
+                this.hashtagDictionary[hashtag] = xpath;
+            }
         },
         removeHashtag: function(hashtag) {
             delete this.hashtagDictionary[hashtag];

--- a/src/form.js
+++ b/src/form.js
@@ -135,7 +135,7 @@ define([
         this.enableInstanceRefCounting = opts.enableInstanceRefCounting;
         this.errors = [];
         this.question_counter = 1;
-        this.xpath = bananas.Parser(xpath.createParser(xpath.makeXPathModels(this.hashtagDictionary)));
+        this.xpath = bananas.Parser(this.hashtagDictionary);
 
         //make the object event aware
         util.eventuality(this);

--- a/src/form.js
+++ b/src/form.js
@@ -160,12 +160,19 @@ define([
                 return xpath_;
             }
         },
-        normalizeXPath: function (xpath_, xpathParser) {
+        normalizeXPath: function (xpath_) {
             // if it's not an xpath just return the original string
             try {
                 return xpath_ ? this.xpath.parse(xpath_).toXPath() : xpath_;
             } catch (err) {
                 return xpath_;
+            }
+        },
+        hashtagsInXPath: function (xpath_) {
+            try {
+                return new logic.LogicExpression(xpath_, this.xpath).getHashtags();
+            } catch (err) {
+                return [];
             }
         },
         dataTree: function() {

--- a/src/form.js
+++ b/src/form.js
@@ -5,6 +5,7 @@ define([
     'vellum/tree',
     'vellum/logic',
     'vellum/xpath',
+    'vellum/bananas',
     'vellum/util'
 ], function (
     require,
@@ -13,6 +14,7 @@ define([
     Tree,
     logic,
     xpath,
+    bananas,
     util
 ) {
     // Load these dependencies in the background after all other run-time
@@ -133,7 +135,7 @@ define([
         this.enableInstanceRefCounting = opts.enableInstanceRefCounting;
         this.errors = [];
         this.question_counter = 1;
-        this.xpath = xpath.createParser(xpath.makeXPathModels(this.hashtagDictionary));
+        this.xpath = bananas.Parser(xpath.createParser(xpath.makeXPathModels(this.hashtagDictionary)));
 
         //make the object event aware
         util.eventuality(this);

--- a/src/form.js
+++ b/src/form.js
@@ -153,6 +153,15 @@ define([
         removeHashtag: function(hashtag) {
             delete this.hashtagDictionary[hashtag];
         },
+        normalizeBanana: function (xpath_) {
+            // try catch is needed as workaround for having an itemset without
+            // the itemset plugin enabled
+            try {
+                return xpath_ ? this.xpath.parse(xpath_).toBanana() : xpath_;
+            } catch (err) {
+                return xpath_;
+            }
+        },
         normalizeHashtag: function (xpath_) {
             // try catch is needed as workaround for having an itemset without
             // the itemset plugin enabled

--- a/src/form.js
+++ b/src/form.js
@@ -153,31 +153,27 @@ define([
         removeHashtag: function(hashtag) {
             delete this.hashtagDictionary[hashtag];
         },
+        transform: function(input, transformFn) {
+            input = this.normalizeBanana(input);
+            return bananas.transform(input, transformFn);
+        },
+        normalize: function (methodName, xpath) {
+             // try catch is needed as workaround for having an itemset without
+             // the itemset plugin enabled
+             try {
+                return xpath ? this.xpath.parse(xpath)[methodName]() : xpath;
+             } catch (err) {
+                return xpath;
+             }
+         },
         normalizeBanana: function (xpath_) {
-            // try catch is needed as workaround for having an itemset without
-            // the itemset plugin enabled
-            try {
-                return xpath_ ? this.xpath.parse(xpath_).toBanana() : xpath_;
-            } catch (err) {
-                return xpath_;
-            }
+            return this.normalize('toBanana', xpath_);
         },
         normalizeHashtag: function (xpath_) {
-            // try catch is needed as workaround for having an itemset without
-            // the itemset plugin enabled
-            try {
-                return xpath_ ? this.xpath.parse(xpath_).toHashtag() : xpath_;
-            } catch (err) {
-                return xpath_;
-            }
+            return this.normalize('toHashtag', xpath_);
         },
         normalizeXPath: function (xpath_) {
-            // if it's not an xpath just return the original string
-            try {
-                return xpath_ ? this.xpath.parse(xpath_).toXPath() : xpath_;
-            } catch (err) {
-                return xpath_;
-            }
+            return this.normalize('toXPath', xpath_);
         },
         hashtagsInXPath: function (xpath_) {
             try {

--- a/src/form.js
+++ b/src/form.js
@@ -205,7 +205,7 @@ define([
                 processChildren();
             });
             _.each(diffDataParents, function (mugs, dataParent) {
-                var dataParentMug = _this.mugMap[_this.normalizeHashtag(dataParent)];
+                var dataParentMug = _this.mugMap[_this.normalizeBanana(dataParent)];
                 for (var i = 0, len = mugs.length; i < len; i++) {
                     dataTree.insertMug(mugs[i], 'into', dataParentMug);
                 }
@@ -858,7 +858,7 @@ define([
         },
         _updateMugPath: function (mug, oldHashtag, newHashtag) {
             var map = this.mugMap, newPath;
-            delete map[this.normalizeHashtag(oldHashtag)];
+            delete map[this.normalizeBanana(oldHashtag)];
             if (oldHashtag) {
                 this.removeHashtag(oldHashtag);
             }
@@ -876,7 +876,7 @@ define([
                 if (newPath) {
                     this.addHashtag(newHashtag, newPath);
                 }
-                map[this.normalizeHashtag(newHashtag)] = mug;
+                map[this.normalizeBanana(newHashtag)] = mug;
             }
         },
         _fixMugState: function (mug) {
@@ -885,7 +885,7 @@ define([
             var path = mug.absolutePath;
             if (path) {
                 this.addHashtag(mug.hashtagPath, path);
-                this.mugMap[this.normalizeHashtag(mug.hashtagPath)] = mug;
+                this.mugMap[this.normalizeBanana(mug.hashtagPath)] = mug;
             }
         },
         fixBrokenReferences: function (mug) {
@@ -919,7 +919,7 @@ define([
             if(!path) { //no path specified
                 return null;
             }
-            return this.mugMap[this.normalizeHashtag(path)];
+            return this.mugMap[this.normalizeBanana(path)];
         },
         removeMugsFromForm: function (mugs) {
             function breakReferences(mug) {
@@ -947,7 +947,7 @@ define([
                 for (var i = 0; i < children.length; i++) {
                     this._removeMugFromForm(children[i], ufids, true);
                 }
-                delete this.mugMap[this.normalizeHashtag(mug.hashtagPath)];
+                delete this.mugMap[this.normalizeBanana(mug.hashtagPath)];
                 this.tree.removeMug(mug);
             }
             if (this.enableInstanceRefCounting) {

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -904,12 +904,12 @@ define([
                 lang = widget.language;
             }
             value = itextItem && itextItem.get(widget.form, lang);
-            return mug.supportsRichText() ? outputToHashtag(value, widget.mug.form.xpath) : outputToXPath(value, widget.mug.form.xpath);
+            return mug.supportsRichText() ? outputToBanana(value, widget.mug.form.xpath) : outputToXPath(value, widget.mug.form.xpath);
         };
 
         widget.setItextValue = function (value) {
             var itextItem = widget.getItextItem();
-            value = outputToHashtag(value, widget.mug.form.xpath);
+            value = outputToBanana(value, widget.mug.form.xpath);
             if (itextItem) {
                 if (widget.isDefaultLang) {
                     widget.mug.fire({
@@ -1585,8 +1585,8 @@ define([
 
             delete this.data.javaRosa.itextMap;
             var form = this.data.core.form;
-            function _toHashtag(value) {
-                return form.xpath.parse(value).toHashtag();
+            function _toBanana(value) {
+                return form.xpath.parse(value).toBanana();
             }
             forEachItextItem(form, function (item, mug) {
                 _(item.forms).each(function (itForm) {
@@ -1599,9 +1599,9 @@ define([
                                 value = output.attr('vellum:value') || output.attr('value'),
                                 ref = output.attr('vellum:ref') || output.attr('ref');
                             if (value) {
-                                return tempOutput.attr('value', _toHashtag(value))[0].outerHTML;
+                                return tempOutput.attr('value', _toBanana(value))[0].outerHTML;
                             } else if (ref) {
-                                return tempOutput.attr('ref', _toHashtag(ref))[0].outerHTML;
+                                return tempOutput.attr('ref', _toBanana(ref))[0].outerHTML;
                             }
                         });
                         itForm.setValue(lang, value.html());
@@ -2294,7 +2294,7 @@ define([
         }
     });
 
-    var outputToHashtag = _outputToXPathOrHashtag('toHashtag');
+    var outputToBanana = _outputToXPathOrHashtag('toBanana');
     var outputToXPath = _outputToXPathOrHashtag('toXPath');
 
     function _outputToXPathOrHashtag(functionName) {

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -1763,13 +1763,13 @@ define([
                 var value = $(outputRef).attr('value') || $(outputRef).attr('ref'),
                     key = $(outputRef).attr('value') ? 'value' : 'ref',
                     parsed = xpathParser.parse(value),
-                    hashtag = parsed.toHashtag(),
+                    banana = parsed.toBanana(),
                     xpath_ = parsed.toXPath(),
                     ret = $("<output>");
-                if (xpath_ === hashtag) {
+                if (xpath_ === banana) {
                     return ret.attr(key, xpath_)[0].outerHTML;
                 } else {
-                    return ret.attr(key, xpath_).attr('vellum:' + key, hashtag)[0].outerHTML;
+                    return ret.attr(key, xpath_).attr('vellum:' + key, banana)[0].outerHTML;
                 }
             }
 

--- a/src/less-style/labels.less
+++ b/src/less-style/labels.less
@@ -65,6 +65,21 @@
     }
 }
 
+.label-datanode-unknown {
+    color: @cc-att-neg-low;
+    border-color:darken(desaturate(@cc-att-neg-hi, 20%), 20%);
+    background-color: desaturate(@cc-att-neg-hi, 20%);
+    .close {
+        color: @cc-att-neg-low;
+    }
+    &:hover {
+        background-color: @cc-att-neg-mid;
+        .close {
+            color: @cc-att-neg-hi;
+        }
+    }
+}
+
 .datanode-tree-bubble {
     font-size: 11px;
     color: #ffffff;

--- a/src/less-style/popover.less
+++ b/src/less-style/popover.less
@@ -1,7 +1,5 @@
 // Styling for popovers for data node bubbles
-
 .rich-text-popover {
-    min-height: 150px !important;
     .border-radius(3px);
     word-wrap: break-word;
 

--- a/src/logic.js
+++ b/src/logic.js
@@ -162,7 +162,7 @@ define([
         },
         getText: function () {
             if (this._text && this.parsed) {
-                return this.parsed.toHashtag();
+                return this.parsed.toBanana();
             } else {
                 return this._text;
             }

--- a/src/logic.js
+++ b/src/logic.js
@@ -215,15 +215,18 @@ define([
                 var isHashtag = path.toHashtag().startsWith('#'),
                     pathString = isHashtag ? path.toHashtag() : path.pathWithoutPredicates(),
                     pathWithoutRoot = isHashtag ? '' : pathString.substring(1 + pathString.indexOf('/', 1)),
-                    refMug = form.getMugByPath(pathString) || pathString.startsWith('#case'),
-                    xpath = path.toHashtag();
+                    refMug = form.getMugByPath(pathString),
+                    xpath = path.toHashtag(),
+                    knownHashtag = pathString.startsWith('#case') && _.contains(form.validHashtags(), xpath);
 
                 // last part is hack to allow root node in data parents
-                if (!refMug &&
+                if ((!refMug && !knownHashtag) &&
                     (!mug.options.ignoreReferenceWarning || !mug.options.ignoreReferenceWarning(mug)) &&
                     _this.opts.allowedDataNodeReferences.indexOf(pathWithoutRoot) === -1 &&
                     !(property === "dataParent" && pathString === form.getBasePath().slice(0,-1)))
                 {
+                    unknowns.push(xpath);
+                } else if (!refMug && pathString.startsWith('#case') && !knownHashtag) {
                     unknowns.push(xpath);
                 }
                 return {

--- a/src/logic.js
+++ b/src/logic.js
@@ -215,7 +215,7 @@ define([
                 var isHashtag = path.toHashtag().startsWith('#'),
                     pathString = isHashtag ? path.toHashtag() : path.pathWithoutPredicates(),
                     pathWithoutRoot = isHashtag ? '' : pathString.substring(1 + pathString.indexOf('/', 1)),
-                    refMug = form.getMugByPath(pathString),
+                    refMug = form.getMugByPath(pathString) || pathString.startsWith('#case'),
                     xpath = path.toHashtag();
 
                 // last part is hack to allow root node in data parents
@@ -236,6 +236,12 @@ define([
             }));
             _.each(expr.instanceRefs, function (ignore, id) {
                 form.referenceInstance(id, mug, property);
+            });
+            _.each(expr.hashtags, function (hashtag) {
+                if (/^#case/.test(hashtag.toHashtag())) {
+                    form.referenceInstance('casedb', mug, property);
+                    form.referenceInstance('commcaresession', mug, property);
+                }
             });
             if (unknowns.length > 0) {
                 if (!this.errors[mug.ufid]) {

--- a/src/logic.js
+++ b/src/logic.js
@@ -374,7 +374,24 @@ define([
         },
         reset: function () {
             this.all = [];
-        }
+        },
+        caseReferences: function () {
+            return _.chain(this.all)
+                .filter(function(ref) {
+                    return ref.path.startsWith('#case');
+                })
+                .map(function(ref) {
+                    var info = ref.path.split('/'),
+                        type = info[1],
+                        prop = info[2];
+                    return {
+                        caseType: type,
+                        caseProperty: prop,
+                        question: ref.sourcePath.replace('#form', '/data'),
+                    };
+                })
+                .value();
+        },
     };
 
     return {

--- a/src/modeliteration.js
+++ b/src/modeliteration.js
@@ -39,7 +39,7 @@ define([
                 key: "id",
                 event: "jr-insert",
                 path: "/item",
-                query: "selected-at({}/@ids,../@index)"
+                query: "selected-at({}/@ids, ../@index)"
             }
         ],
         joinIdsRegexp = /^ *join\(['"] ['"], *(.*)\) *$/i,

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -913,8 +913,17 @@ define([
                 xpathType: 'generic',
                 serialize: serializeXPath,
                 deserialize: deserializeXPath,
-                help: "Referencing a node in this form may cause errors and/or " +
-                    "unexpected behavior",
+                validationFunc: function (mug) {
+                    var paths = new logic.LogicExpression(mug.p.defaultValue).getPaths();
+                    paths = _.filter(paths, function (path) {
+                        return path.initial_context !== xpathmodels.XPathInitialContextEnum.EXPR;
+                    });
+                    if (paths.length) {
+                        return "You are referencing a node in this form. " +
+                               "This can cause errors in the form";
+                    }
+                    return 'pass';
+                }
             },
             comment: {
                 lstring: 'Comment',

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -914,13 +914,13 @@ define([
                 serialize: serializeXPath,
                 deserialize: deserializeXPath,
                 validationFunc: function (mug) {
-                    var paths = new logic.LogicExpression(mug.p.defaultValue).getPaths();
-                    paths = _.filter(paths, function (path) {
-                        return path.initial_context !== xpathmodels.XPathInitialContextEnum.EXPR;
-                    });
-                    if (paths.length) {
-                        return "You are referencing a node in this form. " +
-                               "This can cause errors in the form";
+                    if (!mug.form.vellum.opts().features.allow_data_reference_in_setvalue) {
+                        var paths = mug.form.hashtagsInXPath(mug.p.defaultValue);
+                        paths =  _.filter(paths, function(path) { return path.namespace === 'form'; });
+                        if (paths.length) {
+                            return "You are referencing a node in this form. " +
+                                   "This can cause errors in the form";
+                        }
                     }
                     return 'pass';
                 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -495,15 +495,15 @@ define([
         if(!el){
             return null;
         }
-        var path = form.normalizeHashtag(parseVellumAttrs(form, el, 'ref', noPop)),
+        var path = parseVellumAttrs(form, el, 'ref', noPop),
             rootNodeName = form.tree.getRootNode().getID(),
             nodeId, pathToTry;
         if(!path){
-            path = form.normalizeHashtag(parseVellumAttrs(form, el, 'nodeset', noPop));
+            path = parseVellumAttrs(form, el, 'nodeset', noPop);
         }
         if (!path) {
             // attempt to support sloppy hand-written forms
-            nodeId = form.normalizeHashtag(parseVellumAttrs(form, el, 'bind', noPop));
+            nodeId = parseVellumAttrs(form, el, 'bind', noPop);
             if (nodeId) {
                 pathToTry = processPath(nodeId, rootNodeName, form);
                 if (!form.getMugByPath(pathToTry)) {
@@ -514,7 +514,7 @@ define([
             }
         }
         path = path || nodeId || null;
-        if (path && path[0] !== "/" && path[0] !== "#") {
+        if (path && path[0] !== "/" && path[0] !== "#" && path.slice(0, 2) !== "🍌") {
             // make path absolute
             if (parentMug) {
                 var parentPath = parentMug.hashtagPath;

--- a/src/parser.js
+++ b/src/parser.js
@@ -495,15 +495,15 @@ define([
         if(!el){
             return null;
         }
-        var path = parseVellumAttrs(form, el, 'ref', noPop),
+        var path = form.normalizeHashtag(parseVellumAttrs(form, el, 'ref', noPop)),
             rootNodeName = form.tree.getRootNode().getID(),
             nodeId, pathToTry;
         if(!path){
-            path = parseVellumAttrs(form, el, 'nodeset', noPop);
+            path = form.normalizeHashtag(parseVellumAttrs(form, el, 'nodeset', noPop));
         }
         if (!path) {
             // attempt to support sloppy hand-written forms
-            nodeId = parseVellumAttrs(form, el, 'bind', noPop);
+            nodeId = form.normalizeHashtag(parseVellumAttrs(form, el, 'bind', noPop));
             if (nodeId) {
                 pathToTry = processPath(nodeId, rootNodeName, form);
                 if (!form.getMugByPath(pathToTry)) {
@@ -653,7 +653,7 @@ define([
         var method = (noPop ? el.attr : el.popAttr).bind(el),
             vellumAttr = method('vellum:' + key),
             xmlAttr = method(key);
-        return form.normalizeHashtag(vellumAttr ? vellumAttr : xmlAttr);
+        return form.normalizeBanana(vellumAttr ? vellumAttr : xmlAttr);
     }
 
     var _getInstances = function (xml) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -204,15 +204,15 @@ define([
         setValues.each(function () {
             var $el = $(this);
             form.vellum.parseSetValue(
-                form, $el, processPath(parseVellumAttrs($el, 'ref', true), rootNodeName, form));
+                form, $el, processPath(parseVellumAttrs(form, $el, 'ref', true), rootNodeName, form));
         });
     }
 
     function parseSetValue(form, el, path) {
         var mug = form.getMugByPath(path),
             event = el.attr('event'),
-            ref = parseVellumAttrs(el, 'ref', true),
-            value = parseVellumAttrs(el, 'value', true);
+            ref = parseVellumAttrs(form, el, 'ref', true),
+            value = parseVellumAttrs(form, el, 'value', true);
 
         // HACK: hardcoding these as that's what setValue will support for now
         if (!mug || (event !== 'xforms-ready' && event !== 'jr-insert')) {
@@ -495,15 +495,15 @@ define([
         if(!el){
             return null;
         }
-        var path = parseVellumAttrs(el, 'ref', noPop),
+        var path = parseVellumAttrs(form, el, 'ref', noPop),
             rootNodeName = form.tree.getRootNode().getID(),
             nodeId, pathToTry;
         if(!path){
-            path = parseVellumAttrs(el, 'nodeset', noPop);
+            path = parseVellumAttrs(form, el, 'nodeset', noPop);
         }
         if (!path) {
             // attempt to support sloppy hand-written forms
-            nodeId = parseVellumAttrs(el, 'bind', noPop);
+            nodeId = parseVellumAttrs(form, el, 'bind', noPop);
             if (nodeId) {
                 pathToTry = processPath(nodeId, rootNodeName, form);
                 if (!form.getMugByPath(pathToTry)) {
@@ -614,7 +614,7 @@ define([
 
         bindList.each(function () {
             var el = $(this),
-                path = parseVellumAttrs(el, 'nodeset') || parseVellumAttrs(el, 'ref');
+                path = parseVellumAttrs(form, el, 'nodeset') || parseVellumAttrs(form, el, 'ref');
 
             form.vellum.parseBindElement(
                 form, el, processPath(path, rootNodeName, form));
@@ -632,9 +632,9 @@ define([
         }
 
         var attrs = {
-            relevantAttr: parseVellumAttrs(el, 'relevant'),
-            calculateAttr: parseVellumAttrs(el, 'calculate'),
-            constraintAttr: parseVellumAttrs(el, 'constraint'),
+            relevantAttr: parseVellumAttrs(form, el, 'relevant'),
+            calculateAttr: parseVellumAttrs(form, el, 'calculate'),
+            constraintAttr: parseVellumAttrs(form, el, 'constraint'),
             constraintMsgAttr: lookForNamespaced(el, "constraintMsg"),
             requiredAttr: parseBoolAttributeValue(el.popAttr('required')),
         };
@@ -649,11 +649,11 @@ define([
         mug.p.setAttrs(attrs);
     }
 
-    function parseVellumAttrs(el, key, noPop) {
+    function parseVellumAttrs(form, el, key, noPop) {
         var method = (noPop ? el.attr : el.popAttr).bind(el),
             vellumAttr = method('vellum:' + key),
             xmlAttr = method(key);
-        return vellumAttr ? vellumAttr : xmlAttr;
+        return form.normalizeHashtag(vellumAttr ? vellumAttr : xmlAttr);
     }
 
     var _getInstances = function (xml) {

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -33,4 +33,20 @@ define(function () {
         }
       });
     }
+    if (!String.prototype.endsWith) {
+      Object.defineProperty(String.prototype, 'endsWith', {
+        enumerable: false,
+        configurable: false,
+        writable: false,
+        value: function(searchString, position) {
+          var subjectString = this.toString();
+          if (typeof position !== 'number' || !isFinite(position) || Math.floor(position) !== position || position > subjectString.length) {
+            position = subjectString.length;
+          }
+          position -= searchString.length;
+          var lastIndex = subjectString.indexOf(searchString, position);
+          return lastIndex !== -1 && lastIndex === position;
+        }
+      });
+    }
 });

--- a/src/richText.js
+++ b/src/richText.js
@@ -404,7 +404,7 @@ define([
      */
     function replacePathWithBubble(form, value) {
         var info = extractXPathInfoFromOutputValue(value),
-            xpath = info.reference,
+            xpath = form.normalizeHashtag(info.reference),
             extraAttrs = _.omit(info, 'reference');
 
         // only support absolute path right now

--- a/src/richText.js
+++ b/src/richText.js
@@ -89,7 +89,7 @@ define([
                                 labelMug.p.labelItext.get() : "";
                 labelText = $('<div>').append(labelText);
                 labelText.find('output').replaceWith(function () {
-                    return extractXPathInfoFromOutputValue($(this).attr('value')).reference;
+                    return widget.mug.form.normalizeHashtag(extractXPathInfoFromOutputValue($(this).attr('value')).reference);
                 });
                 // Remove ckeditor-supplied title attributes, which will otherwise override popover title
                 $(this.dragHandlerContainer.$).children("img").removeAttr("title");
@@ -369,7 +369,7 @@ define([
      */
     function makeBubble(form, xpath, extraAttrs) {
         function _parseXPath(xpath, form) {
-            if (/^#case/.test(xpath)) {
+            if (/^(🍌)?#case/.test(xpath)) {
                 return {
                     classes: ['label-datanode-external', 'fcc fcc-fd-external-case']
                 };
@@ -411,7 +411,7 @@ define([
             extraAttrs = _.omit(info, 'reference');
 
         // only support absolute path right now
-        if (!form.getMugByPath(xpath) && !/^#case/.test(xpath)) {
+        if (!form.getMugByPath(xpath) && !/^(🍌)?#case/.test(xpath)) {
             return $('<span>').text(xml.normalize(value)).contents();
         }
 

--- a/src/richText.js
+++ b/src/richText.js
@@ -366,7 +366,7 @@ define([
      */
     function makeBubble(form, xpath, extraAttrs) {
         function _parseXPath(xpath, form) {
-            if (/^(🍌)?#case/.test(xpath)) {
+            if (/^🍌#case/.test(xpath)) {
                 return {
                     classes: ['label-datanode-external', 'fcc fcc-fd-external-case']
                 };
@@ -381,7 +381,7 @@ define([
                 }
             }
 
-            return {classes: ['label-datanode-external', 'fcc fcc-help']};
+            return {classes: ['label-datanode-unknown', 'fcc fcc-help']};
         }
 
         var xpathInfo = _parseXPath(xpath, form),
@@ -406,11 +406,6 @@ define([
         var info = extractXPathInfoFromOutputValue(value),
             xpath = form.normalizeBanana(info.reference),
             extraAttrs = _.omit(info, 'reference');
-
-        // only support absolute path right now
-        if (!form.getMugByPath(xpath) && !/^(🍌)?#case/.test(xpath)) {
-            return $('<span>').text(xml.normalize(value)).contents();
-        }
 
         return $('<div>').append(makeBubble(form, xpath, extraAttrs)).html();
     }

--- a/src/richText.js
+++ b/src/richText.js
@@ -118,6 +118,7 @@ define([
     CKEDITOR.config.customConfig = '';
     CKEDITOR.config.title = false;
     CKEDITOR.config.extraPlugins = 'bubbles';
+    CKEDITOR.config.disableNativeSpellChecker = false;
 
     /**
      * Get or create a rich text editor for the given element

--- a/src/richText.js
+++ b/src/richText.js
@@ -77,7 +77,7 @@ define([
                 getWidget = require('vellum/widgets').util.getWidget,
                 // TODO find out why widget is sometimes null (tests only?)
                 widget = getWidget($this);
-            if (/^🍌#(form|case)\//.test(xpath) && widget) {
+            if (widget) {
                 var isCase = /^🍌#case\//.test(xpath),
                     isText = function () { return this.nodeType === 3; },
                     displayId = $this.contents().filter(isText)[0].nodeValue,
@@ -380,6 +380,7 @@ define([
                     };
                 }
             }
+            
 
             return {classes: ['label-datanode-unknown', 'fcc fcc-help']};
         }
@@ -406,6 +407,10 @@ define([
         var info = extractXPathInfoFromOutputValue(value),
             xpath = form.normalizeBanana(info.reference),
             extraAttrs = _.omit(info, 'reference');
+
+        if (!/^(🍌)?#(form|case)/.test(xpath)) {
+            return $('<span>').text(xml.normalize(value)).contents();
+        }
 
         return $('<div>').append(makeBubble(form, xpath, extraAttrs)).html();
     }

--- a/src/richText.js
+++ b/src/richText.js
@@ -77,11 +77,8 @@ define([
                 getWidget = require('vellum/widgets').util.getWidget,
                 // TODO find out why widget is sometimes null (tests only?)
                 widget = getWidget($this);
-            if (widget) {
-                xpath = widget.mug.form.normalizeHashtag(xpath);
-            }
-            if (/^#(form|case)\//.test(xpath) && widget) {
-                var isCase = /^#case\//.test(xpath),
+            if (/^🍌#(form|case)\//.test(xpath) && widget) {
+                var isCase = /^🍌#case\//.test(xpath),
                     isText = function () { return this.nodeType === 3; },
                     displayId = $this.contents().filter(isText)[0].nodeValue,
                     labelMug = widget.mug.form.getMugByPath(xpath),
@@ -98,7 +95,7 @@ define([
                     container: 'body',
                     placement: 'bottom',
                     title: '<h3>' + util.escape(displayId) + '</h3>' +
-                           '<div class="text-muted">' + util.escape(xpath) + '</div>',
+                           '<div class="text-muted">' + util.escape(widget.mug.form.normalizeHashtag(xpath)) + '</div>',
                     html: true,
                     content: '<p>' + labelText.text() + '</p>',
                     template: '<div contenteditable="false" class="popover rich-text-popover">' +

--- a/src/richText.js
+++ b/src/richText.js
@@ -380,7 +380,6 @@ define([
                     };
                 }
             }
-            
 
             return {classes: ['label-datanode-unknown', 'fcc fcc-help']};
         }
@@ -408,7 +407,7 @@ define([
             xpath = form.normalizeBanana(info.reference),
             extraAttrs = _.omit(info, 'reference');
 
-        if (!/^(🍌)?#(form|case)/.test(xpath)) {
+        if (!/^🍌#(form|case)/.test(xpath)) {
             return $('<span>').text(xml.normalize(value)).contents();
         }
 

--- a/src/richText.js
+++ b/src/richText.js
@@ -77,7 +77,7 @@ define([
                 getWidget = require('vellum/widgets').util.getWidget,
                 // TODO find out why widget is sometimes null (tests only?)
                 widget = getWidget($this);
-            if (/^#form\//.test(xpath) && widget) {
+            if (/^#(form|case)\//.test(xpath) && widget) {
                 var isText = function () { return this.nodeType === 3; },
                     displayId = $this.contents().filter(isText)[0].nodeValue,
                     labelMug = widget.mug.form.getMugByPath(xpath),
@@ -365,7 +365,7 @@ define([
      */
     function makeBubble(form, xpath, extraAttrs) {
         function _parseXPath(xpath, form) {
-            if (/instance\('casedb'\)/.test(xpath)) {
+            if (/^#case/.test(xpath)) {
                 return {
                     classes: ['label-datanode-external', 'fcc fcc-fd-external-case']
                 };
@@ -407,7 +407,7 @@ define([
             extraAttrs = _.omit(info, 'reference');
 
         // only support absolute path right now
-        if (!form.getMugByPath(xpath) && !/instance\('casedb'\)/.test(xpath)) {
+        if (!form.getMugByPath(xpath) && !/^#case/.test(xpath)) {
             return $('<span>').text(xml.normalize(value)).contents();
         }
 
@@ -482,7 +482,7 @@ define([
                     return hashtag.toHashtag();
                 }));
 
-        _.each(paths, function(path) {
+        _.each(_.uniq(paths), function(path) {
             var newPath = replacePathWithBubble(form, path);
             el.html(el.html().replace(
                 new RegExp(RegExp.escape(path).replace(/ /g, '\\s*'), 'mg'),

--- a/src/richText.js
+++ b/src/richText.js
@@ -78,7 +78,8 @@ define([
                 // TODO find out why widget is sometimes null (tests only?)
                 widget = getWidget($this);
             if (/^#(form|case)\//.test(xpath) && widget) {
-                var isText = function () { return this.nodeType === 3; },
+                var isCase = /^#case\//.test(xpath),
+                    isText = function () { return this.nodeType === 3; },
                     displayId = $this.contents().filter(isText)[0].nodeValue,
                     labelMug = widget.mug.form.getMugByPath(xpath),
                     labelText = labelMug && labelMug.p.labelItext ?
@@ -100,7 +101,7 @@ define([
                     template: '<div contenteditable="false" class="popover rich-text-popover">' +
                         '<div class="popover-inner">' +
                         '<div class="popover-title"></div>' +
-                        '<div class="popover-content"><p></p></div>' +
+                        (isCase ? '' : '<div class="popover-content"><p></p></div>') +
                         '</div></div>'
                 });
             }

--- a/src/util.js
+++ b/src/util.js
@@ -308,11 +308,6 @@ define([
         if (!hashtagOrXPath) {
             // don't try to parse a value that doesn't exist
             return;
-        } else if (!mug) {
-            // handwritten setvalues aren't associated with a mug, but go
-            // through this method
-            xmlWriter.writeAttributeString(key, hashtagOrXPath);
-            return;
         } else if (mug.options && mug.options.ignoreHashtags) {
             xmlWriter.writeAttributeString(key, hashtagOrXPath);
             return;

--- a/src/util.js
+++ b/src/util.js
@@ -318,9 +318,15 @@ define([
             return;
         }
 
-        var expr = mug.form.xpath.parse(hashtagOrXPath),
-            xpath_ = expr.toXPath(),
+        var xpath_, hashtag;
+        try {
+            var expr = mug.form.xpath.parse(hashtagOrXPath);
+            xpath_ = expr.toXPath();
             hashtag = expr.toHashtag();
+        } catch (err) {
+            xmlWriter.writeAttributeString(key, hashtagOrXPath);
+            return; 
+        }
 
         if (hashtag !== xpath_) {
             xmlWriter.writeAttributeString('vellum:' + key, hashtag);

--- a/src/util.js
+++ b/src/util.js
@@ -322,7 +322,7 @@ define([
         try {
             var expr = mug.form.xpath.parse(hashtagOrXPath);
             xpath_ = expr.toXPath();
-            hashtag = expr.toHashtag();
+            hashtag = expr.toBanana();
         } catch (err) {
             xmlWriter.writeAttributeString(key, hashtagOrXPath);
             return; 

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -213,7 +213,7 @@ define([
             var ret = input.val().replace(/&#10;/g, '\n');
 
             if (ret && widget.hasLogicReferences) {
-                return mug.form.xpath.parse(ret).toHashtag();
+                return mug.form.normalizeBanana(ret);
             } else {
                 return ret;
             }

--- a/src/writer.js
+++ b/src/writer.js
@@ -193,7 +193,7 @@ define([
             xmlWriter.writeEndElement();
         }
 
-        _.each(form.getSetValues(), function (sv) { writeSetValue(sv); });
+        _.each(form.getSetValues(), function (sv) { writeSetValue(sv, {form: form}); });
 
         dataTree.walk(function (mug, nodeID, processChildren) {
             if(mug && mug.options.getSetValues) {

--- a/src/xpath.js
+++ b/src/xpath.js
@@ -7,7 +7,7 @@ define([
         makeXPathModels: function (hashtagToXPath) {
             return xpath.makeXPathModels({
                 isValidNamespace: function (namespace) {
-                    return namespace === 'form';
+                    return namespace === 'form' || namespace === 'case';
                 },
                 hashtagToXPath: function (hashtagExpr) {
                     if (hashtagToXPath.hasOwnProperty(hashtagExpr)) {

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -20,6 +20,7 @@
         "requirejs": false,
         /* MOCHA */
         "describe": false,
+        "context": false,
         "it": false,
         "before": false,
         "beforeEach": false,

--- a/tests/atwho.js
+++ b/tests/atwho.js
@@ -74,7 +74,8 @@ define([
                     return mug.displayName;
                 },
                 data: {
-                    atwho: {}
+                    atwho: {},
+                    core: {},
                 },
             },
             formUuid: 'test',

--- a/tests/bananas.js
+++ b/tests/bananas.js
@@ -1,9 +1,11 @@
 define([
     'chai',
     'vellum/bananas',
+    'vellum/xpath',
 ], function (
     chai,
-    bananas
+    bananas,
+    xpath
 ) {
     var assert = chai.assert;
 
@@ -15,7 +17,7 @@ define([
 
         var testCases = [
             ["🍌#case/type/prop🍌", "#case/type/prop", "prop"],
-            ["(🍌#case/type/prop🍌)", "(#case/type/prop)", "(prop)"], 
+            ["(🍌#case/type/prop🍌)", "(#case/type/prop)", "(prop)"],
             ["(🍌#case/type/prop🍌", "(#case/type/prop", "(prop"],
             [
                 "🍌#case/type/prop🍌 = 🍌#case/type/prop2🍌",
@@ -30,17 +32,53 @@ define([
             ["🍌🍌#case/type/🍌🍌prop🍌 = 🍌🍌", "🍌#case/type/🍌prop🍌 = 🍌", "🍌#case/type/🍌prop🍌 = 🍌"],
         ];
 
+        describe("#toBanana()", function() {
+            var testCases = [
+                    ["#form/text1", "🍌#form/text1🍌"],
+                    ["/data/text1", "🍌#form/text1🍌"],
+                    ["🍌#form/text1🍌", "🍌#form/text1🍌"],
+                ],
+                translationDict = {
+                    "#form/text1": "/data/text1",
+                    "#form/text2": "/data/text2",
+                },
+                xpathParser = xpath.createParser(xpath.makeXPathModels(translationDict));
+
+            testCases.forEach(function(testCase) {
+                it("should parse " + testCase[0] + " into " + testCase[1], function() {
+                    assert.strictEqual(bananas.toBanana(testCase[0], xpathParser), testCase[1]);
+                });
+            });
+        });
+
+        describe("#toXPath()", function() {
+            var testCases = [
+                    ["🍌#form/text1🍌", "/data/text1"],
+                ],
+                translationDict = {
+                    "#form/text1": "/data/text1",
+                    "#form/text2": "/data/text2",
+                },
+                xpathParser = xpath.createParser(xpath.makeXPathModels(translationDict));
+
+            testCases.forEach(function(testCase) {
+                it("should parse " + testCase[0] + " into " + testCase[1], function() {
+                    assert.strictEqual(bananas.toXPath(testCase[0], xpathParser), testCase[1]);
+                });
+            });
+        });
+
         testCases.forEach(function (testCase) {
             var input = testCase[0],
                 outputNoTransform = testCase[1],
                 outputToProp = testCase[2];
 
-            it("should parse " + input + " into " + outputNoTransform, function() {
-                assert.strictEqual(bananas(input), outputNoTransform);
+            it("default transform should parse " + input + " into " + outputNoTransform, function() {
+                assert.strictEqual(bananas.transform(input), outputNoTransform);
             });
 
-            it("should parse " + input + " into " + outputToProp, function() {
-                assert.strictEqual(bananas(input, transformToProperty), outputToProp);
+            it("custom transform should parse " + input + " into " + outputToProp, function() {
+                assert.strictEqual(bananas.transform(input, transformToProperty), outputToProp);
             });
         });
     });

--- a/tests/bananas.js
+++ b/tests/bananas.js
@@ -8,45 +8,39 @@ define([
     var assert = chai.assert;
 
     describe("The 🍌 parser", function () {
-        var testCases = [
-            ["🍌#case/type/prop🍌", "#case/type/prop", ["#case/type/prop"], "prop"],
-            ["(🍌#case/type/prop🍌)", "(#case/type/prop)", ["#case/type/prop"], "(prop)"],
-            ["(🍌#case/type/prop🍌", "(#case/type/prop", ["#case/type/prop"], "(prop"],
-            [
-                "🍌#case/type/prop🍌 = 🍌#case/type/prop2🍌",
-                "#case/type/prop = #case/type/prop2",
-                ["#case/type/prop", "#case/type/prop2"],
-                "prop = prop2"
-            ],
-            ["🍌🍌", "🍌", []],
-            ["🍊you glad I didn't use 🍌", "🍊you glad I didn't use 🍌", []],
-            ["🍌#case/type/prop🍌 = 🍌", "#case/type/prop = 🍌", ["#case/type/prop"], "prop = 🍌"],
-            ["🍌#case/type/prop🍌 = 🍌🍌", "#case/type/prop = 🍌", ["#case/type/prop"], "prop = 🍌"],
-            ["🍌#case/type/🍌🍌prop🍌 = 🍌🍌", "#case/type/🍌prop = 🍌", ["#case/type/🍌prop"], "🍌prop = 🍌"],
-            ["🍌🍌#case/type/🍌🍌prop🍌 = 🍌🍌", "🍌#case/type/🍌prop🍌 = 🍌", []],
-        ];
-
-        function transform(input) {
+        function transformToProperty(input) {
             var ret = input.split('/');
             return ret[ret.length-1];
         }
 
+        var testCases = [
+            ["🍌#case/type/prop🍌", "#case/type/prop", "prop"],
+            ["(🍌#case/type/prop🍌)", "(#case/type/prop)", "(prop)"], 
+            ["(🍌#case/type/prop🍌", "(#case/type/prop", "(prop"],
+            [
+                "🍌#case/type/prop🍌 = 🍌#case/type/prop2🍌",
+                "#case/type/prop = #case/type/prop2",
+                "prop = prop2",
+            ],
+            ["🍌🍌", "🍌", "🍌"],
+            ["🍊you glad I didn't use 🍌", "🍊you glad I didn't use 🍌", "🍊you glad I didn't use 🍌"],
+            ["🍌#case/type/prop🍌 = 🍌", "#case/type/prop = 🍌",  "prop = 🍌"],
+            ["🍌#case/type/prop🍌 = 🍌🍌", "#case/type/prop = 🍌", "prop = 🍌"],
+            ["🍌#case/type/🍌🍌prop🍌 = 🍌🍌", "#case/type/🍌prop = 🍌", "🍌prop = 🍌"],
+            ["🍌🍌#case/type/🍌🍌prop🍌 = 🍌🍌", "🍌#case/type/🍌prop🍌 = 🍌", "🍌#case/type/🍌prop🍌 = 🍌"],
+        ];
+
         testCases.forEach(function (testCase) {
             var input = testCase[0],
-                output = testCase[1],
-                references = testCase[2],
-                transformed = testCase[3] || output;
+                outputNoTransform = testCase[1],
+                outputToProp = testCase[2];
 
-            it("should parse " + input + " into " + output, function() {
-                assert.strictEqual(bananas(input).text, output);
+            it("should parse " + input + " into " + outputNoTransform, function() {
+                assert.strictEqual(bananas(input), outputNoTransform);
             });
 
-            it("should return " + references + " from " + input, function() {
-                assert.sameMembers(bananas(input).references, references);
-            });
-
-            it("should transform " + input + " to " + transformed, function() {
-                assert.strictEqual(bananas(input, transform).text, transformed);
+            it("should parse " + input + " into " + outputToProp, function() {
+                assert.strictEqual(bananas(input, transformToProperty), outputToProp);
             });
         });
     });

--- a/tests/bananas.js
+++ b/tests/bananas.js
@@ -1,0 +1,53 @@
+define([
+    'chai',
+    'vellum/bananas',
+], function (
+    chai,
+    bananas
+) {
+    var assert = chai.assert;
+
+    describe("The 🍌 parser", function () {
+        var testCases = [
+            ["🍌#case/type/prop🍌", "#case/type/prop", ["#case/type/prop"], "prop"],
+            ["(🍌#case/type/prop🍌)", "(#case/type/prop)", ["#case/type/prop"], "(prop)"],
+            ["(🍌#case/type/prop🍌", "(#case/type/prop", ["#case/type/prop"], "(prop"],
+            [
+                "🍌#case/type/prop🍌 = 🍌#case/type/prop2🍌",
+                "#case/type/prop = #case/type/prop2",
+                ["#case/type/prop", "#case/type/prop2"],
+                "prop = prop2"
+            ],
+            ["🍌🍌", "🍌", []],
+            ["🍊you glad I didn't use 🍌", "🍊you glad I didn't use 🍌", []],
+            ["🍌#case/type/prop🍌 = 🍌", "#case/type/prop = 🍌", ["#case/type/prop"], "prop = 🍌"],
+            ["🍌#case/type/prop🍌 = 🍌🍌", "#case/type/prop = 🍌", ["#case/type/prop"], "prop = 🍌"],
+            ["🍌#case/type/🍌🍌prop🍌 = 🍌🍌", "#case/type/🍌prop = 🍌", ["#case/type/🍌prop"], "🍌prop = 🍌"],
+            ["🍌🍌#case/type/🍌🍌prop🍌 = 🍌🍌", "🍌#case/type/🍌prop🍌 = 🍌", []],
+        ];
+
+        function transform(input) {
+            var ret = input.split('/');
+            return ret[ret.length-1];
+        }
+
+        testCases.forEach(function (testCase) {
+            var input = testCase[0],
+                output = testCase[1],
+                references = testCase[2],
+                transformed = testCase[3] || output;
+
+            it("should parse " + input + " into " + output, function() {
+                assert.strictEqual(bananas(input).text, output);
+            });
+
+            it("should return " + references + " from " + input, function() {
+                assert.sameMembers(bananas(input).references, references);
+            });
+
+            it("should transform " + input + " to " + transformed, function() {
+                assert.strictEqual(bananas(input, transform).text, transformed);
+            });
+        });
+    });
+});

--- a/tests/bananas.js
+++ b/tests/bananas.js
@@ -15,22 +15,38 @@ define([
             return ret[ret.length-1];
         }
 
-        var testCases = [
-            ["🍌#case/type/prop🍌", "#case/type/prop", "prop"],
-            ["(🍌#case/type/prop🍌)", "(#case/type/prop)", "(prop)"],
-            ["(🍌#case/type/prop🍌", "(#case/type/prop", "(prop"],
-            [
-                "🍌#case/type/prop🍌 = 🍌#case/type/prop2🍌",
-                "#case/type/prop = #case/type/prop2",
-                "prop = prop2",
-            ],
-            ["🍌🍌", "🍌", "🍌"],
-            ["🍊you glad I didn't use 🍌", "🍊you glad I didn't use 🍌", "🍊you glad I didn't use 🍌"],
-            ["🍌#case/type/prop🍌 = 🍌", "#case/type/prop = 🍌",  "prop = 🍌"],
-            ["🍌#case/type/prop🍌 = 🍌🍌", "#case/type/prop = 🍌", "prop = 🍌"],
-            ["🍌#case/type/🍌🍌prop🍌 = 🍌🍌", "#case/type/🍌prop = 🍌", "🍌prop = 🍌"],
-            ["🍌🍌#case/type/🍌🍌prop🍌 = 🍌🍌", "🍌#case/type/🍌prop🍌 = 🍌", "🍌#case/type/🍌prop🍌 = 🍌"],
-        ];
+        describe("#transform()", function() {
+            var testCases = [
+                ["🍌#case/type/prop🍌", "#case/type/prop", "prop"],
+                ["(🍌#case/type/prop🍌)", "(#case/type/prop)", "(prop)"],
+                ["(🍌#case/type/prop🍌", "(#case/type/prop", "(prop"],
+                [
+                    "🍌#case/type/prop🍌 = 🍌#case/type/prop2🍌",
+                    "#case/type/prop = #case/type/prop2",
+                    "prop = prop2",
+                ],
+                ["🍌🍌", "🍌", "🍌"],
+                ["🍊you glad I didn't use 🍌", "🍊you glad I didn't use 🍌", "🍊you glad I didn't use 🍌"],
+                ["🍌#case/type/prop🍌 = 🍌", "#case/type/prop = 🍌",  "prop = 🍌"],
+                ["🍌#case/type/prop🍌 = 🍌🍌", "#case/type/prop = 🍌", "prop = 🍌"],
+                ["🍌#case/type/🍌🍌prop🍌 = 🍌🍌", "#case/type/🍌prop = 🍌", "🍌prop = 🍌"],
+                ["🍌🍌#case/type/🍌🍌prop🍌 = 🍌🍌", "🍌#case/type/🍌prop🍌 = 🍌", "🍌#case/type/🍌prop🍌 = 🍌"],
+            ];
+
+            testCases.forEach(function (testCase) {
+                var input = testCase[0],
+                    outputNoTransform = testCase[1],
+                    outputToProp = testCase[2];
+
+                it("default transform should parse " + input + " into " + outputNoTransform, function() {
+                    assert.strictEqual(bananas.transform(input), outputNoTransform);
+                });
+
+                it("custom transform should parse " + input + " into " + outputToProp, function() {
+                    assert.strictEqual(bananas.transform(input, transformToProperty), outputToProp);
+                });
+            });
+        });
 
         describe("#toBanana()", function() {
             var testCases = [
@@ -65,20 +81,6 @@ define([
                 it("should parse " + testCase[0] + " into " + testCase[1], function() {
                     assert.strictEqual(bananas.toXPath(testCase[0], xpathParser), testCase[1]);
                 });
-            });
-        });
-
-        testCases.forEach(function (testCase) {
-            var input = testCase[0],
-                outputNoTransform = testCase[1],
-                outputToProp = testCase[2];
-
-            it("default transform should parse " + input + " into " + outputNoTransform, function() {
-                assert.strictEqual(bananas.transform(input), outputNoTransform);
-            });
-
-            it("custom transform should parse " + input + " into " + outputToProp, function() {
-                assert.strictEqual(bananas.transform(input, transformToProperty), outputToProp);
             });
         });
     });

--- a/tests/copy-paste.js
+++ b/tests/copy-paste.js
@@ -1020,7 +1020,7 @@ define([
                 ['/output', 'DataBindOnly', 'null', 'null',
                     "instance('scores')/score[@high > 🍌#form/score🍌][@low < 🍌#form/score🍌]",
                     '{"scores":{"children":"<score low=\\"0.0\\" high=\\"500.0\\">You\'re really bad</score><score low=\\"500.0\\" high=\\"99999999.0\\">You\'re really good</score>"}}'],
-                ['/result', 'Trigger', '<output value="#form/output"></output>', 'minimal', 'null', 'null'],
+                ['/result', 'Trigger', '<output value="🍌#form/output🍌"></output>', 'minimal', 'null', 'null'],
             ];
 
             it("should properly paste", function() {

--- a/tests/copy-paste.js
+++ b/tests/copy-paste.js
@@ -457,7 +457,7 @@ define([
                 ["id", "type", "calculateAttr"],
                 ["/radius", "DataBindOnly", "42"],
                 ["/pi", "DataBindOnly", "3.1415"],
-                ["/circumference", "DataBindOnly", "2 * #form/pi * #form/radius"],
+                ["/circumference", "DataBindOnly", "2 * 🍌#form/pi🍌 * 🍌#form/radius🍌"],
             ]);
         });
 
@@ -1018,7 +1018,7 @@ define([
                 ['id', 'type', 'labelItext:en-default', 'appearance', 'calculateAttr', 'instances'],
                 ['/score', 'Int', 'What was your score', 'null', 'null', 'null'],
                 ['/output', 'DataBindOnly', 'null', 'null',
-                    "instance('scores')/score[@high > #form/score][@low < #form/score]",
+                    "instance('scores')/score[@high > 🍌#form/score🍌][@low < 🍌#form/score🍌]",
                     '{"scores":{"children":"<score low=\\"0.0\\" high=\\"500.0\\">You\'re really bad</score><score low=\\"500.0\\" high=\\"99999999.0\\">You\'re really good</score>"}}'],
                 ['/result', 'Trigger', '<output value="#form/output"></output>', 'minimal', 'null', 'null'],
             ];

--- a/tests/core.js
+++ b/tests/core.js
@@ -87,7 +87,7 @@ define([
                 q2 = call("getMugByPath", "/data/question2");
             group.p.nodeID = "g8";
             assert.equal(q1.form.getAbsolutePath(q1), "/data/g8/question1");
-            assert.equal(q2.p.relevantAttr,
+            assert.strictEqual(q2.p.relevantAttr,
                 "#form/g8/question1 = 'valley girl' and #form/g8/question2 = 'dude'");
         });
 

--- a/tests/core.js
+++ b/tests/core.js
@@ -88,7 +88,7 @@ define([
             group.p.nodeID = "g8";
             assert.equal(q1.form.getAbsolutePath(q1), "/data/g8/question1");
             assert.strictEqual(q2.p.relevantAttr,
-                "#form/g8/question1 = 'valley girl' and #form/g8/question2 = 'dude'");
+                "🍌#form/g8/question1🍌 = 'valley girl' and 🍌#form/g8/question2🍌 = 'dude'");
         });
 
         it("should show warning icons on invalid questions", function () {

--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -2,6 +2,7 @@
 define([
     'tests/options',
     'tests/utils',
+    'vellum/util',
     'chai',
     'jquery',
     'underscore',
@@ -12,6 +13,7 @@ define([
 ], function (
     options,
     util,
+    vellum_util,
     chai,
     $,
     _,
@@ -68,24 +70,6 @@ define([
 
     describe("The data browser", function () {
         var dataTree;
-        before(function (done) {
-            util.init({
-                features: {rich_text: false},
-                plugins: plugins,
-                javaRosa: {langs: ['en']},
-                core: {
-                    dataSourcesEndpoint: function (callback) { callback(CASE_DATA); },
-                    onReady: function () {
-                        var _this = this;
-                        datasources.getDataSources(function () {
-                            databrowser.initDataBrowser(_this);
-                            dataTree = _this.$f.find(".fd-external-sources-tree").jstree(true);
-                            done();
-                        });
-                    }
-                }
-            });
-        });
 
         function getInstanceId(form, src) {
             var meta = _.find(form.instanceMetadata, function (meta) {
@@ -93,61 +77,122 @@ define([
             });
             return meta ? meta.attributes.id : null;
         }
+        context("when loaded before the form", function () {
+            before(function (done) {
+                util.init({
+                    features: {rich_text: false},
+                    plugins: plugins,
+                    javaRosa: {langs: ['en']},
+                    core: {
+                        dataSourcesEndpoint: function (callback) { callback(CASE_DATA); },
+                        onReady: function () {
+                            var _this = this;
+                            datasources.getDataSources(function () {
+                                databrowser.initDataBrowser(_this);
+                                dataTree = _this.$f.find(".fd-external-sources-tree").jstree(true);
+                                done();
+                            });
+                        }
+                    }
+                });
+            });
 
-        it("should add ref on drag/drop", function() {
-            util.loadXML("");
-            var mug = util.addQuestion("DataBindOnly", "mug"),
-                calc = $("[name=property-calculateAttr]"),
-                sessionUri = CASE_DATA[0].uri,
-                casedbUri = CASE_DATA[1].uri;
-            assert.equal(getInstanceId(mug.form, sessionUri), null);
-            assert.equal(getInstanceId(mug.form, casedbUri), null);
-            assert.equal(calc.length, 1);
-            util.findNode(dataTree, "dob").data.handleDrop(calc);
-            assert.equal(mug.p.calculateAttr, "#case/child/dob");
-            assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
-            assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
-            util.assertXmlEqual(call("createXML"), CHILD_REF_XML,
-                                {normalize_xmlns: true});
+            it("should add ref on drag/drop", function() {
+                util.loadXML("");
+                var mug = util.addQuestion("DataBindOnly", "mug"),
+                    calc = $("[name=property-calculateAttr]"),
+                    sessionUri = CASE_DATA[0].uri,
+                    casedbUri = CASE_DATA[1].uri;
+                assert.equal(getInstanceId(mug.form, sessionUri), null);
+                assert.equal(getInstanceId(mug.form, casedbUri), null);
+                assert.equal(calc.length, 1);
+                util.findNode(dataTree, "dob").data.handleDrop(calc);
+                assert.equal(mug.p.calculateAttr, "#case/child/dob");
+                assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
+                assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
+                util.assertXmlEqual(call("createXML"), CHILD_REF_XML,
+                                    {normalize_xmlns: true});
+            });
+
+            it("should add parent ref on drag/drop", function() {
+                util.loadXML("");
+                var mug = util.addQuestion("DataBindOnly", "mug"),
+                    calc = $("[name=property-calculateAttr]"),
+                    sessionUri = CASE_DATA[0].uri,
+                    casedbUri = CASE_DATA[1].uri;
+                assert.equal(getInstanceId(mug.form, sessionUri), null);
+                assert.equal(getInstanceId(mug.form, casedbUri), null);
+                assert.equal(calc.length, 1);
+                util.findNode(dataTree, "edd").data.handleDrop(calc);
+                assert.equal(mug.p.calculateAttr, "#case/mother/edd");
+                assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
+                assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
+                util.assertXmlEqual(call("createXML"), MOTHER_REF_XML,
+                                    {normalize_xmlns: true});
+            });
+
+            it("should add recursive ref on drag/drop", function() {
+                util.loadXML("");
+                var mug = util.addQuestion("DataBindOnly", "mug"),
+                    calc = $("[name=property-calculateAttr]"),
+                    sessionUri = CASE_DATA[0].uri,
+                    casedbUri = CASE_DATA[1].uri;
+                assert.equal(getInstanceId(mug.form, sessionUri), null);
+                assert.equal(getInstanceId(mug.form, casedbUri), null);
+                assert.equal(calc.length, 1);
+                var motherNode = util.findNode(dataTree, "mother"),
+                    node = util.findNode(dataTree, "child", motherNode);
+                dataTree.open_node(node);
+                util.findNode(dataTree, "dob", node).data.handleDrop(calc);
+                assert.equal(mug.p.calculateAttr, '#case/child/dob');
+                assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
+                assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
+                util.assertXmlEqual(call("createXML"), CHILD_REF_XML,
+                                    {normalize_xmlns: true});
+            });
+
+            // TODO should remove instances when expression ref is removed
         });
 
-        it("should add parent ref on drag/drop", function() {
-            util.loadXML("");
-            var mug = util.addQuestion("DataBindOnly", "mug"),
-                calc = $("[name=property-calculateAttr]"),
-                sessionUri = CASE_DATA[0].uri,
-                casedbUri = CASE_DATA[1].uri;
-            assert.equal(getInstanceId(mug.form, sessionUri), null);
-            assert.equal(getInstanceId(mug.form, casedbUri), null);
-            assert.equal(calc.length, 1);
-            util.findNode(dataTree, "edd").data.handleDrop(calc);
-            assert.equal(mug.p.calculateAttr, "#case/mother/edd");
-            assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
-            assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
-            util.assertXmlEqual(call("createXML"), MOTHER_REF_XML,
-                                {normalize_xmlns: true});
-        });
+        context("when loaded after the form", function () {
+            var _this, widget, blue, event = {};
+            vellum_util.eventuality(event);
+            function loadDataTree(done) {
+                datasources.getDataSources(function () {
+                    databrowser.initDataBrowser(_this);
+                    done();
+                });
+            }
+            before(function (done) {
+                util.init({
+                    plugins: plugins,
+                    javaRosa: {langs: ['en']},
+                    core: {
+                        dataSourcesEndpoint: function (callback) {
+                            event.on("nodeError", function() {
+                                callback(CASE_DATA);
+                            });
+                        },
+                        form: "",
+                        onReady: function () {
+                            _this = this;
+                            blue = util.addQuestion("DataBindOnly", "blue");
+                            widget = util.getWidget('property-calculateAttr');
+                            widget.input.promise.then(done);
+                        }
+                    }
+                });
+            });
 
-        it("should add recursive ref on drag/drop", function() {
-            util.loadXML("");
-            var mug = util.addQuestion("DataBindOnly", "mug"),
-                calc = $("[name=property-calculateAttr]"),
-                sessionUri = CASE_DATA[0].uri,
-                casedbUri = CASE_DATA[1].uri;
-            assert.equal(getInstanceId(mug.form, sessionUri), null);
-            assert.equal(getInstanceId(mug.form, casedbUri), null);
-            assert.equal(calc.length, 1);
-            var motherNode = util.findNode(dataTree, "mother"),
-                node = util.findNode(dataTree, "child", motherNode);
-            dataTree.open_node(node);
-            util.findNode(dataTree, "dob", node).data.handleDrop(calc);
-            assert.equal(mug.p.calculateAttr, '#case/child/dob');
-            assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
-            assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
-            util.assertXmlEqual(call("createXML"), CHILD_REF_XML,
-                                {normalize_xmlns: true});
+            it("should error for unknown properties", function(done) {
+                widget.setValue("#case/child/dob");
+                assert(!util.isTreeNodeValid(blue), "expected validation error");
+                event.fire("nodeError");
+                loadDataTree(function() {
+                    assert(util.isTreeNodeValid(blue), blue.getErrors().join("\n"));
+                    done();
+                });
+            });
         });
-
-        // TODO should remove instances when expression ref is removed
     });
 });

--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -109,7 +109,7 @@ define([
                 assert.equal(getInstanceId(mug.form, casedbUri), null);
                 assert.equal(calc.length, 1);
                 util.findNode(dataTree, "dob").data.handleDrop(calc);
-                assert.equal(mug.p.calculateAttr, "#case/child/dob");
+                assert.equal(mug.p.calculateAttr, "🍌#case/child/dob🍌");
                 assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
                 assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
                 util.assertXmlEqual(call("createXML"), CHILD_REF_XML,
@@ -126,7 +126,7 @@ define([
                 assert.equal(getInstanceId(mug.form, casedbUri), null);
                 assert.equal(calc.length, 1);
                 util.findNode(dataTree, "edd").data.handleDrop(calc);
-                assert.equal(mug.p.calculateAttr, "#case/mother/edd");
+                assert.equal(mug.p.calculateAttr, "🍌#case/mother/edd🍌");
                 assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
                 assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
                 util.assertXmlEqual(call("createXML"), MOTHER_REF_XML,
@@ -146,7 +146,7 @@ define([
                     node = util.findNode(dataTree, "child", motherNode);
                 dataTree.open_node(node);
                 util.findNode(dataTree, "dob", node).data.handleDrop(calc);
-                assert.equal(mug.p.calculateAttr, '#case/child/dob');
+                assert.equal(mug.p.calculateAttr, '🍌#case/child/dob🍌');
                 assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
                 assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
                 util.assertXmlEqual(call("createXML"), CHILD_REF_XML,
@@ -192,7 +192,7 @@ define([
             });
 
             it("should error for unknown properties", function(done) {
-                widget.setValue("#case/child/dob");
+                widget.setValue("🍌#case/child/dob🍌");
                 assert(!util.isTreeNodeValid(blue), "expected validation error");
                 event.fire("nodeError");
                 loadDataTree(function() {

--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -7,6 +7,8 @@ define([
     'underscore',
     'vellum/databrowser',
     'vellum/datasources',
+    'text!static/databrowser/child-ref.xml',
+    'text!static/databrowser/mother-ref.xml',
 ], function (
     options,
     util,
@@ -14,9 +16,12 @@ define([
     $,
     _,
     databrowser,
-    datasources
+    datasources,
+    CHILD_REF_XML,
+    MOTHER_REF_XML
 ) {
     var assert = chai.assert,
+        call = util.call,
         plugins = _.union(util.options.options.plugins || [], ["databrowser"]),
         CASE_DATA = [{
             id: "commcaresession",
@@ -94,16 +99,16 @@ define([
             var mug = util.addQuestion("DataBindOnly", "mug"),
                 calc = $("[name=property-calculateAttr]"),
                 sessionUri = CASE_DATA[0].uri,
-                casedbUri = CASE_DATA[1].uri,
-                where = "@case_id = instance('commcaresession')/session/data/case_id";
+                casedbUri = CASE_DATA[1].uri;
             assert.equal(getInstanceId(mug.form, sessionUri), null);
             assert.equal(getInstanceId(mug.form, casedbUri), null);
             assert.equal(calc.length, 1);
             util.findNode(dataTree, "dob").data.handleDrop(calc);
-            assert.equal(mug.p.calculateAttr,
-                         "instance('casedb')/cases/case[" + where + "]/dob");
+            assert.equal(mug.p.calculateAttr, "#case/child/dob");
             assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
             assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
+            util.assertXmlEqual(call("createXML"), CHILD_REF_XML,
+                                {normalize_xmlns: true});
         });
 
         it("should add parent ref on drag/drop", function() {
@@ -111,18 +116,16 @@ define([
             var mug = util.addQuestion("DataBindOnly", "mug"),
                 calc = $("[name=property-calculateAttr]"),
                 sessionUri = CASE_DATA[0].uri,
-                casedbUri = CASE_DATA[1].uri,
-                whereSession = "@case_id = instance('commcaresession')/session/data/case_id",
-                whereParent = "@case_id = instance('casedb')/cases/case[" +
-                              whereSession + "]/index/parent";
+                casedbUri = CASE_DATA[1].uri;
             assert.equal(getInstanceId(mug.form, sessionUri), null);
             assert.equal(getInstanceId(mug.form, casedbUri), null);
             assert.equal(calc.length, 1);
             util.findNode(dataTree, "edd").data.handleDrop(calc);
-            assert.equal(mug.p.calculateAttr,
-                         "instance('casedb')/cases/case[" + whereParent + "]/edd");
+            assert.equal(mug.p.calculateAttr, "#case/mother/edd");
             assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
             assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
+            util.assertXmlEqual(call("createXML"), MOTHER_REF_XML,
+                                {normalize_xmlns: true});
         });
 
         it("should add recursive ref on drag/drop", function() {
@@ -130,12 +133,7 @@ define([
             var mug = util.addQuestion("DataBindOnly", "mug"),
                 calc = $("[name=property-calculateAttr]"),
                 sessionUri = CASE_DATA[0].uri,
-                casedbUri = CASE_DATA[1].uri,
-                whereSession = "@case_id = instance('commcaresession')/session/data/case_id",
-                whereParent = "@case_id = instance('casedb')/cases/case[" +
-                              whereSession + "]/index/parent",
-                whereChild = "@case_id = instance('casedb')/cases/case[" +
-                             whereParent + "]/index/first-child";
+                casedbUri = CASE_DATA[1].uri;
             assert.equal(getInstanceId(mug.form, sessionUri), null);
             assert.equal(getInstanceId(mug.form, casedbUri), null);
             assert.equal(calc.length, 1);
@@ -143,10 +141,11 @@ define([
                 node = util.findNode(dataTree, "child", motherNode);
             dataTree.open_node(node);
             util.findNode(dataTree, "dob", node).data.handleDrop(calc);
-            assert.equal(mug.p.calculateAttr,
-                         "instance('casedb')/cases/case[" + whereChild + "]/dob");
+            assert.equal(mug.p.calculateAttr, '#case/child/dob');
             assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
             assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
+            util.assertXmlEqual(call("createXML"), CHILD_REF_XML,
+                                {normalize_xmlns: true});
         });
 
         // TODO should remove instances when expression ref is removed

--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -9,6 +9,7 @@ define([
     'vellum/databrowser',
     'vellum/datasources',
     'text!static/databrowser/child-ref.xml',
+    'text!static/databrowser/child-ref-no-hashtag.xml',
     'text!static/databrowser/mother-ref.xml',
 ], function (
     options,
@@ -20,6 +21,7 @@ define([
     databrowser,
     datasources,
     CHILD_REF_XML,
+    CHILD_REF_NO_HASHTAG_XML,
     MOTHER_REF_XML
 ) {
     var assert = chai.assert,
@@ -149,6 +151,11 @@ define([
                 assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
                 util.assertXmlEqual(call("createXML"), CHILD_REF_XML,
                                     {normalize_xmlns: true});
+            });
+
+            it("should hashtagify refs when written", function() {
+                util.loadXML(CHILD_REF_NO_HASHTAG_XML);
+                util.assertXmlEqual(call("createXML"), CHILD_REF_XML);
             });
 
             // TODO should remove instances when expression ref is removed

--- a/tests/diffDataParent.js
+++ b/tests/diffDataParent.js
@@ -58,11 +58,11 @@ define([
                 form = call("getData").core.form;
 
             util.addQuestion("Group", 'group1');
-            text2.p.dataParent = '#form/group1';
+            text2.p.dataParent = '🍌#form/group1🍌';
 
             form.moveMug(text2, 'before', text1);
 
-            assert.equal(text2.p.dataParent, '#form/group1');
+            assert.equal(text2.p.dataParent, '🍌#form/group1🍌');
         });
 
         it("should update data tree after a change to data parent", function() {
@@ -75,7 +75,7 @@ define([
             text1.p.dataParent = '#form/group1';
             assert.equal(text1.p.dataParent, "#form/group1");
             form.moveMug(group1, 'into', group2);
-            assert.equal(text1.p.dataParent, "#form/group2/group1");
+            assert.equal(text1.p.dataParent, "🍌#form/group2/group1🍌");
         });
 
         it("should clear the data parent when moving to a repeat group", function() {

--- a/tests/form.js
+++ b/tests/form.js
@@ -71,7 +71,7 @@ define([
 
             blue.p.nodeID = "orange";
             assert.equal(green.p.nodeID, "blue");
-            assert.equal(black.p.calculateAttr, "#form/orange + #form/blue");
+            assert.equal(black.p.calculateAttr, "🍌#form/orange🍌 + 🍌#form/blue🍌");
             assert(util.isTreeNodeValid(blue), blue.getErrors().join("\n"));
             assert(util.isTreeNodeValid(green), green.getErrors().join("\n"));
             assert(util.isTreeNodeValid(black), black.getErrors().join("\n"));
@@ -91,7 +91,7 @@ define([
 
             form.moveMug(text, "into", null);
             assert.equal(text.p.nodeID, "text");
-            assert.equal(hid.p.calculateAttr, "#form/text + #form/group/text");
+            assert.equal(hid.p.calculateAttr, "🍌#form/text🍌 + 🍌#form/group/text🍌");
             assert(util.isTreeNodeValid(text), text.getErrors().join("\n"));
         });
 
@@ -161,7 +161,7 @@ define([
             form.duplicateMug(group);
             var green2 = util.getMug("copy-1-of-group/green");
             assert.equal(green2.p.relevantAttr,
-                "#form/copy-1-of-group/blue = 'red' and #form/red = 'blue'");
+                "🍌#form/copy-1-of-group/blue🍌 = 'red' and 🍌#form/red🍌 = 'blue'");
         });
 
         it("should set non-standard form root node", function () {
@@ -216,7 +216,7 @@ define([
             repeat.p.repeat_count = '#form/text';
             assert.equal(repeat.p.repeat_count, '#form/text');
             text.p.nodeID = 'text2';
-            assert.equal(repeat.p.repeat_count, '#form/text2');
+            assert.equal(repeat.p.repeat_count, '🍌#form/text2🍌');
         });
 
         it ("should show warnings for duplicate choice value", function() {

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -373,7 +373,7 @@ define([
             vellum_util.setCaretPosition(target[0], 4);
             call("handleDropFinish", target, mug1.absolutePath, mug1);
             var val = mug2.p.labelItext.get('default', 'en');
-            assert.equal(val, 'test<output value="#form/question1"></output> string');
+            assert.equal(val, 'test<output value="🍌#form/question1🍌"></output> string');
             assert.equal(target.val(), 'test<output value="/data/question1" /> string');
         });
 
@@ -419,13 +419,13 @@ define([
                 q1 = util.call("getMugByPath", "/data/question1"),
                 itext = q1.p.labelItext;
 
-            assert(itext.get().indexOf('"#form/question2/question3"') > 0,
-                '"#form/question2/question3" not in ' + itext.get());
+            assert(itext.get().indexOf('"🍌#form/question2/question3🍌"') > 0,
+                '"🍌#form/question2/question3🍌" not in ' + itext.get());
             group.p.nodeID = "group";
-            assert(itext.get('default', 'en').indexOf('"#form/group/question3"') > 0,
-                '"#form/group/question3" not in ' + itext.get('default', 'en'));
-            assert(itext.get('default', 'hin').indexOf('"#form/group/question3"') > 0,
-                '"#form/group/question3" not in ' + itext.get('default', 'hin'));
+            assert(itext.get('default', 'en').indexOf('"🍌#form/group/question3🍌"') > 0,
+                '"🍌#form/group/question3🍌" not in ' + itext.get('default', 'en'));
+            assert(itext.get('default', 'hin').indexOf('"🍌#form/group/question3🍌"') > 0,
+                '"🍌#form/group/question🍌3" not in ' + itext.get('default', 'hin'));
         });
 
         it("should add warning on add Audio output ref to itext", function () {

--- a/tests/logic.js
+++ b/tests/logic.js
@@ -35,7 +35,7 @@ define([
             util.loadXML(TEST_XML_1);
             util.getMug("question1").p.nodeID = 'question';
             var mug = util.getMug("/data/question2");
-            assert.equal(mug.p.relevantAttr, "#form/question = 1");
+            assert.equal(mug.p.relevantAttr, "🍌#form/question🍌 = 1");
         });
 
         it("should not update expressions for model iteration", function () {

--- a/tests/logic.js
+++ b/tests/logic.js
@@ -35,7 +35,7 @@ define([
             util.loadXML(TEST_XML_1);
             util.getMug("question1").p.nodeID = 'question';
             var mug = util.getMug("/data/question2");
-            assert.equal("#form/question = 1", mug.p.relevantAttr);
+            assert.equal(mug.p.relevantAttr, "#form/question = 1");
         });
 
         it("should not update expressions for model iteration", function () {

--- a/tests/main.js
+++ b/tests/main.js
@@ -116,6 +116,7 @@ requirejs(['jquery', 'jquery.vellum'], function ($) {
         'tests/richText',
         'tests/comments',
         'tests/atwho',
+        'tests/bananas',
     ], function (
         options
     ) {

--- a/tests/modeliteration.js
+++ b/tests/modeliteration.js
@@ -148,8 +148,8 @@ define([
         });
 
         it("should not remove instance when ignore/retain is active", function () {
-            var normal = '<bind vellum:nodeset="#form/product/item" nodeset="/data/product/item" />',
-                ignore = '<bind vellum:nodeset="#form/product/item" nodeset="/data/product/item" wierd="true()" vellum:ignore="retain" />',
+            var normal = '<bind vellum:nodeset="🍌#form/product/item🍌" nodeset="/data/product/item" />',
+                ignore = '<bind vellum:nodeset="🍌#form/product/item🍌" nodeset="/data/product/item" wierd="true()" vellum:ignore="retain" />',
                 xml = FIXTURE_REPEAT_XML.replace(normal, normal + ignore);
             assert(xml.indexOf(ignore) > 0, ignore + " not found in XML:\n\n" + xml);
             util.loadXML(xml);

--- a/tests/modeliteration.js
+++ b/tests/modeliteration.js
@@ -64,7 +64,7 @@ define([
                 idsQuery: "instance('casedb')/mother/child/@case_id"
             });
             assert.equal(phone.__className, "PhoneNumber");
-            assert.equal(hidden.p.calculateAttr, "#form/group/item/phone = '12345'");
+            assert.equal(hidden.p.calculateAttr, "🍌#form/group/item/phone🍌 = '12345'");
             util.assertXmlEqual(call("createXML"), CASE_LIST_REPEAT_WITH_QUESTIONS_XML);
         });
 

--- a/tests/options.js
+++ b/tests/options.js
@@ -187,6 +187,7 @@ define(["underscore"], function (_) {
             'custom_intents': true,
             'image_resize': true,
             'markdown_in_groups': true,
+            'allow_data_reference_in_setvalue': true
         }
     };
 

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -86,7 +86,7 @@ define([
         it("should not drop newlines in calculate conditions", function () {
             util.loadXML(TEST_XML_2);
             var mug = call("getMugByPath", "/data/question1");
-            assert.equal(mug.p.calculateAttr, 'concat("Line 1","\nLine 2")');
+            assert.equal(mug.p.calculateAttr, 'concat("Line 1", "\nLine 2")');
         });
 
         var ignoreWarnings = /Form (JRM namespace|does not have a (Name|(UI)?Version))/;

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -144,7 +144,7 @@ define([
                 it("should override " + prop + " in question " + question, function() {
                     util.loadXML(OVERRIDE_XML);
                     var mug = util.getMug(question);
-                    assert.strictEqual(mug.p[prop], "#form/question1");
+                    assert.strictEqual(mug.p[prop], "🍌#form/question1🍌");
                 });
             });
 

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -30,6 +30,7 @@ define([
     'vellum/richText',
     'vellum/javaRosa',
     'vellum/xpath',
+    'vellum/bananas',
     'ckeditor',
     'text!static/richText/burpee.xml',
 ], function(
@@ -40,27 +41,36 @@ define([
     richText,
     javaRosa,
     xpath,
+    bananas,
     CKEDITOR,
     BURPEE_XML
 ) {
     var assert = chai.assert,
         hashtagToXPath = {},
         formShim = {
-            normalizeHashtag: function (path) {
-                return path;
+            normalizeBanana: function (path) {
+                 return path;
+             },
+            transform: function (path) {
+                return bananas.transform(path, function (path) {
+                    var mug = formShim.getMugByPath(path),
+                        icon_ = mug ? icon(mug.options.icon) : externalIcon();
+                    return $('<div>').html(makeBubble(path, path.split('/').slice(-1)[0], icon_, !!mug)).html();
+                });
             },
+
             getMugByPath: function(path) {
                 return {
-                    "/data/text": {
+                    "#form/text": {
                         options: { icon: 'fcc fcc-fd-text' },
                     },
-                    "/data/othertext": {
+                    "#form/othertext": {
                         options: { icon: 'fcc fcc-fd-text' },
                     },
-                    "/data/date": {
+                    "#form/date": {
                         options: { icon: 'fcc fa fa-calendar' },
                     },
-                    "/data/group": {
+                    "#form/group": {
                         options: { icon: 'fcc icon-folder-open' },
                     },
                 }[path];
@@ -105,9 +115,9 @@ define([
         describe("simple conversions", function() {
             // path, display value, icon
             var simpleConversions = [
-                    ['/data/text', 'text', icon('fcc-fd-text'), true],
-                    ["#case/child/case", 'case', externalIcon(), false],
-                    ["#case/mother/edd", 'edd', externalIcon(), false]
+                    ['🍌#form/text🍌', 'text', icon('fcc-fd-text'), true],
+                    ["🍌#case/child/case🍌", 'case', externalIcon(), false],
+                    ["🍌#case/mother/edd🍌", 'edd', externalIcon(), false]
                 ],
                 opts = {isExpression: true};
 
@@ -115,14 +125,14 @@ define([
                 it("from text to html: " + val[0], function() {
                     assert.strictEqual(
                         wrapWithDiv(richText.toRichText(val[0], formShim, opts)).html(),
-                        wrapWithDivP(makeBubble(val[0], val[1], val[2], val[3])).html()
+                        wrapWithDivP(makeBubble(val[0].slice(2,-2), val[1], val[2], val[3])).html()
                     );
                 });
 
                 it("from text to html with output value: " + val[0], function() {
                     assert.strictEqual(
-                        wrapWithDiv(richText.toRichText(outputValueTemplateFn(val[0]), formShim)).html(),
-                        wrapWithDivP(makeOutputValue(val[0], val[1], val[2], val[3])).html()
+                        wrapWithDiv(richText.toRichText(outputValueTemplateFn(val[0].slice(2, -2)), formShim)).html(),
+                        wrapWithDivP(makeOutputValue(val[0].slice(2,-2), val[1], val[2], val[3])).html()
                     );
                 });
             });
@@ -131,8 +141,8 @@ define([
         describe("date conversions", function() {
             var dates = [
                     {
-                        xmlValue: "format-date(date(/data/date), '%d/%n/%y')",
-                        valueInBubble: '/data/date',
+                        xmlValue: "format-date(date(#form/date), '%d/%n/%y')",
+                        valueInBubble: '#form/date',
                         bubbleDispValue: 'date',
                         icon: icon('fa fa-calendar'),
                         internalRef: true,
@@ -154,30 +164,30 @@ define([
 
             it("bubble a drag+drop reference", function() {
                 var fmt = "%d/%n/%y",
-                    tag = javaRosa.getOutputRef("/data/text", fmt),
+                    tag = javaRosa.getOutputRef("#form/text", fmt),
                     bubble = richText.toRichText(tag, formShim);
                 assert.strictEqual($(bubble).find('span').data('date-format'), fmt);
             });
         });
 
         describe("equation conversions", function() {
-            var f_1065 = "#case/child/f_1065",
+            var f_1065 = "🍌#case/child/f_1065🍌",
                 ico = icon('fcc-fd-text'),
                 equations = [
                     [
-                        "/data/text = /data/othertext",
-                        wrapWithDiv(makeBubble('/data/text', 'text', ico, true)).html() + " = " +
-                        wrapWithDiv(makeBubble('/data/othertext', 'othertext', ico, true)).html()
+                        "🍌#form/text🍌 = 🍌#form/othertext🍌",
+                        wrapWithDiv(makeBubble('#form/text', 'text', ico, true)).html() + " = " +
+                        wrapWithDiv(makeBubble('#form/othertext', 'othertext', ico, true)).html()
                     ],
                     [
-                        "/data/text <= /data/othertext",
-                        wrapWithDiv(makeBubble('/data/text', 'text', ico, true)).html() + " &lt;= " +
-                        wrapWithDiv(makeBubble('/data/othertext', 'othertext', ico, true)).html()
+                        "🍌#form/text🍌 <= 🍌#form/othertext🍌",
+                        wrapWithDiv(makeBubble('#form/text', 'text', ico, true)).html() + " &lt;= " +
+                        wrapWithDiv(makeBubble('#form/othertext', 'othertext', ico, true)).html()
                     ],
                     [
                         f_1065 + " = " + f_1065,
-                        wrapWithDiv(makeBubble(f_1065, 'f_1065', icon('fcc-fd-external-case'))).html() + " = " +
-                        wrapWithDiv(makeBubble(f_1065, 'f_1065', icon('fcc-fd-external-case'))).html()
+                        wrapWithDiv(makeBubble(f_1065.slice(2,-2), 'f_1065', icon('fcc-fd-external-case'))).html() + " = " +
+                        wrapWithDiv(makeBubble(f_1065.slice(2,-2), 'f_1065', icon('fcc-fd-external-case'))).html()
                     ],
                 ],
                 opts = {isExpression: true};
@@ -256,12 +266,12 @@ define([
 
         describe("convert value with output and escaped HTML", function () {
             var items = [
-                    ['<h1><output value="/data/text" /></h1>',
+                    ['<h1><output value="#form/text" /></h1>',
                      '&lt;h1&gt;{text}&lt;/h1&gt;'],
-                    ['<output value="/data/text" /> <tag /> <output value="/data/othertext" />',
+                    ['<output value="#form/text" /> <tag /> <output value="#form/othertext" />',
                      '{text} &lt;tag /&gt; {othertext}'],
                     ["{blah}", "{blah}"],
-                    ['<output value="unknown(/data/text)" />', '&lt;output value="unknown(/data/text)" /&gt;'],
+                    ['<output value="unknown(#form/text)" />', '&lt;output value="unknown(#form/text)" /&gt;'],
                 ],
                 ico = icon('fcc-fd-text');
 
@@ -269,8 +279,8 @@ define([
                 it("to text: " + item[0], function () {
                     var result = richText.bubbleOutputs(item[0], formShim, true),
                         expect = item[1].replace(/{(.*?)}/g, function (m, name) {
-                            if (formShim.getMugByPath("/data/" + name)) {
-                                var output = makeOutputValue("/data/" + name, name, ico, true);
+                            if (formShim.getMugByPath("#form/" + name)) {
+                                var output = makeOutputValue("#form/" + name, name, ico, true);
                                 return output[0].outerHTML;
                             }
                             return m;
@@ -316,25 +326,25 @@ define([
             });
 
             it("should return just-set value on get value", function () {
-                var text = '<output value="/data/text" />';
+                var text = '<output value="#form/text" />';
                 assert.notEqual(editor.getValue(), text);
                 editor.setValue(text);
                 assert.equal(editor.getValue(), text);
             });
 
             it("should create output on insert expression into label editor", function (done) {
-                var output = '<output value="/data/text" />';
+                var output = '<output value="#form/text" />';
                 editor.setValue('one two', function () {
                     assert.equal(editor.getValue(), 'one two');
                     editor.select(3);
-                    editor.insertExpression("/data/text");
+                    editor.insertExpression("#form/text");
                     assert.equal(editor.getValue(), "one" + output + " two");
                     done();
                 });
             });
 
             it("should insert output into label editor", function (done) {
-                var output = '<output value="/data/text" />';
+                var output = '<output value="#form/text" />';
                 editor.setValue('one two', function () {
                     assert.equal(editor.getValue(), 'one two');
                     editor.select(3);

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -46,6 +46,9 @@ define([
     var assert = chai.assert,
         hashtagToXPath = {},
         formShim = {
+            normalizeHashtag: function (path) {
+                return path;
+            },
             getMugByPath: function(path) {
                 return {
                     "/data/text": {

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -103,12 +103,8 @@ define([
             // path, display value, icon
             var simpleConversions = [
                     ['/data/text', 'text', icon('fcc-fd-text'), true],
-                    ["instance('casedb')/cases/case" +
-                     "[@case_id = instance('commcaresession')/session/data/case_id]",
-                     'case', externalIcon(), false],
-                    ["instance('casedb')/cases/case[@case_id = instance('casedb')/cases/case" +
-                     "[@case_id = instance('commcaresession')/session/data/case_id]" +
-                     "/index/parent]/edd", 'edd', externalIcon(), false]
+                    ["#case/child/case", 'case', externalIcon(), false],
+                    ["#case/mother/edd", 'edd', externalIcon(), false]
                 ],
                 opts = {isExpression: true};
 
@@ -162,9 +158,7 @@ define([
         });
 
         describe("equation conversions", function() {
-            var f_1065 = "instance('casedb')/cases/case[" +
-                            "@case_id = instance('commcaresession')/session/data/case_id" +
-                         "]/f_1065",
+            var f_1065 = "#case/child/f_1065",
                 ico = icon('fcc-fd-text'),
                 equations = [
                     [

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -53,7 +53,7 @@ define([
                 return bananas.transform(path, function (path) {
                     var mug = formShim.getMugByPath(path),
                         icon_ = mug ? icon(mug.options.icon) : externalIcon();
-                    return $('<div>').html(makeBubble(path, path.split('/').slice(-1)[0], icon_, !!mug)).html();
+                    return $('<div>').html(makeBubble("🍌" + path + "🍌", path.split('/').slice(-1)[0], icon_, !!mug)).html();
                 });
             },
             getMugByPath: function(path) {
@@ -127,14 +127,14 @@ define([
             _.each(simpleConversions, function(val) {
                 it("from text to html: " + val[0], function() {
                     assert.strictEqual(
-                        wrapWithDiv(richText.toRichText(val[0], formShim, opts)).html(),
-                        wrapWithDivP(makeBubble(val[0].slice(2,-2), val[1], val[2], val[3])).html()
+                        richText.toRichText(val[0], formShim, opts),
+                        wrapWithDivP(makeBubble(val[0], val[1], val[2], val[3])).html()
                     );
                 });
 
                 it("from text to html with output value: " + val[0], function() {
                     assert.strictEqual(
-                        wrapWithDiv(richText.toRichText(outputValueTemplateFn(val[0]), formShim)).html(),
+                        richText.toRichText(outputValueTemplateFn(val[0]), formShim),
                         wrapWithDivP(makeOutputValue(val[0], val[1], val[2], val[3])).html()
                     );
                 });
@@ -144,8 +144,8 @@ define([
         describe("date conversions", function() {
             var dates = [
                     {
-                        xmlValue: "format-date(date(#form/date), '%d/%n/%y')",
-                        valueInBubble: '#form/date',
+                        xmlValue: "format-date(date(🍌#form/date🍌), '%d/%n/%y')",
+                        valueInBubble: '🍌#form/date🍌',
                         bubbleDispValue: 'date',
                         icon: icon('fa fa-calendar'),
                         internalRef: true,
@@ -167,7 +167,7 @@ define([
 
             it("bubble a drag+drop reference", function() {
                 var fmt = "%d/%n/%y",
-                    tag = javaRosa.getOutputRef("#form/text", fmt),
+                    tag = javaRosa.getOutputRef("🍌#form/text🍌", fmt),
                     bubble = richText.toRichText(tag, formShim);
                 assert.strictEqual($(bubble).find('span').data('date-format'), fmt);
             });
@@ -179,18 +179,18 @@ define([
                 equations = [
                     [
                         "🍌#form/text🍌 = 🍌#form/othertext🍌",
-                        wrapWithDiv(makeBubble('#form/text', 'text', ico, true)).html() + " = " +
-                        wrapWithDiv(makeBubble('#form/othertext', 'othertext', ico, true)).html()
+                        wrapWithDiv(makeBubble('🍌#form/text🍌', 'text', ico, true)).html() + " = " +
+                        wrapWithDiv(makeBubble('🍌#form/othertext🍌', 'othertext', ico, true)).html()
                     ],
                     [
                         "🍌#form/text🍌 <= 🍌#form/othertext🍌",
-                        wrapWithDiv(makeBubble('#form/text', 'text', ico, true)).html() + " &lt;= " +
-                        wrapWithDiv(makeBubble('#form/othertext', 'othertext', ico, true)).html()
+                        wrapWithDiv(makeBubble('🍌#form/text🍌', 'text', ico, true)).html() + " &lt;= " +
+                        wrapWithDiv(makeBubble('🍌#form/othertext🍌', 'othertext', ico, true)).html()
                     ],
                     [
                         f_1065 + " = " + f_1065,
-                        wrapWithDiv(makeBubble(f_1065.slice(2,-2), 'f_1065', icon('fcc-fd-external-case'))).html() + " = " +
-                        wrapWithDiv(makeBubble(f_1065.slice(2,-2), 'f_1065', icon('fcc-fd-external-case'))).html()
+                        wrapWithDiv(makeBubble(f_1065, 'f_1065', icon('fcc-fd-external-case'))).html() + " = " +
+                        wrapWithDiv(makeBubble(f_1065, 'f_1065', icon('fcc-fd-external-case'))).html()
                     ],
                 ],
                 opts = {isExpression: true};
@@ -269,9 +269,9 @@ define([
 
         describe("convert value with output and escaped HTML", function () {
             var items = [
-                    ['<h1><output value="#form/text" /></h1>',
+                    ['<h1><output value="🍌#form/text🍌" /></h1>',
                      '&lt;h1&gt;{text}&lt;/h1&gt;'],
-                    ['<output value="#form/text" /> <tag /> <output value="#form/othertext" />',
+                    ['<output value="🍌#form/text🍌" /> <tag /> <output value="🍌#form/othertext🍌" />',
                      '{text} &lt;tag /&gt; {othertext}'],
                     ["{blah}", "{blah}"],
                     ['<output value="unknown(#form/text)" />', '&lt;output value="unknown(#form/text)" /&gt;'],
@@ -282,8 +282,8 @@ define([
                 it("to text: " + item[0], function () {
                     var result = richText.bubbleOutputs(item[0], formShim, true),
                         expect = item[1].replace(/{(.*?)}/g, function (m, name) {
-                            if (formShim.getMugByPath("#form/" + name)) {
-                                var output = makeOutputValue("#form/" + name, name, ico, true);
+                            if (formShim.getMugByPath("🍌#form/" + name + "🍌")) {
+                                var output = makeOutputValue("🍌#form/" + name + "🍌", name, ico, true);
                                 return output[0].outerHTML;
                             }
                             return m;

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -29,7 +29,6 @@ define([
     'tests/utils',
     'vellum/richText',
     'vellum/javaRosa',
-    'vellum/xpath',
     'vellum/bananas',
     'ckeditor',
     'text!static/richText/burpee.xml',
@@ -40,7 +39,6 @@ define([
     util,
     richText,
     javaRosa,
-    xpath,
     bananas,
     CKEDITOR,
     BURPEE_XML
@@ -58,8 +56,13 @@ define([
                     return $('<div>').html(makeBubble(path, path.split('/').slice(-1)[0], icon_, !!mug)).html();
                 });
             },
-
             getMugByPath: function(path) {
+                if (path.startsWith("🍌")) {
+                    path = path.slice(2);
+                }
+                if (path.endsWith("🍌")) {
+                    path = path.slice(0, -2);
+                }
                 return {
                     "#form/text": {
                         options: { icon: 'fcc fcc-fd-text' },
@@ -75,7 +78,7 @@ define([
                     },
                 }[path];
             },
-            xpath: xpath.createParser(xpath.makeXPathModels(hashtagToXPath)),
+            xpath: bananas.Parser(hashtagToXPath),
         };
 
     function icon(iconClass) { 
@@ -131,8 +134,8 @@ define([
 
                 it("from text to html with output value: " + val[0], function() {
                     assert.strictEqual(
-                        wrapWithDiv(richText.toRichText(outputValueTemplateFn(val[0].slice(2, -2)), formShim)).html(),
-                        wrapWithDivP(makeOutputValue(val[0].slice(2,-2), val[1], val[2], val[3])).html()
+                        wrapWithDiv(richText.toRichText(outputValueTemplateFn(val[0]), formShim)).html(),
+                        wrapWithDivP(makeOutputValue(val[0], val[1], val[2], val[3])).html()
                     );
                 });
             });

--- a/tests/setvalue.js
+++ b/tests/setvalue.js
@@ -69,20 +69,60 @@ define([
             assert.strictEqual(setvalue.attr('value'), 'blah');
         });
 
-        it("should warn when referencing another node", function() {
-            util.loadXML("");
-            util.addQuestion("Text", 'text1');
-            var text2 = util.addQuestion("Text", 'text2');
-            text2.p.defaultValue = '/data/text1';
-            assert.notStrictEqual(text2.spec.defaultValue.validationFunc(text2), 'pass');
+        context("with allow data reference enabled", function () {
+            before(function (done) {
+                util.init({
+                    javaRosa: {langs: ['en']},
+                    core: {onReady: done},
+                    features: {
+                        rich_text: false,
+                        allow_data_reference_in_setvalue: true,
+                    },
+                });
+            });
+            it("should not warn when referencing another node", function() {
+                util.loadXML("");
+                util.addQuestion("Text", 'text1');
+                var text2 = util.addQuestion("Text", 'text2');
+                text2.p.defaultValue = '#form/text1';
+                assert.strictEqual(text2.spec.defaultValue.validationFunc(text2), 'pass');
+            });
+
+            it("should not warn when referencing a case", function() {
+                util.loadXML("");
+                util.addQuestion("Text", 'text1');
+                var text2 = util.addQuestion("Text", 'text2');
+                text2.p.defaultValue = "#case/case/attribute";
+                assert.strictEqual(text2.spec.defaultValue.validationFunc(text2), 'pass');
+            });
         });
 
-        it("should not warn when referencing a case", function() {
-            util.loadXML("");
-            util.addQuestion("Text", 'text1');
-            var text2 = util.addQuestion("Text", 'text2');
-            text2.p.defaultValue = "instance('casedb')/case/attribute";
-            assert.strictEqual(text2.spec.defaultValue.validationFunc(text2), 'pass');
+        context("without allow data reference enabled", function () {
+            before(function (done) {
+                util.init({
+                    javaRosa: {langs: ['en']},
+                    core: {onReady: done},
+                    features: {
+                        rich_text: false,
+                        allow_data_reference_in_setvalue: false,
+                    },
+                });
+            });
+            it("should warn when referencing another node", function() {
+                util.loadXML("");
+                util.addQuestion("Text", 'text1');
+                var text2 = util.addQuestion("Text", 'text2');
+                text2.p.defaultValue = '#form/text1';
+                assert.notStrictEqual(text2.spec.defaultValue.validationFunc(text2), 'pass');
+            });
+
+            it("should not warn when referencing a case", function() {
+                util.loadXML("");
+                util.addQuestion("Text", 'text1');
+                var text2 = util.addQuestion("Text", 'text2');
+                text2.p.defaultValue = "#case/case/attribute";
+                assert.strictEqual(text2.spec.defaultValue.validationFunc(text2), 'pass');
+            });
         });
     });
 });

--- a/tests/setvalue.js
+++ b/tests/setvalue.js
@@ -68,5 +68,21 @@ define([
             assert.strictEqual(setvalue.attr('ref'), '/data/text');
             assert.strictEqual(setvalue.attr('value'), 'blah');
         });
+
+        it("should warn when referencing another node", function() {
+            util.loadXML("");
+            util.addQuestion("Text", 'text1');
+            var text2 = util.addQuestion("Text", 'text2');
+            text2.p.defaultValue = '/data/text1';
+            assert.notStrictEqual(text2.spec.defaultValue.validationFunc(text2), 'pass');
+        });
+
+        it("should not warn when referencing a case", function() {
+            util.loadXML("");
+            util.addQuestion("Text", 'text1');
+            var text2 = util.addQuestion("Text", 'text2');
+            text2.p.defaultValue = "instance('casedb')/case/attribute";
+            assert.strictEqual(text2.spec.defaultValue.validationFunc(text2), 'pass');
+        });
     });
 });

--- a/tests/static/all_question_types.tsv
+++ b/tests/static/all_question_types.tsv
@@ -1,5 +1,5 @@
 Question	Type	Text (en)	Text (hin)	Audio (en)	Audio (hin)	Image (en)	Image (hin)	Display Condition	Validation Condition	Validation Message	Calculate Condition	Required
-/question1	Text	question1 en label	question1 hin label	jr://file/commcare/audio/data/question1.mp3	jr://file/commcare/audio/data/question1.mp3	jr://file/commcare/image/data/question1.png	jr://file/commcare/image/data/question1.png	#form/question20	#form/question20 = 2	question1 en validation		yes
+/question1	Text	question1 en label	question1 hin label	jr://file/commcare/audio/data/question1.mp3	jr://file/commcare/audio/data/question1.mp3	jr://file/commcare/image/data/question1.png	jr://file/commcare/image/data/question1.png	🍌#form/question20🍌	🍌#form/question20🍌 = 2	question1 en validation		yes
 /question2	Label	question2	question2									no
 /question30	Label	question30	question30									no
 /question3	Multiple Choice	question3	question3									no

--- a/tests/static/all_question_types.xml
+++ b/tests/static/all_question_types.xml
@@ -39,36 +39,36 @@
 				</data>
 			</instance>
 			<instance src="jr://instance/casedb" id="casedb"></instance>
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="xsd:string" vellum:constraint="#form/question20 = 2" constraint="/data/question20 = 2" vellum:relevant="#form/question20" relevant="/data/question20" jr:constraintMsg="jr:itext('question1-constraintMsg')" required="true()" />
-			<bind vellum:nodeset="#form/question2" nodeset="/data/question2" />
-			<bind vellum:nodeset="#form/question30" nodeset="/data/question30" />
-			<bind vellum:nodeset="#form/question3" nodeset="/data/question3" />
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" type="xsd:string" vellum:constraint="🍌#form/question20🍌 = 2" constraint="/data/question20 = 2" vellum:relevant="🍌#form/question20🍌" relevant="/data/question20" jr:constraintMsg="jr:itext('question1-constraintMsg')" required="true()" />
+			<bind vellum:nodeset="🍌#form/question2🍌" nodeset="/data/question2" />
+			<bind vellum:nodeset="🍌#form/question30🍌" nodeset="/data/question30" />
+			<bind vellum:nodeset="🍌#form/question3🍌" nodeset="/data/question3" />
 			<!-- arbitrary bind attributes -->
-			<bind vellum:nodeset="#form/question6" nodeset="/data/question6" spam="eggs" />
-			<bind vellum:nodeset="#form/question13" nodeset="/data/question13" type="xsd:int" />
-			<bind vellum:nodeset="#form/question14" nodeset="/data/question14" type="xsd:string" />
-			<bind vellum:nodeset="#form/question15" nodeset="/data/question15" type="xsd:double" />
-			<bind vellum:nodeset="#form/question16" nodeset="/data/question16" type="xsd:long" />
-			<bind vellum:nodeset="#form/question17" nodeset="/data/question17" type="xsd:date" />
-			<bind vellum:nodeset="#form/question18" nodeset="/data/question18" type="xsd:time" />
-			<bind vellum:nodeset="#form/question19" nodeset="/data/question19" type="xsd:dateTime" />
-			<bind vellum:nodeset="#form/question21" nodeset="/data/question21" />
-			<bind vellum:nodeset="#form/question21/question31" nodeset="/data/question21/question31" />
-			<bind vellum:nodeset="#form/question22" nodeset="/data/question22" />
-			<bind vellum:nodeset="#form/question22/question23" nodeset="/data/question22/question23" />
-			<bind vellum:nodeset="#form/question22/question23/question40" nodeset="/data/question22/question23/question40" />
-			<bind vellum:nodeset="#form/question22/question23/question41" nodeset="/data/question22/question23/question41" />
-			<bind vellum:nodeset="#form/question22/question23/question24" nodeset="/data/question22/question23/question24" type="binary" />
-			<bind vellum:nodeset="#form/question22/question23/question25" nodeset="/data/question22/question23/question25" type="binary" />
-			<bind vellum:nodeset="#form/question22/question23/question26" nodeset="/data/question22/question23/question26" type="binary" />
-			<bind vellum:nodeset="#form/question22/question23/question27" nodeset="/data/question22/question23/question27" type="geopoint" />
-			<bind vellum:nodeset="#form/question22/question23/question28" nodeset="/data/question22/question23/question28" type="xsd:string" />
-			<bind vellum:nodeset="#form/question22/question23/question29" nodeset="/data/question22/question23/question29" type="binary" />
-			<bind vellum:nodeset="#form/question22/question23/question7" nodeset="/data/question22/question23/question7" type="intent" />
-			<bind vellum:nodeset="#form/question20" nodeset="/data/question20" />
-			<bind vellum:nodeset="#form/question32" nodeset="/data/question32" calculate="1 + 2" />
+			<bind vellum:nodeset="🍌#form/question6🍌" nodeset="/data/question6" spam="eggs" />
+			<bind vellum:nodeset="🍌#form/question13🍌" nodeset="/data/question13" type="xsd:int" />
+			<bind vellum:nodeset="🍌#form/question14🍌" nodeset="/data/question14" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/question15🍌" nodeset="/data/question15" type="xsd:double" />
+			<bind vellum:nodeset="🍌#form/question16🍌" nodeset="/data/question16" type="xsd:long" />
+			<bind vellum:nodeset="🍌#form/question17🍌" nodeset="/data/question17" type="xsd:date" />
+			<bind vellum:nodeset="🍌#form/question18🍌" nodeset="/data/question18" type="xsd:time" />
+			<bind vellum:nodeset="🍌#form/question19🍌" nodeset="/data/question19" type="xsd:dateTime" />
+			<bind vellum:nodeset="🍌#form/question21🍌" nodeset="/data/question21" />
+			<bind vellum:nodeset="🍌#form/question21/question31🍌" nodeset="/data/question21/question31" />
+			<bind vellum:nodeset="🍌#form/question22🍌" nodeset="/data/question22" />
+			<bind vellum:nodeset="🍌#form/question22/question23🍌" nodeset="/data/question22/question23" />
+			<bind vellum:nodeset="🍌#form/question22/question23/question40🍌" nodeset="/data/question22/question23/question40" />
+			<bind vellum:nodeset="🍌#form/question22/question23/question41🍌" nodeset="/data/question22/question23/question41" />
+			<bind vellum:nodeset="🍌#form/question22/question23/question24🍌" nodeset="/data/question22/question23/question24" type="binary" />
+			<bind vellum:nodeset="🍌#form/question22/question23/question25🍌" nodeset="/data/question22/question23/question25" type="binary" />
+			<bind vellum:nodeset="🍌#form/question22/question23/question26🍌" nodeset="/data/question22/question23/question26" type="binary" />
+			<bind vellum:nodeset="🍌#form/question22/question23/question27🍌" nodeset="/data/question22/question23/question27" type="geopoint" />
+			<bind vellum:nodeset="🍌#form/question22/question23/question28🍌" nodeset="/data/question22/question23/question28" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/question22/question23/question29🍌" nodeset="/data/question22/question23/question29" type="binary" />
+			<bind vellum:nodeset="🍌#form/question22/question23/question7🍌" nodeset="/data/question22/question23/question7" type="intent" />
+			<bind vellum:nodeset="🍌#form/question20🍌" nodeset="/data/question20" />
+			<bind vellum:nodeset="🍌#form/question32🍌" nodeset="/data/question32" calculate="1 + 2" />
 			<!-- setvalues -->
-			<setvalue event="xforms-ready" vellum:ref="#form/question1" ref="/data/question1" value="2" />
+			<setvalue event="xforms-ready" vellum:ref="🍌#form/question1🍌" ref="/data/question1" value="2" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="question1-label">
@@ -310,19 +310,19 @@
 		</odkx:intent>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/question1" ref="/data/question1">
+		<input vellum:ref="🍌#form/question1🍌" ref="/data/question1">
 			<label ref="jr:itext('question1-label')">non-itext label</label>
 			<hint ref="jr:itext('question1-hint')">non-itext hint</hint>
 			<help ref="jr:itext('question1-help')" />
 			<alert ref="jr:itext('question1-constraintMsg')" />
 		</input>
-		<trigger vellum:ref="#form/question2" ref="/data/question2" appearance="minimal">
+		<trigger vellum:ref="🍌#form/question2🍌" ref="/data/question2" appearance="minimal">
 			<label ref="jr:itext('question2-label')" />
 		</trigger>
-		<trigger vellum:ref="#form/question30" ref="/data/question30">
+		<trigger vellum:ref="🍌#form/question30🍌" ref="/data/question30">
 			<label ref="jr:itext('question30-label')" />
 		</trigger>
-		<select1 vellum:ref="#form/question3" ref="/data/question3">
+		<select1 vellum:ref="🍌#form/question3🍌" ref="/data/question3">
 			<label ref="jr:itext('question3-label')" />
 			<item>
 				<label ref="jr:itext('question3-choice1-label')" />
@@ -334,7 +334,7 @@
 			</item>
 		</select1>
 		<!-- arbitrary control attributes -->
-		<select vellum:ref="#form/question6" ref="/data/question6" foo="baz">
+		<select vellum:ref="🍌#form/question6🍌" ref="/data/question6" foo="baz">
 			<label ref="jr:itext('question6-label')" />
 			<item>
 				<label ref="jr:itext('question6-choice1-label')" />
@@ -345,65 +345,65 @@
 				<value>choice2</value>
 			</item>
 		</select>
-		<input vellum:ref="#form/question13" ref="/data/question13">
+		<input vellum:ref="🍌#form/question13🍌" ref="/data/question13">
 			<label ref="jr:itext('question13-label')" />
 		</input>
-		<input vellum:ref="#form/question14" ref="/data/question14" appearance="numeric">
+		<input vellum:ref="🍌#form/question14🍌" ref="/data/question14" appearance="numeric">
 			<label ref="jr:itext('question14-label')" />
 		</input>
-		<input vellum:ref="#form/question15" ref="/data/question15">
+		<input vellum:ref="🍌#form/question15🍌" ref="/data/question15">
 			<label ref="jr:itext('question15-label')" />
 		</input>
-		<input vellum:ref="#form/question16" ref="/data/question16">
+		<input vellum:ref="🍌#form/question16🍌" ref="/data/question16">
 			<label ref="jr:itext('question16-label')" />
 		</input>
-		<input vellum:ref="#form/question17" ref="/data/question17">
+		<input vellum:ref="🍌#form/question17🍌" ref="/data/question17">
 			<label ref="jr:itext('question17-label')" />
 		</input>
-		<input vellum:ref="#form/question18" ref="/data/question18">
+		<input vellum:ref="🍌#form/question18🍌" ref="/data/question18">
 			<label ref="jr:itext('question18-label')" />
 		</input>
-		<input vellum:ref="#form/question19" ref="/data/question19">
+		<input vellum:ref="🍌#form/question19🍌" ref="/data/question19">
 			<label ref="jr:itext('question19-label')" />
 		</input>
-		<group vellum:ref="#form/question21" ref="/data/question21">
+		<group vellum:ref="🍌#form/question21🍌" ref="/data/question21">
 			<label ref="jr:itext('question21-label')" />
 			<group>
 				<label ref="jr:itext('question21/question31-label')" />
-				<repeat jr:noAddRemove="true()"  vellum:nodeset="#form/question21/question31" nodeset="/data/question21/question31" jr:count="2" />
+				<repeat jr:noAddRemove="true()"  vellum:nodeset="🍌#form/question21/question31🍌" nodeset="/data/question21/question31" jr:count="2" />
 			</group>
 		</group>
 		<group>
 			<label ref="jr:itext('question22-label')" />
-			<repeat vellum:nodeset="#form/question22" nodeset="/data/question22">
-				<group vellum:ref="#form/question22/question23" ref="/data/question22/question23" appearance="field-list">
+			<repeat vellum:nodeset="🍌#form/question22🍌" nodeset="/data/question22">
+				<group vellum:ref="🍌#form/question22/question23🍌" ref="/data/question22/question23" appearance="field-list">
 					<label ref="jr:itext('question22/question23-label')" />
-					<group vellum:ref="#form/question22/question23/question40" ref="/data/question22/question23/question40">
+					<group vellum:ref="🍌#form/question22/question23/question40🍌" ref="/data/question22/question23/question40">
 						<label ref="jr:itext('question22/question23/question40-label')" />
 					</group>
 					<group>
 						<label ref="jr:itext('question22/question23/question41-label')" />
-						<repeat vellum:nodeset="#form/question22/question23/question41" nodeset="/data/question22/question23/question41" />
+						<repeat vellum:nodeset="🍌#form/question22/question23/question41🍌" nodeset="/data/question22/question23/question41" />
 					</group>
-					<upload vellum:ref="#form/question22/question23/question24" ref="/data/question22/question23/question24" mediatype="image/*" jr:imageDimensionScaledMax="250px">
+					<upload vellum:ref="🍌#form/question22/question23/question24🍌" ref="/data/question22/question23/question24" mediatype="image/*" jr:imageDimensionScaledMax="250px">
 						<label ref="jr:itext('question22/question23/question24-label')" />
 					</upload>
-					<upload vellum:ref="#form/question22/question23/question25" ref="/data/question22/question23/question25" mediatype="audio/*">
+					<upload vellum:ref="🍌#form/question22/question23/question25🍌" ref="/data/question22/question23/question25" mediatype="audio/*">
 						<label ref="jr:itext('question22/question23/question25-label')" />
 					</upload>
-					<upload vellum:ref="#form/question22/question23/question26" ref="/data/question22/question23/question26" mediatype="video/*">
+					<upload vellum:ref="🍌#form/question22/question23/question26🍌" ref="/data/question22/question23/question26" mediatype="video/*">
 						<label ref="jr:itext('question22/question23/question26-label')" />
 					</upload>
-					<input vellum:ref="#form/question22/question23/question27" ref="/data/question22/question23/question27">
+					<input vellum:ref="🍌#form/question22/question23/question27🍌" ref="/data/question22/question23/question27">
 						<label ref="jr:itext('question22/question23/question27-label')" />
 					</input>
-					<secret vellum:ref="#form/question22/question23/question28" ref="/data/question22/question23/question28">
+					<secret vellum:ref="🍌#form/question22/question23/question28🍌" ref="/data/question22/question23/question28">
 						<label ref="jr:itext('question22/question23/question28-label')" />
 					</secret>
-					<upload vellum:ref="#form/question22/question23/question29" ref="/data/question22/question23/question29" mediatype="image/*" appearance="signature">
+					<upload vellum:ref="🍌#form/question22/question23/question29🍌" ref="/data/question22/question23/question29" mediatype="image/*" appearance="signature">
 						<label ref="jr:itext('question22/question23/question29-label')" />
 					</upload>
-					<input vellum:ref="#form/question22/question23/question7" ref="/data/question22/question23/question7" appearance="intent:question7">
+					<input vellum:ref="🍌#form/question22/question23/question7🍌" ref="/data/question22/question23/question7" appearance="intent:question7">
 						<label ref="jr:itext('question22/question23/question7-label')" />
 					</input>
 				</group>

--- a/tests/static/comments/comment-test.xml
+++ b/tests/static/comments/comment-test.xml
@@ -8,7 +8,7 @@
 					<mug vellum:comment="This is a comment" />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/mug" nodeset="/data/mug" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/mug🍌" nodeset="/data/mug" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="mug-label">
@@ -19,7 +19,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/mug" ref="/data/mug">
+		<input vellum:ref="🍌#form/mug🍌" ref="/data/mug">
 			<label ref="jr:itext('mug-label')" />
 		</input>
 	</h:body>

--- a/tests/static/commtrack/balance-block.xml
+++ b/tests/static/commtrack/balance-block.xml
@@ -14,9 +14,9 @@
 			<instance id="ledger" src="jr://instance/ledgerdb" />
 			<instance id="commcaresession" src="jr://instance/session" />
 			<instance id="products" src="jr://fixture/commtrack:products" />
-			<bind vellum:nodeset="#form/stock_amount" nodeset="/data/stock_amount" type="xsd:int" />
-			<bind nodeset="/data/balance[@type='bal-0']" vellum:relevant="#form/stock_amount != 0" relevant="/data/stock_amount != 0" />
-			<bind nodeset="/data/balance[@type='bal-0']/entry/@quantity" vellum:calculate="#form/stock_amount" calculate="/data/stock_amount" />
+			<bind vellum:nodeset="🍌#form/stock_amount🍌" nodeset="/data/stock_amount" type="xsd:int" />
+			<bind nodeset="/data/balance[@type='bal-0']" vellum:relevant="🍌#form/stock_amount🍌 != 0" relevant="/data/stock_amount != 0" />
+			<bind nodeset="/data/balance[@type='bal-0']/entry/@quantity" vellum:calculate="🍌#form/stock_amount🍌" calculate="/data/stock_amount" />
 			<setvalue event="xforms-ready" ref="/data/balance[@type='bal-0']/entry/@id" value="instance('commcaresession')/session/data/product_id" />
 			<setvalue event="xforms-ready" ref="/data/balance[@type='bal-0']/@entity-id" value="instance('commcaresession')/session/data/case_id" />
 			<setvalue event="xforms-ready" ref="/data/balance[@type='bal-0']/@date" value="/data/meta/timeEnd" />
@@ -30,7 +30,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/stock_amount" ref="/data/stock_amount">
+		<input vellum:ref="🍌#form/stock_amount🍌" ref="/data/stock_amount">
 			<label ref="jr:itext('stock_amount-label')" />
 		</input>
 	</h:body>

--- a/tests/static/commtrack/transfer-block.xml
+++ b/tests/static/commtrack/transfer-block.xml
@@ -15,9 +15,9 @@
 			<instance id="commcaresession" src="jr://instance/session" />
 			<instance id="casedb" src="jr://instance/casedb" />
 			<instance id="products" src="jr://fixture/commtrack:products" />
-			<bind vellum:nodeset="#form/amount_received" nodeset="/data/amount_received" type="xsd:int" />
+			<bind vellum:nodeset="🍌#form/amount_received🍌" nodeset="/data/amount_received" type="xsd:int" />
 			<bind nodeset="/data/transfer[@type='trans-1']" relevant="true()" />
-			<bind nodeset="/data/transfer[@type='trans-1']/entry/@quantity" vellum:calculate="#form/amount_received" calculate="/data/amount_received" />
+			<bind nodeset="/data/transfer[@type='trans-1']/entry/@quantity" vellum:calculate="🍌#form/amount_received🍌" calculate="/data/amount_received" />
 			<setvalue event="xforms-ready" ref="/data/transfer[@type='trans-1']/entry/@id" value="instance('commcaresession')/session/data/product_id" />
 			<setvalue event="xforms-ready" ref="/data/transfer[@type='trans-1']/@src" value="instance('commcaresession')/session/data/case_id" />
 			<setvalue event="xforms-ready" ref="/data/transfer[@type='trans-1']/@dest" value="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/index/parent" />
@@ -32,7 +32,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/amount_received" ref="/data/amount_received">
+		<input vellum:ref="🍌#form/amount_received🍌" ref="/data/amount_received">
 			<label ref="jr:itext('amount_received-label')" />
 		</input>
 	</h:body>

--- a/tests/static/copy-paste/many-itext-forms.xml
+++ b/tests/static/copy-paste/many-itext-forms.xml
@@ -8,7 +8,7 @@
 					<text />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/text" nodeset="/data/text" type="xsd:string" constraint="1 = 0" jr:constraintMsg="jr:itext('text-constraintMsg')" />
+			<bind vellum:nodeset="🍌#form/text🍌" nodeset="/data/text" type="xsd:string" constraint="1 = 0" jr:constraintMsg="jr:itext('text-constraintMsg')" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="default-label">
@@ -60,7 +60,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/text" ref="/data/text">
+		<input vellum:ref="🍌#form/text🍌" ref="/data/text">
 			<label ref="jr:itext('default-label')" />
 			<hint ref="jr:itext('default-hint')">hint label</hint>
 			<help ref="jr:itext('default-help')" />

--- a/tests/static/copy-paste/text-question.xml
+++ b/tests/static/copy-paste/text-question.xml
@@ -8,7 +8,7 @@
 					<txt />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/txt" nodeset="/data/txt" type="xsd:string" constraint="1 = 0" relevant="x = y" jr:constraintMsg="jr:itext('txt-constraintMsg')" required="true()" />
+			<bind vellum:nodeset="🍌#form/txt🍌" nodeset="/data/txt" type="xsd:string" constraint="1 = 0" relevant="x = y" jr:constraintMsg="jr:itext('txt-constraintMsg')" required="true()" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="txt-label">
@@ -30,7 +30,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/txt" ref="/data/txt">
+		<input vellum:ref="🍌#form/txt🍌" ref="/data/txt">
 			<label ref="jr:itext('txt-label')" />
 			<alert ref="jr:itext('txt-constraintMsg')" />
 		</input>

--- a/tests/static/copy-paste/two-choices.xml
+++ b/tests/static/copy-paste/two-choices.xml
@@ -9,8 +9,8 @@
 					<fox />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/box" nodeset="/data/box" />
-			<bind vellum:nodeset="#form/fox" nodeset="/data/fox" />
+			<bind vellum:nodeset="🍌#form/box🍌" nodeset="/data/box" />
+			<bind vellum:nodeset="🍌#form/fox🍌" nodeset="/data/fox" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="box-label">
@@ -44,7 +44,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<select1 vellum:ref="#form/box" ref="/data/box">
+		<select1 vellum:ref="🍌#form/box🍌" ref="/data/box">
 			<label ref="jr:itext('box-label')" />
 			<item>
 				<label ref="jr:itext('yes-label')" />
@@ -55,7 +55,7 @@
 				<value>no</value>
 			</item>
 		</select1>
-		<select1 vellum:ref="#form/fox" ref="/data/fox">
+		<select1 vellum:ref="🍌#form/fox🍌" ref="/data/fox">
 			<label ref="jr:itext('fox-label')" />
 			<item>
 				<label ref="jr:itext('yes-label')" />

--- a/tests/static/copy-paste/two-questions.xml
+++ b/tests/static/copy-paste/two-questions.xml
@@ -9,8 +9,8 @@
 					<choice />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/text" nodeset="/data/text" type="xsd:string" />
-			<bind vellum:nodeset="#form/choice" nodeset="/data/choice" />
+			<bind vellum:nodeset="🍌#form/text🍌" nodeset="/data/text" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/choice🍌" nodeset="/data/choice" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="default-label">
@@ -44,10 +44,10 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/text" ref="/data/text">
+		<input vellum:ref="🍌#form/text🍌" ref="/data/text">
 			<label ref="jr:itext('default-label')" />
 		</input>
-		<select1 vellum:ref="#form/choice" ref="/data/choice">
+		<select1 vellum:ref="🍌#form/choice🍌" ref="/data/choice">
 			<label ref="jr:itext('choice-label')" />
 			<item>
 				<label ref="jr:itext('choice-true-label')" />

--- a/tests/static/core/group-rename.xml
+++ b/tests/static/core/group-rename.xml
@@ -12,10 +12,10 @@
                     <question2 />
                 </data>
             </instance>
-            <bind vellum:nodeset="#form/group" nodeset="/data/group" />
-            <bind vellum:nodeset="#form/group/question1" nodeset="/data/group/question1" type="xsd:string" />
-            <bind vellum:nodeset="#form/group/question2" nodeset="/data/group/question2" type="xsd:string" />
-            <bind vellum:nodeset="#form/question2" nodeset="/data/question2" type="xsd:string" vellum:relevant="#form/group/question1 = 'valley girl' and #form/group/question2 = 'dude'" relevant="/data/group/question1 = 'valley girl' and /data/group/question2 = 'dude'" />
+            <bind vellum:nodeset="🍌#form/group🍌" nodeset="/data/group" />
+            <bind vellum:nodeset="🍌#form/group/question1🍌" nodeset="/data/group/question1" type="xsd:string" />
+            <bind vellum:nodeset="🍌#form/group/question2🍌" nodeset="/data/group/question2" type="xsd:string" />
+            <bind vellum:nodeset="🍌#form/question2🍌" nodeset="/data/question2" type="xsd:string" vellum:relevant="🍌#form/group/question1🍌 = 'valley girl' and 🍌#form/group/question2🍌 = 'dude'" relevant="/data/group/question1 = 'valley girl' and /data/group/question2 = 'dude'" />
             <itext>
                 <translation lang="en" default="">
                     <text id="group-label">
@@ -35,16 +35,16 @@
         </model>
     </h:head>
     <h:body>
-        <group vellum:ref="#form/group" ref="/data/group">
+        <group vellum:ref="🍌#form/group🍌" ref="/data/group">
             <label ref="jr:itext('group-label')" />
-            <input vellum:ref="#form/group/question1" ref="/data/group/question1">
+            <input vellum:ref="🍌#form/group/question1🍌" ref="/data/group/question1">
                 <label ref="jr:itext('group/question1-label')" />
             </input>
-            <input vellum:ref="#form/group/question2" ref="/data/group/question2">
+            <input vellum:ref="🍌#form/group/question2🍌" ref="/data/group/question2">
                 <label ref="jr:itext('group/question2-label')" />
             </input>
         </group>
-        <input vellum:ref="#form/question2" ref="/data/question2">
+        <input vellum:ref="🍌#form/question2🍌" ref="/data/question2">
             <label ref="jr:itext('question2-label')" />
         </input>
     </h:body>

--- a/tests/static/core/hidden-value-in-repeat.xml
+++ b/tests/static/core/hidden-value-in-repeat.xml
@@ -11,9 +11,9 @@
 					</repeat>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/repeat" nodeset="/data/repeat" />
-			<bind vellum:nodeset="#form/repeat/text" nodeset="/data/repeat/text" type="xsd:string" />
-			<bind vellum:nodeset="#form/repeat/hidden" nodeset="/data/repeat/hidden" />
+			<bind vellum:nodeset="🍌#form/repeat🍌" nodeset="/data/repeat" />
+			<bind vellum:nodeset="🍌#form/repeat/text🍌" nodeset="/data/repeat/text" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/repeat/hidden🍌" nodeset="/data/repeat/hidden" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="repeat-label">
@@ -37,8 +37,8 @@
 	<h:body>
 		<group>
 			<label ref="jr:itext('repeat-label')" />
-			<repeat vellum:nodeset="#form/repeat" nodeset="/data/repeat">
-				<input vellum:ref="#form/repeat/text" ref="/data/repeat/text">
+			<repeat vellum:nodeset="🍌#form/repeat🍌" nodeset="/data/repeat">
+				<input vellum:ref="🍌#form/repeat/text🍌" ref="/data/repeat/text">
 					<label ref="jr:itext('repeat/text-label')" />
 				</input>
 			</repeat>

--- a/tests/static/databrowser/child-ref-no-hashtag.xml
+++ b/tests/static/databrowser/child-ref-no-hashtag.xml
@@ -10,7 +10,7 @@
 			</instance>
 			<instance src="jr://instance/casedb" id="casedb" />
 			<instance src="jr://instance/session" id="commcaresession" />
-			<bind vellum:nodeset="#form/mug" nodeset="/data/mug" vellum:calculate="#case/child/dob" calculate="instance('casedb')/cases/case[@case_id = instance('commcaresession')/session/data/case_id]/dob" />
+			<bind nodeset="/data/mug" calculate="instance('casedb')/cases/case[@case_id = instance('commcaresession')/session/data/case_id]/dob" />
 			<itext>
 				<translation lang="en" default="">
 				</translation>

--- a/tests/static/databrowser/child-ref.xml
+++ b/tests/static/databrowser/child-ref.xml
@@ -10,7 +10,7 @@
 			</instance>
 			<instance src="jr://instance/casedb" id="casedb" />
 			<instance src="jr://instance/session" id="commcaresession" />
-			<bind vellum:nodeset="#form/mug" nodeset="/data/mug" vellum:calculate="#case/child/dob" calculate="instance('casedb')/cases/case[@case_id = instance('commcaresession')/session/data/case_id]/dob" />
+			<bind vellum:nodeset="🍌#form/mug🍌" nodeset="/data/mug" vellum:calculate="🍌#case/child/dob🍌" calculate="instance('casedb')/cases/case[@case_id = instance('commcaresession')/session/data/case_id]/dob" />
 			<itext>
 				<translation lang="en" default="">
 				</translation>

--- a/tests/static/databrowser/child-ref.xml
+++ b/tests/static/databrowser/child-ref.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/DC38FCC5-930C-4385-AE6C-5B15ED1F95B1" uiVersion="1" version="1" name="Untitled Form">
+					<mug />
+				</data>
+			</instance>
+			<instance src="jr://instance/casedb" id="casedb" />
+			<instance src="jr://instance/session" id="commcaresession" />
+			<bind vellum:nodeset="#form/mug" nodeset="/data/mug" vellum:calculate="#case/child/dob" calculate="instance('casedb')/cases/case[@case_id=instance('commcaresession')/session/data/case_id]/dob" />
+			<itext>
+				<translation lang="en" default="">
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+	</h:body>
+</h:html>
+/h:html>

--- a/tests/static/databrowser/mother-ref.xml
+++ b/tests/static/databrowser/mother-ref.xml
@@ -10,7 +10,7 @@
 			</instance>
 			<instance src="jr://instance/casedb" id="casedb" />
 			<instance id="commcaresession" src="jr://instance/session" />
-			<bind vellum:nodeset="#form/mug" nodeset="/data/mug" vellum:calculate="#case/mother/edd" calculate="instance('casedb')/cases/case[@case_id=instance('casedb')/cases/case[@case_id=instance('commcaresession')/session/data/case_id]/index/parent]/edd" />
+			<bind vellum:nodeset="#form/mug" nodeset="/data/mug" vellum:calculate="#case/mother/edd" calculate="instance('casedb')/cases/case[@case_id = instance('casedb')/cases/case[@case_id = instance('commcaresession')/session/data/case_id]/index/parent]/edd" />
 			<itext>
 				<translation lang="en" default="">
 				</translation>

--- a/tests/static/databrowser/mother-ref.xml
+++ b/tests/static/databrowser/mother-ref.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/DC38FCC5-930C-4385-AE6C-5B15ED1F95B1" uiVersion="1" version="1" name="Untitled Form">
+					<mug />
+				</data>
+			</instance>
+			<instance src="jr://instance/casedb" id="casedb" />
+			<instance id="commcaresession" src="jr://instance/session" />
+			<bind vellum:nodeset="#form/mug" nodeset="/data/mug" vellum:calculate="#case/mother/edd" calculate="instance('casedb')/cases/case[@case_id=instance('casedb')/cases/case[@case_id=instance('commcaresession')/session/data/case_id]/index/parent]/edd" />
+			<itext>
+				<translation lang="en" default="">
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+	</h:body>
+</h:html>

--- a/tests/static/databrowser/mother-ref.xml
+++ b/tests/static/databrowser/mother-ref.xml
@@ -10,7 +10,7 @@
 			</instance>
 			<instance src="jr://instance/casedb" id="casedb" />
 			<instance id="commcaresession" src="jr://instance/session" />
-			<bind vellum:nodeset="#form/mug" nodeset="/data/mug" vellum:calculate="#case/mother/edd" calculate="instance('casedb')/cases/case[@case_id = instance('casedb')/cases/case[@case_id = instance('commcaresession')/session/data/case_id]/index/parent]/edd" />
+			<bind vellum:nodeset="🍌#form/mug🍌" nodeset="/data/mug" vellum:calculate="🍌#case/mother/edd🍌" calculate="instance('casedb')/cases/case[@case_id = instance('casedb')/cases/case[@case_id = instance('commcaresession')/session/data/case_id]/index/parent]/edd" />
 			<itext>
 				<translation lang="en" default="">
 				</translation>

--- a/tests/static/diffDataParent/data-parent-mug-after.xml
+++ b/tests/static/diffDataParent/data-parent-mug-after.xml
@@ -11,9 +11,9 @@
 					</parent>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/before-child" nodeset="/data/before-child" type="xsd:string" />
-			<bind vellum:nodeset="#form/parent" nodeset="/data/parent" />
-			<bind vellum:nodeset="#form/parent/child" nodeset="/data/parent/child" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/before-child🍌" nodeset="/data/before-child" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/parent🍌" nodeset="/data/parent" />
+			<bind vellum:nodeset="🍌#form/parent/child🍌" nodeset="/data/parent/child" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="before-child-label">
@@ -30,13 +30,13 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/before-child" ref="/data/before-child">
+		<input vellum:ref="🍌#form/before-child🍌" ref="/data/before-child">
 			<label ref="jr:itext('before-child-label')" />
 		</input>
-		<input vellum:ref="#form/parent/child" ref="/data/parent/child">
+		<input vellum:ref="🍌#form/parent/child🍌" ref="/data/parent/child">
 			<label ref="jr:itext('child-label')" />
 		</input>
-		<group vellum:ref="#form/parent" ref="/data/parent">
+		<group vellum:ref="🍌#form/parent🍌" ref="/data/parent">
 			<label ref="jr:itext('parent-label')" />
 		</group>
 	</h:body>

--- a/tests/static/diffDataParent/data-parent-mug-before.xml
+++ b/tests/static/diffDataParent/data-parent-mug-before.xml
@@ -11,9 +11,9 @@
 					</parent>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/after-child" nodeset="/data/after-child" type="xsd:string" />
-			<bind vellum:nodeset="#form/parent" nodeset="/data/parent" />
-			<bind vellum:nodeset="#form/parent/child" nodeset="/data/parent/child" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/after-child🍌" nodeset="/data/after-child" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/parent🍌" nodeset="/data/parent" />
+			<bind vellum:nodeset="🍌#form/parent/child🍌" nodeset="/data/parent/child" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="child-label">
@@ -30,13 +30,13 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/parent/child" ref="/data/parent/child">
+		<input vellum:ref="🍌#form/parent/child🍌" ref="/data/parent/child">
 			<label ref="jr:itext('child-label')" />
 		</input>
-        <input vellum:ref="#form/after-child" ref="/data/after-child">
+        <input vellum:ref="🍌#form/after-child🍌" ref="/data/after-child">
             <label ref="jr:itext('after-child-label')" />
         </input>
-		<group vellum:ref="#form/parent" ref="/data/parent">
+		<group vellum:ref="🍌#form/parent🍌" ref="/data/parent">
 			<label ref="jr:itext('parent-label')" />
 		</group>
 	</h:body>

--- a/tests/static/diffDataParent/data-parent-mug-in-between.xml
+++ b/tests/static/diffDataParent/data-parent-mug-in-between.xml
@@ -12,10 +12,10 @@
 					</parent>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/before-child" nodeset="/data/before-child" type="xsd:string" />
-			<bind vellum:nodeset="#form/after-child" nodeset="/data/after-child" type="xsd:string" />
-			<bind vellum:nodeset="#form/parent" nodeset="/data/parent" />
-			<bind vellum:nodeset="#form/parent/child" nodeset="/data/parent/child" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/before-child🍌" nodeset="/data/before-child" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/after-child🍌" nodeset="/data/after-child" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/parent🍌" nodeset="/data/parent" />
+			<bind vellum:nodeset="🍌#form/parent/child🍌" nodeset="/data/parent/child" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="before-child-label">
@@ -35,16 +35,16 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/before-child" ref="/data/before-child">
+		<input vellum:ref="🍌#form/before-child🍌" ref="/data/before-child">
 			<label ref="jr:itext('before-child-label')" />
 		</input>
-		<input vellum:ref="#form/parent/child" ref="/data/parent/child">
+		<input vellum:ref="🍌#form/parent/child🍌" ref="/data/parent/child">
 			<label ref="jr:itext('child-label')" />
 		</input>
-		<input vellum:ref="#form/after-child" ref="/data/after-child">
+		<input vellum:ref="🍌#form/after-child🍌" ref="/data/after-child">
 			<label ref="jr:itext('after-child-label')" />
 		</input>
-		<group vellum:ref="#form/parent" ref="/data/parent">
+		<group vellum:ref="🍌#form/parent🍌" ref="/data/parent">
 			<label ref="jr:itext('parent-label')" />
 		</group>
 	</h:body>

--- a/tests/static/diffDataParent/parse.xml
+++ b/tests/static/diffDataParent/parse.xml
@@ -11,9 +11,9 @@
 					</parent>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/parent" nodeset="/data/parent" />
-			<bind vellum:nodeset="#form/parent/normal-child" nodeset="/data/parent/normal-child" type="xsd:string" />
-			<bind vellum:nodeset="#form/parent/different-child" nodeset="/data/parent/different-child" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/parent🍌" nodeset="/data/parent" />
+			<bind vellum:nodeset="🍌#form/parent/normal-child🍌" nodeset="/data/parent/normal-child" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/parent/different-child🍌" nodeset="/data/parent/different-child" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="different-child-label">
@@ -30,12 +30,12 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/parent/different-child" ref="/data/parent/different-child">
+		<input vellum:ref="🍌#form/parent/different-child🍌" ref="/data/parent/different-child">
 			<label ref="jr:itext('different-child-label')" />
 		</input>
-		<group vellum:ref="#form/parent" ref="/data/parent">
+		<group vellum:ref="🍌#form/parent🍌" ref="/data/parent">
 			<label ref="jr:itext('parent-label')" />
-			<input vellum:ref="#form/parent/normal-child" ref="/data/parent/normal-child">
+			<input vellum:ref="🍌#form/parent/normal-child🍌" ref="/data/parent/normal-child">
 				<label ref="jr:itext('normal-child-label')" />
 			</input>
 		</group>

--- a/tests/static/diffDataParent/sibling-as-child.xml
+++ b/tests/static/diffDataParent/sibling-as-child.xml
@@ -9,8 +9,8 @@
 					<text />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/group" nodeset="/data/group" />
-			<bind vellum:nodeset="#form/text" nodeset="/data/text" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/group🍌" nodeset="/data/group" />
+			<bind vellum:nodeset="🍌#form/text🍌" nodeset="/data/text" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="group-label">
@@ -24,9 +24,9 @@
 		</model>
 	</h:head>
 	<h:body>
-		<group vellum:ref="#form/group" ref="/data/group">
+		<group vellum:ref="🍌#form/group🍌" ref="/data/group">
 			<label ref="jr:itext('group-label')" />
-			<input vellum:ref="#form/text" ref="/data/text">
+			<input vellum:ref="🍌#form/text🍌" ref="/data/text">
 				<label ref="jr:itext('text-label')" />
 			</input>
 		</group>

--- a/tests/static/form/manual-instance-reference.xml
+++ b/tests/static/form/manual-instance-reference.xml
@@ -14,26 +14,26 @@
 				<score low="0.0" high="500.0">You're really bad</score>
 				<score low="500.0" high="99999999.0">You're really good</score>
 			</instance>
-			<bind vellum:nodeset="#form/score" nodeset="/data/score" type="xsd:int" />
-			<bind vellum:nodeset="#form/output" nodeset="/data/output" vellum:calculate="instance('scores')/score[@high &gt; #form/score][@low &lt; #form/score]" calculate="instance('scores')/score[@high &gt; /data/score][@low &lt; /data/score]" />
-			<bind vellum:nodeset="#form/result" nodeset="/data/result" />
+			<bind vellum:nodeset="🍌#form/score🍌" nodeset="/data/score" type="xsd:int" />
+			<bind vellum:nodeset="🍌#form/output🍌" nodeset="/data/output" vellum:calculate="instance('scores')/score[@high &gt; 🍌#form/score🍌][@low &lt; 🍌#form/score🍌]" calculate="instance('scores')/score[@high &gt; /data/score][@low &lt; /data/score]" />
+			<bind vellum:nodeset="🍌#form/result🍌" nodeset="/data/result" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="score-label">
 						<value>What was your score</value>
 					</text>
 					<text id="result-label">
-						<value><output vellum:value="#form/output" value="/data/output" /></value>
+						<value><output vellum:value="🍌#form/output🍌" value="/data/output" /></value>
 					</text>
 				</translation>
 			</itext>
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/score" ref="/data/score">
+		<input vellum:ref="🍌#form/score🍌" ref="/data/score">
 			<label ref="jr:itext('score-label')" />
 		</input>
-		<trigger vellum:ref="#form/result" ref="/data/result" appearance="minimal">
+		<trigger vellum:ref="🍌#form/result🍌" ref="/data/result" appearance="minimal">
 			<label ref="jr:itext('result-label')" />
 		</trigger>
 	</h:body>

--- a/tests/static/ignoreButRetain/case-with-update.xml
+++ b/tests/static/ignoreButRetain/case-with-update.xml
@@ -14,7 +14,7 @@
 					</case>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question" nodeset="/data/question" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/question🍌" nodeset="/data/question" type="xsd:string"/>
 			<itext>
 				<translation lang="en" default="">
 					<text id="question-label">
@@ -25,7 +25,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/question" ref="/data/question">
+		<input vellum:ref="🍌#form/question🍌" ref="/data/question">
 			<label ref="jr:itext('question-label')"/>
 		</input>
 	</h:body>

--- a/tests/static/ignoreButRetain/common-ignored.xml
+++ b/tests/static/ignoreButRetain/common-ignored.xml
@@ -18,7 +18,7 @@
 			<bind nodeset="/data/question9/question10" type="xsd:int" vellum:ignore="retain"/>
 			<bind vellum:nodeset="#form/question9/question11" nodeset="/data/question9/question11" type="xsd:int"/>
 			<bind nodeset="/data/question4" vellum:ignore="retain"/>
-			<setvalue event="xforms-revalidate" ref="/data/question1" value="0"/>
+			<setvalue event="xforms-revalidate" vellum:ref="#form/question1" ref="/data/question1" value="0"/>
 			<setvalue event="xforms-ready" ref="/data/question3" value="3"/>
 			<itext>
 				<translation lang="en" default="">

--- a/tests/static/ignoreButRetain/common-ignored.xml
+++ b/tests/static/ignoreButRetain/common-ignored.xml
@@ -13,12 +13,12 @@
 					<question4 vellum:ignore="retain"/>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="xsd:string"/>
-			<bind vellum:nodeset="#form/question9" nodeset="/data/question9"/>
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/question9🍌" nodeset="/data/question9"/>
 			<bind nodeset="/data/question9/question10" type="xsd:int" vellum:ignore="retain"/>
-			<bind vellum:nodeset="#form/question9/question11" nodeset="/data/question9/question11" type="xsd:int"/>
+			<bind vellum:nodeset="🍌#form/question9/question11🍌" nodeset="/data/question9/question11" type="xsd:int"/>
 			<bind nodeset="/data/question4" vellum:ignore="retain"/>
-			<setvalue event="xforms-revalidate" vellum:ref="#form/question1" ref="/data/question1" value="0"/>
+			<setvalue event="xforms-revalidate" vellum:ref="🍌#form/question1🍌" ref="/data/question1" value="0"/>
 			<setvalue event="xforms-ready" ref="/data/question3" value="3"/>
 			<itext>
 				<translation lang="en" default="">
@@ -37,16 +37,16 @@
 	</h:head>
 	<!-- body nodes, including nesting -->
 	<h:body>
-		<input vellum:ref="#form/question1" ref="/data/question1">
+		<input vellum:ref="🍌#form/question1🍌" ref="/data/question1">
 			<label ref="jr:itext('question1-label')"/>
 		</input>
-		<group vellum:ref="#form/question9" ref="/data/question9">
+		<group vellum:ref="🍌#form/question9🍌" ref="/data/question9">
 			<label ref="jr:itext('question9-label')"/>
 			<!-- ignored node after an inner label -->
 			<input ref="/data/question9/question10" vellum:ignore="retain">
 				<label ref="jr:itext('question10-label')"/>
 			</input>
-			<input vellum:ref="#form/question9/question11" ref="/data/question9/question11">
+			<input vellum:ref="🍌#form/question9/question11🍌" ref="/data/question9/question11">
 				<label ref="jr:itext('question11-label')"/>
 			</input>
 		</group>

--- a/tests/static/ignoreButRetain/common.xml
+++ b/tests/static/ignoreButRetain/common.xml
@@ -13,14 +13,14 @@
 					<question4 vellum:ignore="retain"/>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="xsd:string"/>
-			<bind vellum:nodeset="#form/question9" nodeset="/data/question9"/>
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/question9🍌" nodeset="/data/question9"/>
 			<bind nodeset="/data/question9/question10" type="xsd:int" vellum:ignore="retain"/>
-			<bind vellum:nodeset="#form/question9/question11" nodeset="/data/question9/question11" type="xsd:int"/>
+			<bind vellum:nodeset="🍌#form/question9/question11🍌" nodeset="/data/question9/question11" type="xsd:int"/>
 			<bind nodeset="/data/question4" vellum:ignore="retain"/>
-			<setvalue event="xforms-revalidate" vellum:ref="#form/question1" ref="/data/question1" value="0"/>
-			<setvalue event="xforms-ready" vellum:ref="#form/question1" ref="/data/question1" value="1" vellum:ignore="retain"/>
-			<setvalue event="xforms-ready" vellum:ref="#form/question2" ref="/data/question2" value="2" vellum:ignore="retain"/>
+			<setvalue event="xforms-revalidate" vellum:ref="🍌#form/question1🍌" ref="/data/question1" value="0"/>
+			<setvalue event="xforms-ready" ref="/data/question1" value="1" vellum:ignore="retain"/>
+			<setvalue event="xforms-ready" ref="/data/question2" value="2" vellum:ignore="retain"/>
 			<setvalue event="xforms-ready" ref="/data/question3" value="3"/>
 			<itext>
 				<translation lang="en" default="">
@@ -39,16 +39,16 @@
 	</h:head>
 	<!-- body nodes, including nesting -->
 	<h:body>
-		<input vellum:ref="#form/question1" ref="/data/question1">
+		<input vellum:ref="🍌#form/question1🍌" ref="/data/question1">
 			<label ref="jr:itext('question1-label')"/>
 		</input>
-		<group vellum:ref="#form/question9" ref="/data/question9">
+		<group vellum:ref="🍌#form/question9🍌" ref="/data/question9">
 			<label ref="jr:itext('question9-label')"/>
 			<!-- ignored node after an inner label -->
 			<input ref="/data/question9/question10" vellum:ignore="retain">
 				<label ref="jr:itext('question10-label')"/>
 			</input>
-			<input vellum:ref="#form/question9/question11" ref="/data/question9/question11">
+			<input vellum:ref="🍌#form/question9/question11🍌" ref="/data/question9/question11">
 				<label ref="jr:itext('question11-label')"/>
 			</input>
 		</group>

--- a/tests/static/ignoreButRetain/common.xml
+++ b/tests/static/ignoreButRetain/common.xml
@@ -18,7 +18,7 @@
 			<bind nodeset="/data/question9/question10" type="xsd:int" vellum:ignore="retain"/>
 			<bind vellum:nodeset="#form/question9/question11" nodeset="/data/question9/question11" type="xsd:int"/>
 			<bind nodeset="/data/question4" vellum:ignore="retain"/>
-			<setvalue event="xforms-revalidate" ref="/data/question1" value="0"/>
+			<setvalue event="xforms-revalidate" vellum:ref="#form/question1" ref="/data/question1" value="0"/>
 			<setvalue event="xforms-ready" vellum:ref="#form/question1" ref="/data/question1" value="1" vellum:ignore="retain"/>
 			<setvalue event="xforms-ready" vellum:ref="#form/question2" ref="/data/question2" value="2" vellum:ignore="retain"/>
 			<setvalue event="xforms-ready" ref="/data/question3" value="3"/>

--- a/tests/static/ignoreButRetain/delete-bug-after.xml
+++ b/tests/static/ignoreButRetain/delete-bug-after.xml
@@ -10,9 +10,9 @@
 					<after/>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/before" nodeset="/data/before" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/before🍌" nodeset="/data/before" type="xsd:string"/>
 			<bind nodeset="/data/ignored" type="xsd:string" vellum:ignore="retain"/>
-			<bind vellum:nodeset="#form/after" nodeset="/data/after" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/after🍌" nodeset="/data/after" type="xsd:string"/>
 			<setvalue event="when-youre-strange" ref="/data/ignored[inner]" value="super()/flip"/>
 			<itext>
 				<translation lang="en" default="">
@@ -30,13 +30,13 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/before" ref="/data/before">
+		<input vellum:ref="🍌#form/before🍌" ref="/data/before">
 			<label ref="jr:itext('before-label')"/>
 		</input>
 		<input ref="/data/ignored" vellum:ignore="retain">
 			<label ref="jr:itext('ignored-label')"/>
 		</input>
-		<input vellum:ref="#form/after" ref="/data/after">
+		<input vellum:ref="🍌#form/after🍌" ref="/data/after">
 			<label ref="jr:itext('after-label')"/>
 		</input>
 	</h:body>

--- a/tests/static/ignoreButRetain/empty-parent.xml
+++ b/tests/static/ignoreButRetain/empty-parent.xml
@@ -11,8 +11,8 @@
 					<update vellum:ignore="retain"/></case>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="xsd:string" />
-			<bind vellum:nodeset="#form/case" nodeset="/data/case"/>
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/case🍌" nodeset="/data/case"/>
 			<itext>
 				<translation lang="en" default=""/>
 			</itext>

--- a/tests/static/ignoreButRetain/ignore-in-head.xml
+++ b/tests/static/ignoreButRetain/ignore-in-head.xml
@@ -8,7 +8,7 @@
 					<question1 />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" type="xsd:string" />
 			<itext>
 				<translation lang="en" default=""/>
 			</itext>

--- a/tests/static/ignoreButRetain/ignored-binds-with-extra-path.xml
+++ b/tests/static/ignoreButRetain/ignored-binds-with-extra-path.xml
@@ -13,7 +13,7 @@
 			<bind nodeset="/data/question/extra/path" type="xsd:string"/>
 			<bind nodeset="/data/question[extra = path]" type="xsd:string"/>
 			<bind nodeset="/data/question[with][extra = path]" type="xsd:string"/>
-			<bind vellum:nodeset="#form/question2" nodeset="/data/question2" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/question2🍌" nodeset="/data/question2" type="xsd:string"/>
 			<itext>
 				<translation lang="en" default="">
 					<text id="question2-label">
@@ -24,7 +24,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/question2" ref="/data/question2">
+		<input vellum:ref="🍌#form/question2🍌" ref="/data/question2">
 			<label ref="jr:itext('question2-label')"/>
 		</input>
 	</h:body>

--- a/tests/static/ignoreButRetain/ignored-control-node.xml
+++ b/tests/static/ignoreButRetain/ignored-control-node.xml
@@ -8,7 +8,7 @@
 					<question/>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question" nodeset="/data/question" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/question🍌" nodeset="/data/question" type="xsd:string"/>
 			<itext>
 				<translation lang="en" default="">
 					<text id="question-label" vellum:ignore="retain">

--- a/tests/static/ignoreButRetain/ignored-tag-first.xml
+++ b/tests/static/ignoreButRetain/ignored-tag-first.xml
@@ -9,7 +9,7 @@
 					<question/>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question" nodeset="/data/question" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/question🍌" nodeset="/data/question" type="xsd:string"/>
 			<itext>
 				<translation lang="en" default="">
 					<text id="question-label">
@@ -20,7 +20,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/question" ref="/data/question">
+		<input vellum:ref="🍌#form/question🍌" ref="/data/question">
 			<label ref="jr:itext('question-label')"/>
 		</input>
 	</h:body>

--- a/tests/static/ignoreButRetain/multi-match.xml
+++ b/tests/static/ignoreButRetain/multi-match.xml
@@ -8,7 +8,7 @@
 					<question1/>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" type="xsd:string"/>
 			<bind nodeset="/data/question1" vellum:ignore="retain"/>
 			<bind nodeset="/data/question1" vellum:ignore="retain"/>
 			<itext>

--- a/tests/static/ignoreButRetain/multiple-ignores.xml
+++ b/tests/static/ignoreButRetain/multiple-ignores.xml
@@ -10,7 +10,7 @@
 					<question4 vellum:ignore="retain" />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" type="xsd:string" />
 			<bind nodeset="/data/question9" vellum:ignore="retain" />
 			<bind nodeset="/data/question4" vellum:ignore="retain" />
 			<itext>

--- a/tests/static/ignoreButRetain/nested-ignored-nodes.xml
+++ b/tests/static/ignoreButRetain/nested-ignored-nodes.xml
@@ -8,7 +8,7 @@
 					<question/>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question" nodeset="/data/question" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/question🍌" nodeset="/data/question" type="xsd:string"/>
 			<itext>
 				<translation lang="en" default="">
 					<text id="question-label">
@@ -23,7 +23,7 @@
 		</ext>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/question" ref="/data/question">
+		<input vellum:ref="🍌#form/question🍌" ref="/data/question">
 			<label ref="jr:itext('question-label')"/>
 		</input>
 	</h:body>

--- a/tests/static/ignoreButRetain/referenced-renamed.xml
+++ b/tests/static/ignoreButRetain/referenced-renamed.xml
@@ -9,7 +9,7 @@
 					<question9 vellum:ignore="retain"/>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/foobar" nodeset="/data/foobar" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/foobar🍌" nodeset="/data/foobar" type="xsd:string"/>
 			<bind nodeset="/data/question9" calculate="1 + /data/foobar" vellum:ignore="retain"/>
 			<itext>
 				<translation lang="en" default=""/>

--- a/tests/static/ignoreButRetain/renamed.xml
+++ b/tests/static/ignoreButRetain/renamed.xml
@@ -13,10 +13,10 @@
 					<question4 vellum:ignore="retain"/>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="xsd:string"/>
-			<bind vellum:nodeset="#form/question9a" nodeset="/data/question9a"/>
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/question9a🍌" nodeset="/data/question9a"/>
 			<bind type="xsd:int" vellum:ignore="retain" nodeset="/data/question9a/question10"/>
-			<bind vellum:nodeset="#form/question9a/question11" nodeset="/data/question9a/question11" type="xsd:int"/>
+			<bind vellum:nodeset="🍌#form/question9a/question11🍌" nodeset="/data/question9a/question11" type="xsd:int"/>
 			<bind vellum:ignore="retain" nodeset="/data/question4"/>
 			<itext>
 				<translation lang="en" default="">
@@ -38,16 +38,16 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/question1" ref="/data/question1">
+		<input vellum:ref="🍌#form/question1🍌" ref="/data/question1">
 			<label ref="jr:itext('question1-label')"/>
 		</input>
-		<group vellum:ref="#form/question9a" ref="/data/question9a">
+		<group vellum:ref="🍌#form/question9a🍌" ref="/data/question9a">
 			<!-- todo: renaming of itext IDs without requiring UI layer -->
 			<label ref="jr:itext('question9a-label')"/>
 			<input vellum:ignore="retain" ref="/data/question9a/question10">
 				<label ref="jr:itext('question10-label')"/>
 			</input>
-			<input vellum:ref="#form/question9a/question11" ref="/data/question9a/question11">
+			<input vellum:ref="🍌#form/question9a/question11🍌" ref="/data/question9a/question11">
 				<label ref="jr:itext('question11-label')"/>
 			</input>
 		</group>

--- a/tests/static/ignoreButRetain/unknown-element.xml
+++ b/tests/static/ignoreButRetain/unknown-element.xml
@@ -9,13 +9,13 @@
 					<question2 vellum:ignore="retain"/>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question" nodeset="/data/question" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/question🍌" nodeset="/data/question" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="" />
 			</itext>
 		</model>
 	</h:head>
 	<h:body>
-		<unknown vellum:ref="#form/question" ref="/data/question" />
+		<unknown vellum:ref="🍌#form/question🍌" ref="/data/question" />
 	</h:body>
 </h:html>

--- a/tests/static/intentManager/intent-with-no-mug.xml
+++ b/tests/static/intentManager/intent-with-no-mug.xml
@@ -8,7 +8,7 @@
 					<breath_count />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/breath_count" nodeset="/data/breath_count" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/breath_count🍌" nodeset="/data/breath_count" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="breath_count-label">
@@ -23,7 +23,7 @@
 		</odkx:intent>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/breath_count" ref="/data/breath_count">
+		<input vellum:ref="🍌#form/breath_count🍌" ref="/data/breath_count">
 			<label ref="jr:itext('breath_count-label')" />
 		</input>
 	</h:body>

--- a/tests/static/intentManager/intent-with-unknown-attrs.xml
+++ b/tests/static/intentManager/intent-with-unknown-attrs.xml
@@ -8,7 +8,7 @@
 					<breath_count />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/breath_count" nodeset="/data/breath_count" type="intent" />
+			<bind vellum:nodeset="🍌#form/breath_count🍌" nodeset="/data/breath_count" type="intent" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="breath_count-label">
@@ -23,7 +23,7 @@
 		</odkx:intent>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/breath_count" ref="/data/breath_count" appearance="intent:breath_count">
+		<input vellum:ref="🍌#form/breath_count🍌" ref="/data/breath_count" appearance="intent:breath_count">
 			<label ref="jr:itext('breath_count-label')" />
 		</input>
 	</h:body>

--- a/tests/static/intentManager/printing-intent.xml
+++ b/tests/static/intentManager/printing-intent.xml
@@ -9,8 +9,8 @@
 					<print_data />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/text" nodeset="/data/text" type="xsd:string" />
-			<bind vellum:nodeset="#form/print_data" nodeset="/data/print_data" type="intent" />
+			<bind vellum:nodeset="🍌#form/text🍌" nodeset="/data/text" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/print_data🍌" nodeset="/data/print_data" type="intent" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="text-label">
@@ -28,10 +28,10 @@
 		</odkx:intent>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/text" ref="/data/text">
+		<input vellum:ref="🍌#form/text🍌" ref="/data/text">
 			<label ref="jr:itext('text-label')" />
 		</input>
-		<input vellum:ref="#form/print_data" ref="/data/print_data" appearance="intent:print_data">
+		<input vellum:ref="🍌#form/print_data🍌" ref="/data/print_data" appearance="intent:print_data">
 			<label ref="jr:itext('print_data-label')" />
 		</input>
 	</h:body>

--- a/tests/static/itemset/inner-filters.xml
+++ b/tests/static/itemset/inner-filters.xml
@@ -9,7 +9,7 @@
 				</data>
 			</instance>
 			<instance id="somefixture" src="jr://fixture/some-fixture" />
-			<bind vellum:nodeset="#form/question2" nodeset="/data/question2" />
+			<bind vellum:nodeset="🍌#form/question2🍌" nodeset="/data/question2" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="question2-label">
@@ -20,7 +20,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<select1 vellum:ref="#form/question2" ref="/data/question2">
+		<select1 vellum:ref="🍌#form/question2🍌" ref="/data/question2">
 			<label ref="jr:itext('question2-label')" />
 			<itemset nodeset="instance('somefixture')/foos/foo[@foo_type='woo'][1=2]/bar[@bar_type='eggs']">
 				<label ref="case_name" />

--- a/tests/static/itemset/test1-with-appearance.xml
+++ b/tests/static/itemset/test1-with-appearance.xml
@@ -9,7 +9,7 @@
 				</data>
 			</instance>
 			<instance id="casedb" src="jr://instance/casedb" />
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" constraint="1 = 1" jr:constraintMsg="jr:itext('question1-constraintMsg')"/>
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" constraint="1 = 1" jr:constraintMsg="jr:itext('question1-constraintMsg')"/>
 			<itext>
 				<translation lang="en" default="">
 					<text id="question1-label">
@@ -23,7 +23,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<select1 vellum:ref="#form/question1" ref="/data/question1" appearance="minimal">
+		<select1 vellum:ref="🍌#form/question1🍌" ref="/data/question1" appearance="minimal">
 			<label ref="jr:itext('question1-label')" />
 			<alert ref="jr:itext('question1-constraintMsg')" />
 			<itemset nodeset="instance('casedb')/casedb/case[@case_type='mother']">

--- a/tests/static/itemset/test1-with-constraint.xml
+++ b/tests/static/itemset/test1-with-constraint.xml
@@ -9,7 +9,7 @@
 				</data>
 			</instance>
 			<instance id="casedb" src="jr://instance/casedb" />
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" />
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="question1-label">
@@ -20,7 +20,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<select1 vellum:ref="#form/question1" ref="/data/question1">
+		<select1 vellum:ref="🍌#form/question1🍌" ref="/data/question1">
 			<label ref="jr:itext('question1-label')" />
 			<itemset nodeset="instance('casedb')/casedb/case[@case_type='mother']">
 				<label ref="case_name" />

--- a/tests/static/itemset/test1.xml
+++ b/tests/static/itemset/test1.xml
@@ -9,7 +9,7 @@
 				</data>
 			</instance>
 			<instance id="casedb" src="jr://instance/casedb" />
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" constraint="1 = 1" jr:constraintMsg="jr:itext('question1-constraintMsg')"/>
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" constraint="1 = 1" jr:constraintMsg="jr:itext('question1-constraintMsg')"/>
 			<itext>
 				<translation lang="en" default="">
 					<text id="question1-label">
@@ -23,7 +23,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<select1 vellum:ref="#form/question1" ref="/data/question1">
+		<select1 vellum:ref="🍌#form/question1🍌" ref="/data/question1">
 			<label ref="jr:itext('question1-label')" />
 			<alert ref="jr:itext('question1-constraintMsg')" />
 			<itemset nodeset="instance('casedb')/casedb/case[@case_type='mother']">

--- a/tests/static/javaRosa/itext-item-rename-group-move.xml
+++ b/tests/static/javaRosa/itext-item-rename-group-move.xml
@@ -11,9 +11,9 @@
 					<green />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/blue" nodeset="/data/blue" />
-			<bind vellum:nodeset="#form/blue/text" nodeset="/data/blue/text" type="xsd:string" />
-			<bind vellum:nodeset="#form/green" nodeset="/data/green" />
+			<bind vellum:nodeset="🍌#form/blue🍌" nodeset="/data/blue" />
+			<bind vellum:nodeset="🍌#form/blue/text🍌" nodeset="/data/blue/text" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/green🍌" nodeset="/data/green" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="blue-label">
@@ -41,13 +41,13 @@
 		</model>
 	</h:head>
 	<h:body>
-		<group vellum:ref="#form/blue" ref="/data/blue">
+		<group vellum:ref="🍌#form/blue🍌" ref="/data/blue">
 			<label ref="jr:itext('blue-label')" />
-			<input vellum:ref="#form/blue/text" ref="/data/blue/text">
+			<input vellum:ref="🍌#form/blue/text🍌" ref="/data/blue/text">
 				<label ref="jr:itext('blue/text-label')" />
 			</input>
 		</group>
-		<group vellum:ref="#form/green" ref="/data/green">
+		<group vellum:ref="🍌#form/green🍌" ref="/data/green">
 			<label ref="jr:itext('green-label')" />
 		</group>
 	</h:body>

--- a/tests/static/javaRosa/itext-item-rename.xml
+++ b/tests/static/javaRosa/itext-item-rename.xml
@@ -9,8 +9,8 @@
 					<ew />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/ns" nodeset="/data/ns" />
-			<bind vellum:nodeset="#form/ew" nodeset="/data/ew" />
+			<bind vellum:nodeset="🍌#form/ns🍌" nodeset="/data/ns" />
+			<bind vellum:nodeset="🍌#form/ew🍌" nodeset="/data/ew" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="ns-label">
@@ -56,7 +56,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<select1 vellum:ref="#form/ns" ref="/data/ns">
+		<select1 vellum:ref="🍌#form/ns🍌" ref="/data/ns">
 			<label ref="jr:itext('ns-label')" />
 			<item>
 				<label ref="jr:itext('ns-north-label')" />
@@ -71,7 +71,7 @@
 				<value>choice2</value>
 			</item>
 		</select1>
-		<select1 vellum:ref="#form/ew" ref="/data/ew">
+		<select1 vellum:ref="🍌#form/ew🍌" ref="/data/ew">
 			<label ref="jr:itext('ew-label')" />
 			<item>
 				<label ref="jr:itext('ew-choice2-label')" />

--- a/tests/static/javaRosa/no-label-text-one-lang.xml
+++ b/tests/static/javaRosa/no-label-text-one-lang.xml
@@ -8,7 +8,7 @@
 					<label />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/label" nodeset="/data/label" />
+			<bind vellum:nodeset="🍌#form/label🍌" nodeset="/data/label" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="label-label">
@@ -20,7 +20,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<trigger vellum:ref="#form/label" ref="/data/label" appearance="minimal">
+		<trigger vellum:ref="🍌#form/label🍌" ref="/data/label" appearance="minimal">
 			<label ref="jr:itext('label-label')" />
 		</trigger>
 	</h:body>

--- a/tests/static/javaRosa/output-refs.xml
+++ b/tests/static/javaRosa/output-refs.xml
@@ -9,15 +9,15 @@
 					<question2 />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/first_question" nodeset="/data/first_question" type="xsd:string" />
-			<bind vellum:nodeset="#form/question2" nodeset="/data/question2" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/first_question🍌" nodeset="/data/first_question" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/question2🍌" nodeset="/data/question2" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="first_question-label">
 						<value>first_question</value>
 					</text>
 					<text id="question2-label">
-						<value><output vellum:value="#form/first_question" value="/data/first_question" /> <output value="/data/question11" /> <output value="/data/question1/b" /> <output value="/data/question1b" /></value>
+						<value><output vellum:value="🍌#form/first_question🍌" value="/data/first_question" /> <output value="/data/question11" /> <output value="/data/question1/b" /> <output value="/data/question1b" /></value>
 					</text>
 				</translation>
 				<translation lang="hin">
@@ -32,10 +32,10 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/first_question" ref="/data/first_question">
+		<input vellum:ref="🍌#form/first_question🍌" ref="/data/first_question">
 			<label ref="jr:itext('first_question-label')" />
 		</input>
-		<input vellum:ref="#form/question2" ref="/data/question2">
+		<input vellum:ref="🍌#form/question2🍌" ref="/data/question2">
 			<label ref="jr:itext('question2-label')" />
 		</input>
 	</h:body>

--- a/tests/static/javaRosa/outputref-with-inequality.xml
+++ b/tests/static/javaRosa/outputref-with-inequality.xml
@@ -9,7 +9,7 @@
 				</data>
 			</instance>
 			<instance src="jr://fixture/commtrack:products" id="products"></instance>
-			<bind vellum:nodeset="#form/product" nodeset="/data/product" />
+			<bind vellum:nodeset="🍌#form/product🍌" nodeset="/data/product" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="product-label">
@@ -25,7 +25,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<select1 vellum:ref="#form/product" ref="/data/product">
+		<select1 vellum:ref="🍌#form/product🍌" ref="/data/product">
 			<label ref="jr:itext('product-label')" />
 			<itemset nodeset="instance('products')/products/product[(@id &gt; 3 and @id &lt; 6) or (@id &gt;= 3 and @id &lt;= 6)]">
 				<label ref="name" />

--- a/tests/static/javaRosa/test-xml-2.xml
+++ b/tests/static/javaRosa/test-xml-2.xml
@@ -14,7 +14,7 @@
 					<question1/>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="xsd:string"
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" type="xsd:string"
 				jr:constraintMsg="jr:itext('question1-constraintMsg')" />
 			<itext>
 				<translation lang="en" default="">
@@ -73,7 +73,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/question1" ref="/data/question1">
+		<input vellum:ref="🍌#form/question1🍌" ref="/data/question1">
 			<label ref="jr:itext('question1-label')"/>
 			<hint ref="jr:itext('question1-hint')"/>
 			<help ref="jr:itext('question1-help')"/>

--- a/tests/static/javaRosa/test-xml-4.xml
+++ b/tests/static/javaRosa/test-xml-4.xml
@@ -15,15 +15,15 @@
 					<question2/>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/first_question" nodeset="/data/first_question" type="xsd:string"/>
-			<bind vellum:nodeset="#form/question2" nodeset="/data/question2" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/first_question🍌" nodeset="/data/first_question" type="xsd:string"/>
+			<bind vellum:nodeset="🍌#form/question2🍌" nodeset="/data/question2" type="xsd:string"/>
 			<itext>
 				<translation lang="en" default="">
 					<text id="first_question-label">
 						<value>first_question</value>
 					</text>
 					<text id="question2-label">
-						<value><output vellum:value="#form/first_question" value="/data/first_question" /> a <output vellum:value="#form/first_question" value="/data/first_question" /> b <output vellum:value="#form/first_question" value="/data/first_question" /> c <output vellum:value="#form/first_question" value="/data/first_question" /> d <output vellum:value="if(#form/first_question = '', '', format-date(date(#form/first_question), '%a%b%c'))" value="if(/data/first_question = '', '', format-date(date(/data/first_question), '%a%b%c'))" /></value>
+						<value><output vellum:value="🍌#form/first_question🍌" value="/data/first_question" /> a <output vellum:value="🍌#form/first_question🍌" value="/data/first_question" /> b <output vellum:value="🍌#form/first_question🍌" value="/data/first_question" /> c <output vellum:value="🍌#form/first_question🍌" value="/data/first_question" /> d <output vellum:value="if(🍌#form/first_question🍌 = '', '', format-date(date(🍌#form/first_question🍌), '%a%b%c'))" value="if(/data/first_question = '', '', format-date(date(/data/first_question), '%a%b%c'))" /></value>
 					</text>
 				</translation>
 				<translation lang="hin">
@@ -31,17 +31,17 @@
 						<value>first_question</value>
 					</text>
 					<text id="question2-label">
-						<value><output vellum:value="#form/first_question" value="/data/first_question" /></value>
+						<value><output vellum:value="🍌#form/first_question🍌" value="/data/first_question" /></value>
 					</text>
 				</translation>
 			</itext>
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/first_question" ref="/data/first_question">
+		<input vellum:ref="🍌#form/first_question🍌" ref="/data/first_question">
 			<label ref="jr:itext('first_question-label')"/>
 		</input>
-		<input vellum:ref="#form/question2" ref="/data/question2">
+		<input vellum:ref="🍌#form/question2🍌" ref="/data/question2">
 			<label ref="jr:itext('question2-label')"/>
 		</input>
 	</h:body>

--- a/tests/static/javaRosa/text-question.xml
+++ b/tests/static/javaRosa/text-question.xml
@@ -8,7 +8,7 @@
 					<question1 />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="question1-label">
@@ -24,7 +24,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/question1" ref="/data/question1">
+		<input vellum:ref="🍌#form/question1🍌" ref="/data/question1">
 			<label ref="jr:itext('question1-label')" />
 		</input>
 	</h:body>

--- a/tests/static/lock/test.xml
+++ b/tests/static/lock/test.xml
@@ -19,11 +19,11 @@
 					<group />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/node_locked" nodeset="/data/node_locked" type="xsd:string" vellum:lock="node" />
-			<bind vellum:nodeset="#form/value_locked" nodeset="/data/value_locked" type="xsd:string" vellum:lock="value"/>
-			<bind vellum:nodeset="#form/none_locked" nodeset="/data/none_locked" type="xsd:string" vellum:lock="none" />
-			<bind vellum:nodeset="#form/normal" nodeset="/data/normal" type="xsd:string" />
-			<bind vellum:nodeset="#form/group" nodeset="/data/group" />
+			<bind vellum:nodeset="🍌#form/node_locked🍌" nodeset="/data/node_locked" type="xsd:string" vellum:lock="node" />
+			<bind vellum:nodeset="🍌#form/value_locked🍌" nodeset="/data/value_locked" type="xsd:string" vellum:lock="value"/>
+			<bind vellum:nodeset="🍌#form/none_locked🍌" nodeset="/data/none_locked" type="xsd:string" vellum:lock="none" />
+			<bind vellum:nodeset="🍌#form/normal🍌" nodeset="/data/normal" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/group🍌" nodeset="/data/group" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="node_locked-label">
@@ -43,18 +43,18 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/node_locked" ref="/data/node_locked">
+		<input vellum:ref="🍌#form/node_locked🍌" ref="/data/node_locked">
 			<label ref="jr:itext('node_locked-label')" />
 		</input>
-		<input vellum:ref="#form/value_locked" ref="/data/value_locked">
+		<input vellum:ref="🍌#form/value_locked🍌" ref="/data/value_locked">
 			<label ref="jr:itext('value_locked-label')" />
 		</input>
-		<input vellum:ref="#form/none_locked" ref="/data/none_locked">
+		<input vellum:ref="🍌#form/none_locked🍌" ref="/data/none_locked">
 			<label ref="jr:itext('none_locked-label')" />
 		</input>
-		<input vellum:ref="#form/normal" ref="/data/normal">
+		<input vellum:ref="🍌#form/normal🍌" ref="/data/normal">
 			<label ref="jr:itext('normal-label')" />
 		</input>
-		<group vellum:ref="#form/group" ref="/data/group"></group>
+		<group vellum:ref="🍌#form/group🍌" ref="/data/group"></group>
 	</h:body>
 </h:html>

--- a/tests/static/markdown/explicit-no-markdown.xml
+++ b/tests/static/markdown/explicit-no-markdown.xml
@@ -8,7 +8,7 @@
 					<markdown_question />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/markdown_question" nodeset="/data/markdown_question" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/markdown_question🍌" nodeset="/data/markdown_question" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="markdown_question-label">
@@ -24,7 +24,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/markdown_question" ref="/data/markdown_question">
+		<input vellum:ref="🍌#form/markdown_question🍌" ref="/data/markdown_question">
 			<label ref="jr:itext('markdown_question-label')" />
 		</input>
 	</h:body>

--- a/tests/static/markdown/no-markdown-stars.xml
+++ b/tests/static/markdown/no-markdown-stars.xml
@@ -8,7 +8,7 @@
 					<markdown_question />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/markdown_question" nodeset="/data/markdown_question" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/markdown_question🍌" nodeset="/data/markdown_question" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="markdown_question-label">
@@ -24,7 +24,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/markdown_question" ref="/data/markdown_question">
+		<input vellum:ref="🍌#form/markdown_question🍌" ref="/data/markdown_question">
 			<label ref="jr:itext('markdown_question-label')" />
 		</input>
 	</h:body>

--- a/tests/static/markdown/no-markdown.xml
+++ b/tests/static/markdown/no-markdown.xml
@@ -8,7 +8,7 @@
 					<markdown_question />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/markdown_question" nodeset="/data/markdown_question" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/markdown_question🍌" nodeset="/data/markdown_question" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="markdown_question-label">
@@ -24,7 +24,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/markdown_question" ref="/data/markdown_question">
+		<input vellum:ref="🍌#form/markdown_question🍌" ref="/data/markdown_question">
 			<label ref="jr:itext('markdown_question-label')" />
 		</input>
 	</h:body>

--- a/tests/static/markdown/simple-markdown-no-chars.xml
+++ b/tests/static/markdown/simple-markdown-no-chars.xml
@@ -8,7 +8,7 @@
 					<markdown_question />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/markdown_question" nodeset="/data/markdown_question" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/markdown_question🍌" nodeset="/data/markdown_question" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="markdown_question-label">
@@ -26,7 +26,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/markdown_question" ref="/data/markdown_question">
+		<input vellum:ref="🍌#form/markdown_question🍌" ref="/data/markdown_question">
 			<label ref="jr:itext('markdown_question-label')" />
 		</input>
 	</h:body>

--- a/tests/static/markdown/simple-markdown.xml
+++ b/tests/static/markdown/simple-markdown.xml
@@ -8,7 +8,7 @@
 					<markdown_question />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/markdown_question" nodeset="/data/markdown_question" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/markdown_question🍌" nodeset="/data/markdown_question" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="markdown_question-label">
@@ -26,7 +26,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/markdown_question" ref="/data/markdown_question">
+		<input vellum:ref="🍌#form/markdown_question🍌" ref="/data/markdown_question">
 			<label ref="jr:itext('markdown_question-label')" />
 		</input>
 	</h:body>

--- a/tests/static/modeliteration/case-list-iteration-with-questions.xml
+++ b/tests/static/modeliteration/case-list-iteration-with-questions.xml
@@ -21,7 +21,7 @@
 			<setvalue event="xforms-ready" ref="/data/group/@ids" value="join(' ', instance('casedb')/mother/child/@case_id)" />
 			<setvalue event="xforms-ready" ref="/data/group/@count" value="count-selected(/data/group/@ids)" />
 			<setvalue event="jr-insert" ref="/data/group/item/@index" value="int(/data/group/@current_index)" />
-			<setvalue event="jr-insert" ref="/data/group/item/@id" value="selected-at(/data/group/@ids,../@index)" />
+			<setvalue event="jr-insert" ref="/data/group/item/@id" value="selected-at(/data/group/@ids, ../@index)" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="group/item-label">

--- a/tests/static/modeliteration/case-list-iteration-with-questions.xml
+++ b/tests/static/modeliteration/case-list-iteration-with-questions.xml
@@ -14,10 +14,10 @@
 				</data>
 			</instance>
 			<instance src="jr://instance/casedb" id="casedb"></instance>
-			<bind nodeset="/data/group/@current_index" vellum:calculate="count(#form/group/item)" calculate="count(/data/group/item)" />
-			<bind vellum:nodeset="#form/group/item" nodeset="/data/group/item" />
-			<bind vellum:nodeset="#form/group/item/phone" nodeset="/data/group/item/phone" type="xsd:string" />
-			<bind vellum:nodeset="#form/group/item/hidden" nodeset="/data/group/item/hidden" vellum:calculate="#form/group/item/phone = '12345'" calculate="/data/group/item/phone = '12345'" />
+			<bind nodeset="/data/group/@current_index" vellum:calculate="count(🍌#form/group/item🍌)" calculate="count(/data/group/item)" />
+			<bind vellum:nodeset="🍌#form/group/item🍌" nodeset="/data/group/item" />
+			<bind vellum:nodeset="🍌#form/group/item/phone🍌" nodeset="/data/group/item/phone" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/group/item/hidden🍌" nodeset="/data/group/item/hidden" vellum:calculate="🍌#form/group/item/phone🍌 = '12345'" calculate="/data/group/item/phone = '12345'" />
 			<setvalue event="xforms-ready" ref="/data/group/@ids" value="join(' ', instance('casedb')/mother/child/@case_id)" />
 			<setvalue event="xforms-ready" ref="/data/group/@count" value="count-selected(/data/group/@ids)" />
 			<setvalue event="jr-insert" ref="/data/group/item/@index" value="int(/data/group/@current_index)" />
@@ -37,8 +37,8 @@
 	<h:body>
 		<group>
 			<label ref="jr:itext('group/item-label')" />
-			<repeat jr:count="/data/group/@count" jr:noAddRemove="true()" vellum:nodeset="#form/group/item" nodeset="/data/group/item">
-				<input vellum:ref="#form/group/item/phone" ref="/data/group/item/phone" appearance="numeric">
+			<repeat jr:count="/data/group/@count" jr:noAddRemove="true()" vellum:nodeset="🍌#form/group/item🍌" nodeset="/data/group/item">
+				<input vellum:ref="🍌#form/group/item/phone🍌" ref="/data/group/item/phone" appearance="numeric">
 					<label ref="jr:itext('group/item/phone-label')" />
 				</input>
 			</repeat>

--- a/tests/static/modeliteration/case-list-iteration.xml
+++ b/tests/static/modeliteration/case-list-iteration.xml
@@ -11,8 +11,8 @@
 				</data>
 			</instance>
 			<instance id="casedb" src="jr://instance/casedb"></instance>
-			<bind nodeset="/data/child/@current_index" vellum:calculate="count(#form/child/item)" calculate="count(/data/child/item)" />
-			<bind vellum:nodeset="#form/child/item" nodeset="/data/child/item" />
+			<bind nodeset="/data/child/@current_index" vellum:calculate="count(🍌#form/child/item🍌)" calculate="count(/data/child/item)" />
+			<bind vellum:nodeset="🍌#form/child/item🍌" nodeset="/data/child/item" />
 			<setvalue event="xforms-ready" ref="/data/child/@ids" value="join(' ', instance('casedb')/mother/child/@case_id)" />
 			<setvalue event="xforms-ready" ref="/data/child/@count" value="count-selected(/data/child/@ids)" />
 			<setvalue event="jr-insert" ref="/data/child/item/@index" value="int(/data/child/@current_index)" />
@@ -33,7 +33,7 @@
 	<h:body>
 		<group>
 			<label ref="jr:itext('child/item-label')" />
-			<repeat vellum:nodeset="#form/child/item" nodeset="/data/child/item" jr:count="/data/child/@count" jr:noAddRemove="true()" />
+			<repeat vellum:nodeset="🍌#form/child/item🍌" nodeset="/data/child/item" jr:count="/data/child/@count" jr:noAddRemove="true()" />
 		</group>
 	</h:body>
 </h:html>

--- a/tests/static/modeliteration/case-list-iteration.xml
+++ b/tests/static/modeliteration/case-list-iteration.xml
@@ -16,7 +16,7 @@
 			<setvalue event="xforms-ready" ref="/data/child/@ids" value="join(' ', instance('casedb')/mother/child/@case_id)" />
 			<setvalue event="xforms-ready" ref="/data/child/@count" value="count-selected(/data/child/@ids)" />
 			<setvalue event="jr-insert" ref="/data/child/item/@index" value="int(/data/child/@current_index)" />
-			<setvalue event="jr-insert" ref="/data/child/item/@id" value="selected-at(/data/child/@ids,../@index)" />
+			<setvalue event="jr-insert" ref="/data/child/item/@id" value="selected-at(/data/child/@ids, ../@index)" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="child/item-label">

--- a/tests/static/modeliteration/fixture-iteration-no-ids.xml
+++ b/tests/static/modeliteration/fixture-iteration-no-ids.xml
@@ -12,7 +12,7 @@
 			</instance>
 			<instance id="products" src="jr://fixture/commtrack:products"/>
 			<setvalue event="xforms-ready" ref="/data/product/@count" value="count(instance('products')/products/product)" />
-			<setvalue event="jr-insert" ref="/data/product/@current_index" vellum:value="count(#form/product/item)" value="count(/data/product/item)" />
+			<setvalue event="jr-insert" ref="/data/product/@current_index" vellum:value="count(🍌#form/product/item🍌)" value="count(/data/product/item)" />
 			<setvalue event="jr-insert" ref="/data/product/item/@index" value="int(/data/product/@current_index)" />
 			<bind vellum:nodeset="#form/product" nodeset="/data/product"/>
 			<itext>
@@ -27,7 +27,7 @@
 	<h:body>
 		<group>
 			<label ref="jr:itext('product-label')"/>
-			<repeat vellum:nodeset="#form/product/item" nodeset="/data/product/item" jr:count="/data/product/@count">
+			<repeat vellum:nodeset="🍌#form/product/item🍌" nodeset="/data/product/item" jr:count="/data/product/@count">
 			</repeat>
 		</group>
 	</h:body>

--- a/tests/static/modeliteration/fixture-iteration.xml
+++ b/tests/static/modeliteration/fixture-iteration.xml
@@ -16,7 +16,7 @@
 			<setvalue event="xforms-ready" ref="/data/product/@ids" value="join(' ', instance('products')/products/product/@id)" />
 			<setvalue event="xforms-ready" ref="/data/product/@count" value="count-selected(/data/product/@ids)" />
 			<setvalue event="jr-insert" ref="/data/product/item/@index" value="int(/data/product/@current_index)" />
-			<setvalue event="jr-insert" ref="/data/product/item/@id" value="selected-at(/data/product/@ids,../@index)" />
+			<setvalue event="jr-insert" ref="/data/product/item/@id" value="selected-at(/data/product/@ids, ../@index)" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="product/item-label">

--- a/tests/static/modeliteration/fixture-iteration.xml
+++ b/tests/static/modeliteration/fixture-iteration.xml
@@ -11,8 +11,8 @@
 				</data>
 			</instance>
 			<instance id="products" src="jr://fixture/commtrack:products" />
-			<bind nodeset="/data/product/@current_index" vellum:calculate="count(#form/product/item)" calculate="count(/data/product/item)" />
-			<bind vellum:nodeset="#form/product/item" nodeset="/data/product/item" />
+			<bind nodeset="/data/product/@current_index" vellum:calculate="count(🍌#form/product/item🍌)" calculate="count(/data/product/item)" />
+			<bind vellum:nodeset="🍌#form/product/item🍌" nodeset="/data/product/item" />
 			<setvalue event="xforms-ready" ref="/data/product/@ids" value="join(' ', instance('products')/products/product/@id)" />
 			<setvalue event="xforms-ready" ref="/data/product/@count" value="count-selected(/data/product/@ids)" />
 			<setvalue event="jr-insert" ref="/data/product/item/@index" value="int(/data/product/@current_index)" />
@@ -30,7 +30,7 @@
 	<h:body>
 		<group>
 			<label ref="jr:itext('product/item-label')" />
-			<repeat vellum:nodeset="#form/product/item" nodeset="/data/product/item" jr:count="/data/product/@count" jr:noAddRemove="true()" />
+			<repeat vellum:nodeset="🍌#form/product/item🍌" nodeset="/data/product/item" jr:count="/data/product/@count" jr:noAddRemove="true()" />
 		</group>
 	</h:body>
 </h:html>

--- a/tests/static/modeliteration/regular-repeat.xml
+++ b/tests/static/modeliteration/regular-repeat.xml
@@ -8,7 +8,7 @@
 					<product jr:template="" />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/product" nodeset="/data/product" />
+			<bind vellum:nodeset="🍌#form/product🍌" nodeset="/data/product" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="product-label">
@@ -21,7 +21,7 @@
 	<h:body>
 		<group>
 			<label ref="jr:itext('product-label')" />
-			<repeat vellum:nodeset="#form/product" nodeset="/data/product" />
+			<repeat vellum:nodeset="🍌#form/product🍌" nodeset="/data/product" />
 		</group>
 	</h:body>
 </h:html>

--- a/tests/static/parser/overridden.xml
+++ b/tests/static/parser/overridden.xml
@@ -10,27 +10,27 @@
 					<question3 />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="xsd:string" />
-			<bind vellum:nodeset="#form/question2" nodeset="/data/question2" type="xsd:string" vellum:constraint="#form/question1" constraint="/data/question1" vellum:relevant="#form/question1" relevant="/data/question1" />
-			<bind vellum:nodeset="#form/question3" nodeset="/data/question3" vellum:calculate="#form/question1" calculate="/data/question1" />
-			<setvalue event="xforms-ready" vellum:ref="#form/question2" ref="/data/question2" vellum:value="#form/question1" value="/data/question1" />
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/question2🍌" nodeset="/data/question2" type="xsd:string" vellum:constraint="🍌#form/question1🍌" constraint="/data/question1" vellum:relevant="🍌#form/question1🍌" relevant="/data/question1" />
+			<bind vellum:nodeset="🍌#form/question3🍌" nodeset="/data/question3" vellum:calculate="🍌#form/question1🍌" calculate="/data/question1" />
+			<setvalue event="xforms-ready" vellum:ref="🍌#form/question2🍌" ref="/data/question2" vellum:value="🍌#form/question1🍌" value="/data/question1" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="question1-label">
 						<value>question1</value>
 					</text>
 					<text id="question2-label">
-						<value><output vellum:value="#form/question1" value="/data/question1" /> question2</value>
+						<value><output vellum:value="🍌#form/question1🍌" value="/data/question1" /> question2</value>
 					</text>
 				</translation>
 			</itext>
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/question1" ref="/data/question1">
+		<input vellum:ref="🍌#form/question1🍌" ref="/data/question1">
 			<label ref="jr:itext('question1-label')" />
 		</input>
-		<input vellum:ref="#form/question2" ref="/data/question2">
+		<input vellum:ref="🍌#form/question2🍌" ref="/data/question2">
 			<label ref="jr:itext('question2-label')" />
 		</input>
 	</h:body>

--- a/tests/static/saveToCase/attachment_property.xml
+++ b/tests/static/saveToCase/attachment_property.xml
@@ -15,8 +15,8 @@
 					</save_to_case>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="binary" />
-			<bind nodeset="/data/save_to_case/case/attachment/attach/@src" vellum:calculate="#form/question1" calculate="/data/question1" />
+			<bind vellum:nodeset="🍌#form/question1🍌" nodeset="/data/question1" type="binary" />
+			<bind nodeset="/data/save_to_case/case/attachment/attach/@src" vellum:calculate="🍌#form/question1🍌" calculate="/data/question1" />
 			<bind nodeset="/data/save_to_case/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />
 			<bind nodeset="/data/save_to_case/case/@user_id" calculate="/data/meta/userID" />
 			<bind nodeset="/data/save_to_case/case/@case_id" calculate="/data/meta/caseID" />
@@ -30,7 +30,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<upload mediatype="image/*" vellum:ref="#form/question1" ref="/data/question1">
+		<upload mediatype="image/*" vellum:ref="🍌#form/question1🍌" ref="/data/question1">
 			<label ref="jr:itext('question1-label')" />
 		</upload>
 	</h:body>

--- a/tests/static/saveToCase/close_property.xml
+++ b/tests/static/saveToCase/close_property.xml
@@ -13,7 +13,7 @@
 					</save_to_case>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/name🍌" nodeset="/data/name" type="xsd:string" />
 			<bind nodeset="/data/save_to_case/case/close" relevant="1=1" />
 			<bind nodeset="/data/save_to_case/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />
 			<bind nodeset="/data/save_to_case/case/@user_id" calculate="/data/meta/userID" />
@@ -28,7 +28,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/name" ref="/data/name">
+		<input vellum:ref="🍌#form/name🍌" ref="/data/name">
 			<label ref="jr:itext('name-label')" />
 		</input>
 	</h:body>

--- a/tests/static/saveToCase/create_2_property.xml
+++ b/tests/static/saveToCase/create_2_property.xml
@@ -26,14 +26,14 @@
 					</create2>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/name🍌" nodeset="/data/name" type="xsd:string" />
 			<bind nodeset="/data/create1/case/create/case_type" calculate="caseType" />
-			<bind nodeset="/data/create1/case/create/case_name" vellum:calculate="#form/name" calculate="/data/name" />
+			<bind nodeset="/data/create1/case/create/case_name" vellum:calculate="🍌#form/name🍌" calculate="/data/name" />
 			<bind nodeset="/data/create1/case/create/owner_id" calculate="/data/meta/userID" />
 			<bind nodeset="/data/create1/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />
 			<bind nodeset="/data/create1/case/@user_id" calculate="/data/meta/userID" />
 			<bind nodeset="/data/create2/case/create/case_type" calculate="caseType" />
-			<bind nodeset="/data/create2/case/create/case_name" vellum:calculate="#form/name" calculate="/data/name" />
+			<bind nodeset="/data/create2/case/create/case_name" vellum:calculate="🍌#form/name🍌" calculate="/data/name" />
 			<bind nodeset="/data/create2/case/create/owner_id" calculate="/data/meta/userID" />
 			<bind nodeset="/data/create2/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />
 			<bind nodeset="/data/create2/case/@user_id" calculate="/data/meta/userID" />
@@ -49,7 +49,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/name" ref="/data/name">
+		<input vellum:ref="🍌#form/name🍌" ref="/data/name">
 			<label ref="jr:itext('name-label')" />
 		</input>
 	</h:body>

--- a/tests/static/saveToCase/create_property.xml
+++ b/tests/static/saveToCase/create_property.xml
@@ -17,9 +17,9 @@
 					</save_to_case>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/name🍌" nodeset="/data/name" type="xsd:string" />
 			<bind nodeset="/data/save_to_case/case/create/case_type" calculate="caseType" />
-			<bind nodeset="/data/save_to_case/case/create/case_name" vellum:calculate="#form/name" calculate="/data/name" />
+			<bind nodeset="/data/save_to_case/case/create/case_name" vellum:calculate="🍌#form/name🍌" calculate="/data/name" />
 			<bind nodeset="/data/save_to_case/case/create/owner_id" calculate="/data/meta/userID" />
 			<bind nodeset="/data/save_to_case/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />
 			<bind nodeset="/data/save_to_case/case/@user_id" calculate="/data/meta/userID" />
@@ -34,7 +34,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/name" ref="/data/name">
+		<input vellum:ref="🍌#form/name🍌" ref="/data/name">
 			<label ref="jr:itext('name-label')" />
 		</input>
 	</h:body>

--- a/tests/static/saveToCase/index_property.xml
+++ b/tests/static/saveToCase/index_property.xml
@@ -15,7 +15,7 @@
 					</save_to_case>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/name🍌" nodeset="/data/name" type="xsd:string" />
 			<bind nodeset="/data/save_to_case/case/index/extension" calculate="/data/meta/caseID" />
 			<bind nodeset="/data/save_to_case/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />
 			<bind nodeset="/data/save_to_case/case/@user_id" calculate="/data/meta/userID" />
@@ -30,7 +30,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/name" ref="/data/name">
+		<input vellum:ref="🍌#form/name🍌" ref="/data/name">
 			<label ref="jr:itext('name-label')" />
 		</input>
 	</h:body>

--- a/tests/static/saveToCase/update_property.xml
+++ b/tests/static/saveToCase/update_property.xml
@@ -15,8 +15,8 @@
 					</save_to_case>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
-			<bind nodeset="/data/save_to_case/case/update/name" vellum:relevant="#form/name != ''" vellum:calculate="#form/name" relevant="/data/name != ''" calculate="/data/name" />
+			<bind vellum:nodeset="🍌#form/name🍌" nodeset="/data/name" type="xsd:string" />
+			<bind nodeset="/data/save_to_case/case/update/name" vellum:relevant="🍌#form/name🍌 != ''" vellum:calculate="🍌#form/name🍌" relevant="/data/name != ''" calculate="/data/name" />
 			<bind nodeset="/data/save_to_case/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />
 			<bind nodeset="/data/save_to_case/case/@user_id" calculate="/data/meta/userID" />
 			<bind nodeset="/data/save_to_case/case/@case_id" calculate="/data/meta/caseID" />
@@ -30,7 +30,7 @@
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/name" ref="/data/name">
+		<input vellum:ref="🍌#form/name🍌" ref="/data/name">
 			<label ref="jr:itext('name-label')" />
 		</input>
 	</h:body>

--- a/tests/static/writer/repeat-with-count.xml
+++ b/tests/static/writer/repeat-with-count.xml
@@ -10,8 +10,8 @@
 					</group>
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/group" nodeset="/data/group" />
-			<bind vellum:nodeset="#form/group/question2" nodeset="/data/group/question2" type="xsd:string" />
+			<bind vellum:nodeset="🍌#form/group🍌" nodeset="/data/group" />
+			<bind vellum:nodeset="🍌#form/group/question2🍌" nodeset="/data/group/question2" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="group-label">
@@ -35,8 +35,8 @@
 	<h:body>
 		<group>
 			<label ref="jr:itext('group-label')" />
-			<repeat vellum:nodeset="#form/group" nodeset="/data/group" jr:count="3" jr:noAddRemove="true()">
-				<input vellum:ref="#form/group/question2" ref="/data/group/question2">
+			<repeat vellum:nodeset="🍌#form/group🍌" nodeset="/data/group" jr:count="3" jr:noAddRemove="true()">
+				<input vellum:ref="🍌#form/group/question2🍌" ref="/data/group/question2">
 					<label ref="jr:itext('group/question2-label')" />
 				</input>
 			</repeat>

--- a/tests/static/writer/repeat-without-count.xml
+++ b/tests/static/writer/repeat-without-count.xml
@@ -8,7 +8,7 @@
 					<group jr:template="" />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/group" nodeset="/data/group" />
+			<bind vellum:nodeset="🍌#form/group🍌" nodeset="/data/group" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="group-label">
@@ -26,7 +26,7 @@
 	<h:body>
 		<group>
 			<label ref="jr:itext('group-label')" />
-			<repeat vellum:nodeset="#form/group" nodeset="/data/group" />
+			<repeat vellum:nodeset="🍌#form/group🍌" nodeset="/data/group" />
 		</group>
 	</h:body>
 </h:html>

--- a/tests/widgets.js
+++ b/tests/widgets.js
@@ -152,7 +152,7 @@ define([
             disp.input.promise.then(function () { // wait for editor to be ready
                 util.findNode(tree, "hidden").data.handleDrop(disp.input);
                 disp.handleChange();
-                assert.equal(text.p.relevantAttr, '#form/hidden');
+                assert.equal(text.p.relevantAttr, '🍌#form/hidden🍌');
                 done();
             });
         });


### PR DESCRIPTION
@millerdev 

This is going into my other PR.

Mostly test changes once again. Adds in delimiting :banana:s. Also you can now use #case. I tried splitting these up, but that turned out to be pretty messy.

New functionality:
cases use #case/type/prop instead of instance('casedb')

Now :banana:s can be copied over (and retain their :banana: ness) and will appear red if they don't appear in the form (assuming colors/etc will change): 
![image](https://cloud.githubusercontent.com/assets/1471773/13117949/0170a1e2-d570-11e5-9a70-5000e05879dd.png)

eagerly :banana:s references on parse and interior code should expect :banana: but for now will accept hashtag or absolute (/data/ or instance('casedb')) syntaxing and auto convert it. I imagine it will stay this way until we can fully :banana: everything

Sends case references to HQ (PR coming up) so that the app summary will show the references

Difference between :banana: and hashtags:

:banana: is our internal representation. It is also written to forms in a vellum namespaced attribute. Hashtags are what the user sees. and also what they'll use in the rest of the app manager (like module/form filters)

cc: @snopoke 