### PR TITLE
Inline video

### DIFF
--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -1160,7 +1160,7 @@ define([
         image: 'fa fa-photo',
         audio: 'fa fa-volume-up',
         video: 'fa fa-video-camera',
-        'video-inline': 'fa fa-video-camera',
+        'video-inline': 'fa fa-play',
     };
 
     var itextMediaWidget = function (url_type) {

--- a/src/javaRosa.js
+++ b/src/javaRosa.js
@@ -34,14 +34,15 @@ define([
     tsv,
     xml
 ) {
-    var SUPPORTED_MEDIA_TYPES = ['image', 'audio', 'video'],
+    var SUPPORTED_MEDIA_TYPES = ['image', 'audio', 'video', 'video-inline'],
         DEFAULT_EXTENSIONS = {
             image: 'png',
             audio: 'mp3',
-            video: '3gp'
+            video: '3gp',
+            'video-inline': '3gp'
         },
         RESERVED_ITEXT_CONTENT_TYPES = [
-            'default', 'short', 'long', 'audio', 'video', 'image'
+            'default', 'short', 'long', 'audio', 'video', 'image', 'video-inline',
         ],
         _nextItextItemKey = 1,
         NO_MARKDOWN_MUGS = ['Choice', 'Group', 'FieldList', 'Repeat'];
@@ -1159,6 +1160,7 @@ define([
         image: 'fa fa-photo',
         audio: 'fa fa-volume-up',
         video: 'fa fa-video-camera',
+        'video-inline': 'fa fa-video-camera',
     };
 
     var itextMediaWidget = function (url_type) {
@@ -1185,7 +1187,7 @@ define([
     };
     
     var parseXLSItext = function (form, str, Itext) {
-        var forms = ["default", "audio", "image" , "video"],
+        var forms = ["default", "audio", "image" , "video", 'video-inline'],
             languages = Itext.getLanguages(),
             nextRow = tsv.makeRowParser(str),
             header = nextRow(),
@@ -1247,7 +1249,7 @@ define([
         }
 
         // TODO: should this be configurable?
-        var forms = ["default", "audio", "image" , "video"],
+        var forms = ["default", "audio", "image" , "video", 'video-inline'],
             languages = Itext.getLanguages(),
             rows = [];
 

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -51,6 +51,12 @@ define([
                 'extensions': '*.3gp;*.mp4'
             }
         ],
+        'video-inline': [
+            {
+                'description': 'Inline Video',
+                'extensions': '*.3gp;*.mp4'
+            }
+        ],
         text: [
             {
                 'description': 'HTML',
@@ -62,18 +68,21 @@ define([
         image: multimedia_existing_image,
         audio: multimedia_existing_audio,
         video: multimedia_existing_video,
+        'video-inline': multimedia_existing_video,
         text:  multimedia_existing_text,
     },
         SLUG_TO_CLASS = {
         image: 'CommCareImage',
         audio: 'CommCareAudio',
         video: 'CommCareVideo',
+        'video-inline': 'CommCareVideo',
         text:  'CommCareMultimedia',
     },
         SLUG_TO_UPLOADER_SLUG = {
         image: 'fd_hqimage',
         audio: 'fd_hqaudio',
         video: 'fd_hqvideo',
+        'video-inline': 'fd_hqvideo',
         text:  'fd_hqtext',
     };
 
@@ -248,6 +257,7 @@ define([
             image: false,
             audio: false,
             video: false,
+            'video-inline': false,
             text: false
         },
     }, {
@@ -283,6 +293,12 @@ define([
                         mediaType: 'video',
                         sessionid: sessionid,
                         uploadUrl: uploadUrls.video,
+                    }),
+                    'video-inline': this.initUploadController({
+                        uploaderSlug: 'fd_hqvideo',
+                        mediaType: 'video-inline',
+                        sessionid: sessionid,
+                        uploadUrl: uploadUrls['video-inline'],
                     }),
                     'text': this.initUploadController({
                         uploaderSlug: 'fd_hqtext',

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -471,9 +471,9 @@ define([
                 Itext = util.call("getData").javaRosa.Itext;
             assert.equal(jr.generateItextXLS(form, Itext),
                          'label\tdefault_en\tdefault_hin\t' +
-                         'audio_en\taudio_hin\timage_en\timage_hin\tvideo_en\tvideo_hin\n' +
+                         'audio_en\taudio_hin\timage_en\timage_hin\tvideo_en\tvideo_hin\tvideo-inline_en\tvideo-inline_hin\n' +
                          'question1-label\t"First ""line\nSecond"" line\nThird line"\t' +
-                         'Hindu trans\t\t\t\t\t\t');
+                         'Hindu trans\t\t\t\t\t\t\t\t');
         });
 
         it("should escape all languages when generating bulk translations", function () {
@@ -481,8 +481,8 @@ define([
                 Itext = util.call("getData").javaRosa.Itext;
             assert.equal(jr.generateItextXLS(form, Itext),
                          'label\tdefault_en\tdefault_hin\taudio_en\taudio_hin\t' +
-                         'image_en\timage_hin\tvideo_en\tvideo_hin\n' +
-                         'text-label\t"""Text"\t"""Text"\t\t\t\t\t\t');
+                         'image_en\timage_hin\tvideo_en\tvideo_hin\tvideo-inline_en\tvideo-inline_hin\n' +
+                         'text-label\t"""Text"\t"""Text"\t\t\t\t\t\t\t\t');
         });
 
         it("bulk translation tool should not create empty itext forms", function () {

--- a/tests/questionTypes.js
+++ b/tests/questionTypes.js
@@ -263,6 +263,7 @@ define([
                             $(".btn:contains(image)").click();
                             $(".btn:contains(audio)").click();
                             $(".btn:contains(video)").click();
+                            $(".btn:contains(video-inline)").click();
                             $(".btn:contains(long)").click();
                             $(".btn:contains(short)").click();
                             $(".btn:contains(custom)").click();

--- a/tests/static/all_question_types.xml
+++ b/tests/static/all_question_types.xml
@@ -76,6 +76,7 @@
 						<value form="image">jr://file/commcare/image/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/data/question1.3gp</value>
 						<value form="long">question1 en long</value>
 						<value form="short">question1 en short</value>
 						<value form="custom">question1 en custom</value>
@@ -88,12 +89,14 @@
 						<value form="image">jr://file/commcare/image/help/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/help/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/help/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/help/data/question1.3gp</value>
 					</text>
 					<text id="question1-constraintMsg">
 						<value>question1 en validation</value>
 						<value form="image">jr://file/commcare/image/constraintMsg/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/constraintMsg/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/constraintMsg/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/constraintMsg/data/question1.3gp</value>
 					</text>
 					<text id="question2-label">
 						<value>question2</value>
@@ -109,6 +112,7 @@
 						<value form="image">jr://file/commcare/image/data/question3-choice1.png</value>
 						<value form="audio">jr://file/commcare/audio/data/question3-choice1.mp3</value>
 						<value form="video">jr://file/commcare/video/data/question3-choice1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/data/question3-choice1.3gp</value>
 						<value form="long">choice1 long en</value>
 						<value form="short">choice1 short en</value>
 						<value form="custom">choice1 custom en</value>
@@ -192,6 +196,7 @@
 						<value form="image">jr://file/commcare/image/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/data/question1.3gp</value>
 						<value form="long">question1 hin long</value>
 						<value form="short">question1 hin short</value>
 						<value form="custom">question1 hin custom</value>
@@ -204,12 +209,14 @@
 						<value form="image">jr://file/commcare/image/help/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/help/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/help/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/help/data/question1.3gp</value>
 					</text>
 					<text id="question1-constraintMsg">
 						<value>question1 hin validation</value>
 						<value form="image">jr://file/commcare/image/constraintMsg/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/constraintMsg/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/constraintMsg/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/constraintMsg/data/question1.3gp</value>
 					</text>
 					<text id="question2-label">
 						<value>question2</value>
@@ -225,6 +232,7 @@
 						<value form="image">jr://file/commcare/image/data/question3-choice1.png</value>
 						<value form="audio">jr://file/commcare/audio/data/question3-choice1.mp3</value>
 						<value form="video">jr://file/commcare/video/data/question3-choice1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/data/question3-choice1.3gp</value>
 						<value form="long">choice1 long hin</value>
 						<value form="short">choice1 short hin</value>
 						<value form="custom">choice1 custom hin</value>

--- a/tests/static/javaRosa/test-xml-2-with-bind-constraint.xml
+++ b/tests/static/javaRosa/test-xml-2-with-bind-constraint.xml
@@ -23,6 +23,7 @@
 						<value form="image">jr://file/commcare/image/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/data/question1.3gp</value>
 						<value form="long">question1 en long</value>
 						<value form="short">question1 en short</value>
 						<value form="custom">question1 en custom</value>
@@ -35,12 +36,14 @@
 						<value form="image">jr://file/commcare/image/help/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/help/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/help/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/help/data/question1.3gp</value>
 					</text>
 					<text id="question1-constraintMsg">
 						<value>question1 en validation</value>
 						<value form="image">jr://file/commcare/image/constraintMsg/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/constraintMsg/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/constraintMsg/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/constraintMsg/data/question1.3gp</value>
 					</text>
 				</translation>
 				<translation lang="hin">
@@ -49,6 +52,7 @@
 						<value form="image">jr://file/commcare/image/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/data/question1.3gp</value>
 						<value form="long">question1 hin long</value>
 						<value form="short">question1 hin short</value>
 						<value form="custom">question1 hin custom</value>
@@ -61,12 +65,14 @@
 						<value form="image">jr://file/commcare/image/help/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/help/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/help/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/help/data/question1.3gp</value>
 					</text>
 					<text id="question1-constraintMsg">
 						<value>question1 hin validation</value>
 						<value form="image">jr://file/commcare/image/constraintMsg/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/constraintMsg/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/constraintMsg/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/constraintMsg/data/question1.3gp</value>
 					</text>
 				</translation>
 			</itext>

--- a/tests/static/javaRosa/test-xml-2-with-only-bind-constraint.xml
+++ b/tests/static/javaRosa/test-xml-2-with-only-bind-constraint.xml
@@ -23,6 +23,7 @@
 						<value form="image">jr://file/commcare/image/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/data/question1.3gp</value>
 						<value form="long">question1 en long</value>
 						<value form="short">question1 en short</value>
 						<value form="custom">question1 en custom</value>
@@ -35,12 +36,14 @@
 						<value form="image">jr://file/commcare/image/help/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/help/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/help/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/help/data/question1.3gp</value>
 					</text>
 					<text id="question1-constraintMsg">
 						<value>question1 en validation</value>
 						<value form="image">jr://file/commcare/image/constraintMsg/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/constraintMsg/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/constraintMsg/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/constraintMsg/data/question1.3gp</value>
 					</text>
 				</translation>
 				<translation lang="hin">
@@ -49,6 +52,7 @@
 						<value form="image">jr://file/commcare/image/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/data/question1.3gp</value>
 						<value form="long">question1 hin long</value>
 						<value form="short">question1 hin short</value>
 						<value form="custom">question1 hin custom</value>
@@ -61,12 +65,14 @@
 						<value form="image">jr://file/commcare/image/help/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/help/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/help/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/help/data/question1.3gp</value>
 					</text>
 					<text id="question1-constraintMsg">
 						<value>question1 hin validation</value>
 						<value form="image">jr://file/commcare/image/constraintMsg/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/constraintMsg/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/constraintMsg/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/constraintMsg/data/question1.3gp</value>
 					</text>
 				</translation>
 			</itext>

--- a/tests/static/javaRosa/test-xml-2.xml
+++ b/tests/static/javaRosa/test-xml-2.xml
@@ -23,6 +23,7 @@
 						<value form="image">jr://file/commcare/image/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/data/question1.3gp</value>
 						<value form="long">question1 en long</value>
 						<value form="short">question1 en short</value>
 						<value form="custom">question1 en custom</value>
@@ -35,12 +36,14 @@
 						<value form="image">jr://file/commcare/image/help/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/help/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/help/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/help/data/question1.3gp</value>
 					</text>
 					<text id="question1-constraintMsg">
 						<value>question1 en validation</value>
 						<value form="image">jr://file/commcare/image/constraintMsg/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/constraintMsg/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/constraintMsg/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/constraintMsg/data/question1.3gp</value>
 					</text>
 				</translation>
 				<translation lang="hin">
@@ -49,6 +52,7 @@
 						<value form="image">jr://file/commcare/image/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/data/question1.3gp</value>
 						<value form="long">question1 hin long</value>
 						<value form="short">question1 hin short</value>
 						<value form="custom">question1 hin custom</value>
@@ -61,12 +65,14 @@
 						<value form="image">jr://file/commcare/image/help/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/help/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/help/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/help/data/question1.3gp</value>
 					</text>
 					<text id="question1-constraintMsg">
 						<value>question1 hin validation</value>
 						<value form="image">jr://file/commcare/image/constraintMsg/data/question1.png</value>
 						<value form="audio">jr://file/commcare/audio/constraintMsg/data/question1.mp3</value>
 						<value form="video">jr://file/commcare/video/constraintMsg/data/question1.3gp</value>
+						<value form="video-inline">jr://file/commcare/video-inline/constraintMsg/data/question1.3gp</value>
 					</text>
 				</translation>
 			</itext>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?223608#1126669

![image](https://cloud.githubusercontent.com/assets/1471773/14543978/ad96a7de-0264-11e6-8998-18105b9842f5.png)

It's a little weird that we use the itext type when displaying the types of media. never noticed until now. It'll take a bit of a refactor of how we use `SUPPORTED_MEDIA_TYPES` so it may be out of scope for this

@ctsims 