### PR TITLE
remove placeholder on focus

### DIFF
--- a/src/richText.js
+++ b/src/richText.js
@@ -226,9 +226,15 @@ define([
             },
         };
 
-        // workaround for https://code.google.com/p/chromium/issues/detail?id=313082
-        editor.on('focus', function () {
+        editor.on('focus', function (e) {
+            // workaround for https://code.google.com/p/chromium/issues/detail?id=313082
             editor.setReadOnly(false);
+            // remove any placeholder text that may be in the text area
+            var editable = e.editor.editable();
+            if (editable.hasClass('placeholder')) {
+                editable.removeClass('placeholder');
+                editable.setHtml('');
+            }
             // set the cursor to the end of text
             var selection = editor.getSelection();
             var range = selection.getRanges()[0];


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?222370

Tried making a test using the ckeditor's focusManager, but wasn't able to get it to blur, and display the placeholder. This bug shows up due to a conflict between bubbles and another plugin we use

cc: @dannyroberts 