### PR TITLE
Move fuse to form

### DIFF
--- a/src/atwho.js
+++ b/src/atwho.js
@@ -1,7 +1,6 @@
 define([
     'underscore',
     'jquery',
-    'fusejs',
     'vellum/richText',
     'vellum/util',
     'tpl!vellum/templates/atwho_display',
@@ -9,7 +8,6 @@ define([
 ], function (
     _,
     $,
-    fusejs,
     richText,
     util,
     atwhoDisplay
@@ -90,7 +88,7 @@ define([
 
         function addAtWhoToInput() {
             var _atWhoOptions = function(atKey) {
-                var fuse = mug.form.fuse;
+                var form = mug.form;
 
                 return {
                     at: atKey,
@@ -107,8 +105,8 @@ define([
                             return match ? match[2] : null;
                         },
                         filter: function (query, data, searchKey) {
-                            if (!query) { return fuse.list(); }
-                            return fuse.search(query);
+                            if (!query) { return form.fuse.list(); }
+                            return form.fuse.search(query);
                         },
                         sorter: function (query, items, searchKey) {
                             return _.map(items, function(item, idx) {

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -105,8 +105,14 @@ define([
                             return match ? match[2] : null;
                         },
                         filter: function (query, data, searchKey) {
-                            if (!query) { return form.fuse.list(); }
-                            return form.fuse.search(query);
+                            function withoutSelf (list) {
+                                return _.filter(list, function(mug_) {
+                                    return mug.ufid !== mug_.id;
+                                });
+                            }
+
+                            if (!query) { return withoutSelf(form.fuse.list()); }
+                            return withoutSelf(form.fuse.search(query));
                         },
                         sorter: function (query, items, searchKey) {
                             return _.map(items, function(item, idx) {

--- a/src/core.js
+++ b/src/core.js
@@ -1083,6 +1083,7 @@ define([
                 _this.data.core.parseWarnings = [];
                 _this.loadXML(formString, {});
                 delete _this.data.core.parseWarnings;
+                _this.data.core.form.fire('form-load-finished');
 
                 if (formString) {
                     //re-enable all buttons and inputs in case they were disabled before.

--- a/src/form.js
+++ b/src/form.js
@@ -5,6 +5,7 @@ define([
     'vellum/xpath',
     'vellum/tree',
     'vellum/logic',
+    'vellum/fuse',
     'vellum/util'
 ], function (
     require,
@@ -13,6 +14,7 @@ define([
     xpath,
     Tree,
     logic,
+    Fuse,
     util
 ) {
     // Load these dependencies in the background after all other run-time
@@ -135,6 +137,9 @@ define([
 
         //make the object event aware
         util.eventuality(this);
+        this.on('form-load-finished', function() {
+            _this.fuse = new Fuse(_this);
+        });
     }
 
     Form.prototype = {

--- a/src/fuse.js
+++ b/src/fuse.js
@@ -1,0 +1,76 @@
+define([
+    'underscore',
+    'fusejs',
+    'vellum/util',
+], function (
+    _,
+    fusejs,
+    util
+) {
+    var FUSE_CONFIG = {
+        keys: ['label', 'name', 'absolutePath']
+    };
+
+    function Fuse(form) {
+        var _this = this;
+        this.form = form;
+        this.dataset = generateNewFuseData(form);
+        this.fusejs = new fusejs(this.dataset, FUSE_CONFIG);
+
+
+        function addToDataset(e) {
+            _this.dataset = _.filter(_this.dataset, function (mug) {
+                return mug.id !== e.mug.ufid;
+            });
+            _this.dataset.push(mugToData(e.mug));
+            _this.fusejs.set(_this.dataset);
+        }
+
+
+        this.form.on('mug-property-change', function (e) {
+            if (e.property === 'nodeID') {
+                addToDataset(e);
+            }
+        }).on('question-label-text-change', addToDataset)
+        .on('question-create', addToDataset)
+        .on('question-remove', addToDataset);
+    }
+
+    Fuse.prototype = {
+        list: function () {
+            return this.fusejs.list;
+        },
+        search: function (query) {
+            return this.fusejs.search(query);
+        }
+    };
+
+    function mugToData(mug) {
+        if (mug) {
+            var defaultLabel = mug.form.vellum.getMugDisplayName(mug);
+
+            return {
+                id: mug.ufid,
+                name: mug.absolutePath,
+                absolutePath: mug.absolutePath,
+                icon: mug.options.icon,
+                questionId: mug.p.nodeID,
+                displayLabel: util.truncate(defaultLabel),
+                label: defaultLabel,
+                mug: mug,
+            };
+        }
+        return null;
+    }
+
+    function generateNewFuseData (form) {
+        return _.chain(form.getMugList())
+                .map(mugToData)
+                .filter(function(choice) {
+                    return choice.name && !_.isUndefined(choice.displayLabel);
+                })
+                .value();
+    }
+
+    return Fuse;
+});

--- a/src/tsv.js
+++ b/src/tsv.js
@@ -62,18 +62,6 @@ define([
         return next;
     }
 
-    function parseRows(value, limit) {
-        var rows = [],
-            next = makeRowParser(value),
-            row = next();
-        while (row) {
-            rows.push(row);
-            if (limit && rows.length >= limit) { break; }
-            row = next();
-        }
-        return rows;
-    }
-
     /**
      * Escape a TSV field value
      *
@@ -115,7 +103,6 @@ define([
     return {
         escape: escape,
         makeRowParser: makeRowParser,
-        parseRows: parseRows,
         tabDelimit: tabDelimit
     };
 });

--- a/src/util.js
+++ b/src/util.js
@@ -36,10 +36,6 @@ define([
         return error && error.stack ? error.stack : String(error);
     };
 
-    that.getTemplateObject = function (selector, params) {
-        return $(_.template($(selector).text(), params));
-    };
-    
     that.validAttributeRegex = /^[^<&'">]*$/;
     that.invalidAttributeRegex = /[<&'">]/;
 
@@ -149,10 +145,6 @@ define([
             return this;
         };
         return that;
-    };
-
-    that.pluralize = function (noun, n) {
-        return noun + (n !== 1 ? 's' : '');
     };
 
     /**

--- a/tests/atwho.js
+++ b/tests/atwho.js
@@ -3,151 +3,70 @@ define([
     'chai',
     'jquery',
     'underscore',
-    'vellum/richText',
-    'vellum/atwho',
-    'vellum/util',
-    'tpl!vellum/templates/atwho_display'
+    'text!static/atwho/test1.xml',
 ], function (
     util,
     chai,
     $,
     _,
-    richText,
-    atwho,
-    real_util,
-    ATWHO_DISPLAY
+    TEST1_XML
 ) {
-    var assert = chai.assert,
-        mugs = [
-            {
-                ufid: 0,
-                absolutePath: '/data/one',
-                options: {
-                    icon: 'fcc fcc-text',
-                },
-                p: {
-                    nodeID: 'one',
-                },
-                displayName: 'One',
-            },
-            {
-                ufid: 1,
-                absolutePath: '/data/long',
-                options: {
-                    icon: 'fcc fcc-text',
-                },
-                p: {
-                    nodeID: 'long',
-                },
-                displayName: 'This is going to be a really long display name that should be truncated',
-            },
-            {
-                ufid: 2,
-                absolutePath: undefined,
-                options: {
-                    icon: 'fcc fcc-choice',
-                },
-                p: {
-                    nodeID: 'choice',
-                },
-                displayName: 'Not going to show up',
-            },
-            {
-                ufid: 3,
-                absolutePath: '/data/modeliteration/item',
-                options: {
-                    icon: 'fcc fcc-choice',
-                },
-                p: {
-                    nodeID: 'item',
-                },
-                displayName: undefined,
-            },
-        ],
-        form = {
-            vellum: {
-                getMugDisplayName: function (mug) {
-                    return mug.displayName;
-                },
-                data: {
-                    atwho: {}
-                },
-            },
-            formUuid: 'test',
-            getMugList: function () { return mugs; },
-        };
-    _.each(mugs, function(mug) {
-        mug.form = form;
-        mug.on = function () {};
-        // for tests in editor
-        mug.icon = mug.options.icon;
-        mug.name = mug.absolutePath;
-        mug.displayLabel = real_util.truncate(form.vellum.getMugDisplayName(mug));
-        real_util.eventuality(mug);
-    });
+    var assert = chai.assert;
+
+    function getFuseData(string) {
+        var form = util.call('getData').core.form,
+            fuseRes = form.fuse.search(string);
+        return fuseRes.length ? fuseRes[0] : null;
+    }
 
     describe("atwho", function() {
-        var atwhoData;
-        before(function() {
-            atwhoData = atwho.cachedMugData(0)(form);
+        beforeEach(function(done) {
+            util.init({
+                javaRosa: {langs: ['en']},
+                core: { form: TEST1_XML, onReady: done },
+                features: {rich_text: false},
+                plugins: ['atwho','modeliteration'],
+            });
         });
 
+        function getDisplayedAtwhoViews() {
+            return $('.atwho-view').filter(function() {
+                return $(this).css('display') === 'block';
+            });
+        }
+
+        function displayAtwho(callback) {
+            var mug = util.clickQuestion('one')[0];
+            var input = $('[name=property-relevantAttr]');
+            input.val('/data/').keyup();
+            assert.strictEqual(getDisplayedAtwhoViews().length, 1);
+            callback(mug);
+            mug.fire('teardown-mug-properties');
+            assert(!getDisplayedAtwhoViews().length);
+        }
+
         it("should truncate the display label", function() {
-            var mug = _.findWhere(atwhoData, {id: 0});
+            var mug = getFuseData('one');
             assert.strictEqual(mug.displayLabel, "One");
-            mug = _.findWhere(atwhoData, {id: 1});
+            mug = getFuseData('long');
             assert.strictEqual(mug.displayLabel, "This is going to be a rea&hellip;");
         });
 
         it("should not show mugs without absolutePath", function() {
-            assert(!_.findWhere(atwhoData, {id: 2}));
+            displayAtwho(function(mug) {
+                assert(!getDisplayedAtwhoViews().find('li:contains("choice1")').length);
+            });
         });
 
-        it("should not show mugs that don't display in the question tree", function() {
-            assert(!_.findWhere(atwhoData, {id: 3}));
+        // only valid for small sets of questions
+        it("should have each mug", function () {
+            displayAtwho(function(mug) {
+                assert.strictEqual(getDisplayedAtwhoViews().find('li').length, 4);
+            });
         });
 
-        describe("in an editor", function() {
-            var el = $("<div id='input'><input /></div>"),
-                mug = mugs[0],
-                input, atwhoview;
-
-            function getDisplayedAtwhoViews() {
-                return $('.atwho-view').filter(function() {
-                    return $(this).css('display') === 'block';
-                });
-            }
-            before(function () {
-                $('.atwho-container').remove();
-                $("body").append(el);
-                input = el.children().first();
-                atwho._questionAutocomplete(input, mug);
-                input.val('/data/');
-                input.keyup();
-                atwhoview = getDisplayedAtwhoViews();
-                assert.strictEqual(atwhoview.length, 1);
-            });
-            after(function() {
-                input.atwho('destroy');
-                input.remove();
-            });
-
-            it("should pop up", function () {
-                assert.strictEqual(atwhoview.length, 1);
-            });
-
-            it("should have each mug", function () {
-                assert.strictEqual(atwhoview.length, 1);
-                var listItems = atwhoview.find('li');
-
-                _.each(listItems, function(item, index) {
-                    assert.strictEqual(listItems[index].innerHTML,
-                                       $(ATWHO_DISPLAY(mugs[index]))[0].innerHTML);
-                });
-            });
-
-            it("should destroy the atwho container on mug removal", function() {
-                assert.strictEqual(atwhoview.length, 1);
+        it("should destroy the atwho container on mug removal", function() {
+            displayAtwho(function(mug) {
                 mug.fire('teardown-mug-properties');
                 assert(!getDisplayedAtwhoViews().length);
             });

--- a/tests/atwho.js
+++ b/tests/atwho.js
@@ -40,9 +40,18 @@ define([
             var input = $('[name=property-relevantAttr]');
             input.val('/data/').keyup();
             assert.strictEqual(getDisplayedAtwhoViews().length, 1);
-            callback(mug);
-            mug.fire('teardown-mug-properties');
+            try {
+                callback(mug);
+            } catch (err) {
+                throw err;
+            } finally {
+                mug.fire('teardown-mug-properties');
+            }
             assert(!getDisplayedAtwhoViews().length);
+        }
+
+        function assertNumAtwhoChoices(num) {
+            assert.strictEqual(getDisplayedAtwhoViews().find('li').length, num);
         }
 
         it("should truncate the display label", function() {
@@ -61,7 +70,7 @@ define([
         // only valid for small sets of questions
         it("should have each mug", function () {
             displayAtwho(function(mug) {
-                assert.strictEqual(getDisplayedAtwhoViews().find('li').length, 4);
+                assertNumAtwhoChoices(3);
             });
         });
 
@@ -69,6 +78,12 @@ define([
             displayAtwho(function(mug) {
                 mug.fire('teardown-mug-properties');
                 assert(!getDisplayedAtwhoViews().length);
+            });
+        });
+
+        it("should not show itself in the results", function () {
+            displayAtwho(function(mug) {
+                assertNumAtwhoChoices(3);
             });
         });
     });

--- a/tests/static/atwho/test1.xml
+++ b/tests/static/atwho/test1.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="undefined" uiVersion="1" version="1" name="Untitled Form">
+					<one />
+					<long />
+					<Choice_Question />
+					<question4 ids="" count="" current_index="" vellum:role="Repeat">
+						<item id="" index="" jr:template="" />
+					</question4>
+				</data>
+			</instance>
+			<instance src="jr://instance/casedb" id="casedb" />
+			<bind vellum:nodeset="#form/one" nodeset="/data/one" type="xsd:string" />
+			<bind vellum:nodeset="#form/long" nodeset="/data/long" type="xsd:string" />
+			<bind vellum:nodeset="#form/Choice_Question" nodeset="/data/Choice_Question" />
+			<bind nodeset="/data/question4/@current_index" vellum:calculate="count(#form/question4/item)" calculate="count(/data/question4/item)" />
+			<bind vellum:nodeset="#form/question4/item" nodeset="/data/question4/item" />
+			<setvalue event="xforms-ready" ref="/data/question4/@ids" value="join(' ', instance('casedb')/mother/child/@case_id)" />
+			<setvalue event="xforms-ready" ref="/data/question4/@count" value="count-selected(/data/question4/@ids)" />
+			<setvalue event="jr-insert" ref="/data/question4/item/@index" value="int(/data/question4/@current_index)" />
+			<setvalue event="jr-insert" ref="/data/question4/item/@id" value="selected-at(/data/question4/@ids, ../@index)" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="one-label">
+						<value>One</value>
+					</text>
+					<text id="long-label">
+						<value>This is going to be a really long display name that should be truncated</value>
+					</text>
+					<text id="Choice_Question-label">
+						<value>Choice_Question</value>
+					</text>
+					<text id="Choice_Question-choice1-label">
+						<value>Don't show up</value>
+					</text>
+					<text id="question4/item-label">
+						<value>question4</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input vellum:ref="#form/one" ref="/data/one">
+			<label ref="jr:itext('one-label')" />
+		</input>
+		<input vellum:ref="#form/long" ref="/data/long">
+			<label ref="jr:itext('long-label')" />
+		</input>
+		<select1 vellum:ref="#form/Choice_Question" ref="/data/Choice_Question">
+			<label ref="jr:itext('Choice_Question-label')" />
+			<item>
+				<label ref="jr:itext('Choice_Question-choice1-label')" />
+				<value>choice1</value>
+			</item>
+		</select1>
+		<group>
+			<label ref="jr:itext('question4/item-label')" />
+			<repeat jr:count="/data/question4/@count" jr:noAddRemove="true()" vellum:nodeset="#form/question4/item" nodeset="/data/question4/item" />
+		</group>
+	</h:body>
+</h:html>

--- a/tests/tsv.js
+++ b/tests/tsv.js
@@ -8,12 +8,24 @@ define([
 ) {
     var assert = chai.assert;
 
+    function parseRows(value, limit) {
+        var rows = [],
+            next = tsv.makeRowParser(value),
+            row = next();
+        while (row) {
+            rows.push(row);
+            if (limit && rows.length >= limit) { break; }
+            row = next();
+        }
+        return rows;
+    }
+
     function eq(value, parsed, roundTrip) {
         var repr = value
                     .replace(/\r/g, "\\r")
                     .replace(/\n/g, "\\n")
                     .replace(/\t/g, "\\t");
-        assert.deepEqual(tsv.parseRows(value, parsed.length + 5), parsed,
+        assert.deepEqual(parseRows(value, parsed.length + 5), parsed,
                          "parsed '" + repr + "'");
         if (roundTrip) {
             assert.strictEqual(tsv.tabDelimit(parsed), value);

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -166,10 +166,10 @@ define([
         if (opts.javaRosa && opts.javaRosa.langs) {
             vellum_options.javaRosa.langs = opts.javaRosa.langs;
         }
+        vellum_options.plugins = _.without(vellum_options.plugins, "atwho");
         if (opts.plugins) {
             vellum_options.plugins = opts.plugins;
         }
-        vellum_options.plugins = _.without(vellum_options.plugins, "atwho");
         vellum_options.core = vellum_options.core || {};
         var originalSaveUrl = vellum_options.core.saveUrl || function () {};
         vellum_options.core.saveUrl = function (data) {


### PR DESCRIPTION
A refactor of how we do fuzzy finding.

Instead of caching in src/atwho.js. this moves fuse (fuzzy search library) to the form. This means that we no longer need to go through all mugs everytime an autocomplete is created, and in the future for #case references if datasources load while you are already autocompleting new references should pop up seamlessly

cc: @calellowitz 