### PR TITLE
Stop focus from jumping to different language's textarea

### DIFF
--- a/src/richText.js
+++ b/src/richText.js
@@ -233,6 +233,7 @@ define([
         if (_.isFunction(options.createPopover)) {
             editor.addCommand('createPopover', {
                 exec: options.createPopover,
+                editorFocus: false,
             });
         }
 


### PR DESCRIPTION
@emord 

When bubbles get created, executing `createPopover` has been stealing focus.