### PR TITLE
Make _.template calls 1.8-compatible

### DIFF
--- a/src/richText.js
+++ b/src/richText.js
@@ -628,6 +628,7 @@ define([
     }
 
     return {
+        applyFormats: applyFormats,
         bubbleOutputs: bubbleOutputs,
         editor: initEditor,
         fromRichText: fromRichText,

--- a/src/richText.js
+++ b/src/richText.js
@@ -315,7 +315,7 @@ define([
     var formats = {
             'dateFormat': {
                 serialize: function(currentValue, dataAttrs) {
-                    return _.template("format-date(date(<%=xpath%>), '<%=dateFormat%>')", {
+                    return _.template("format-date(date(<%=xpath%>), '<%=dateFormat%>')")({
                         xpath: currentValue,
                         dateFormat: dataAttrs.dateFormat
                     });
@@ -323,7 +323,7 @@ define([
             },
             'outputValue': {
                 serialize: function(currentValue) {
-                    return _.template('&lt;output value="<%=xpath%>" /&gt;', {
+                    return _.template('&lt;output value="<%=xpath%>" /&gt;')({
                         xpath: currentValue
                     });
                 },

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -309,6 +309,23 @@ define([
                 });
             });
         });
+
+        describe("serialize formats correctly", function () {
+            it("should handle output refs", function() {
+                assert.equal(richText.applyFormats({
+                    outputValue: 1,
+                    value: "`#case/child/f_2685`",
+                }), '&lt;output value="`#case/child/f_2685`" /&gt;');
+            });
+
+            it("should handle dates", function() {
+                assert.equal(richText.applyFormats({
+                    dateFormat: "%d/%n/%y",
+                    outputValue: 1,
+                    value: "`#form/question1`",
+                }), '&lt;output value="format-date(date(`#form/question1`), \'%d/%n/%y\')" /&gt;');
+            });
+        });
     });
 
     describe("The rich text editor", function () {


### PR DESCRIPTION
It's backwards-compatible, and someday we'll upgrade to 1.8

@emord 