### PR TITLE
weird backspace behavior

### DIFF
--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -844,13 +844,15 @@ define([
                             start,
                             end,
                             match;
-                        if (e.which === 8) {
-                            match = val.substr(pos - 2, 2);
-                            if (match === outputEnd) {
-                                start = val.lastIndexOf(outputBegin, pos);
-                                end = pos;
+                        if (e.which === 8) { // backspace
+                            if (pos > 1) {
+                                match = val.substr(pos - 2, 2);
+                                if (match === outputEnd) {
+                                    start = val.lastIndexOf(outputBegin, pos);
+                                    end = pos;
+                                }
                             }
-                        } else if (e.which === 46) {
+                        } else if (e.which === 46) { // delete
                             match = val.substr(pos, outputBegin.length);
                             if (match === outputBegin) {
                                 end = val.indexOf(outputEnd, pos);


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?221799

Tried writing a test for this, but the backspace isn't working in phantomjs 

```
it("delete text before output ref", function () {
    util.loadXML("");
    var mug = util.addQuestion("Text", "question1");

    var target = $("[name=itext-en-label]");
    target.val('question1<output value="/data/question2" />').change();
    vellum_util.setCaretPosition(target[0], 2, 9);

    target.trigger({
        type: "keydown",
        which: 8,
        ctrlKey: false
    });
    target.change();
    var val = mug.p.labelItext.get('default', 'en');
    assert.equal(val, '<output value="/data/question2" />');
});
```

The value stays `question1<output value="/data/question2" />'`. I did verify that does work in chrome though.

cc: @dannyroberts 