### PR TITLE
Use <pre> for error message

### DIFF
--- a/src/expressionEditor.js
+++ b/src/expressionEditor.js
@@ -440,7 +440,7 @@ define([
                 } else {
                     getValidationSummary()
                         .html($(xpath_validation_errors({
-                            errors: results[1]
+                            errors: results[1].message
                         })))
                         .removeClass("hide");
                 }

--- a/src/templates/xpath_validation_errors.html
+++ b/src/templates/xpath_validation_errors.html
@@ -1,10 +1,7 @@
 <div class="alert alert-danger">
     <h4><i class="fa fa-warning"></i> Validation Failed</h4>
-    <p>Please fix all errors before leaving this page:</p>
-    <%=errors%>
-    <ul>
-    <% _.each(errors, function (error) { %>
-        <li><%=error%></li>
-    <% }); %>
-    </ul>
+    <p>Please fix the error before leaving this page:</p>
+    <pre>
+      <%=errors%>
+    </pre>
 </div>


### PR DESCRIPTION
Noticed this while in Moz. The old error wasn't useful at all, because the error message is already formatted. not sure when it was possible to have multiple error messages

Old:
![selection_005](https://cloud.githubusercontent.com/assets/1471773/14605987/3b007032-0549-11e6-91ae-928b7b12aa8c.png)

New:
![selection_004](https://cloud.githubusercontent.com/assets/1471773/14605988/3c1555f0-0549-11e6-8098-fd0cc50b15c3.png)

buddy: @proteusvacuum 