### PR TITLE
More robustly destroy bubble popovers

### DIFF
--- a/src/richText.js
+++ b/src/richText.js
@@ -77,6 +77,12 @@ define([
 
             if (editor.commands.createPopover) {
                 var _this = this;
+
+                // Look for deleted bubbles
+                editor.on('change', function(e) {
+                    editor.widgets.checkWidgets({ initOnlyNew: 1 });
+                });
+
                 // if the editor is still being initialized then this command
                 // won't be enabled until it is ready
                 if (editor.status === "ready") {


### PR DESCRIPTION
@emord 

Seems that widgets get checked (and therefore destroyed) on `afterInsertHtml` but not on content change. Slightly concerned about performance, but the `key` event is less reliable than `change`.

should fix http://manage.dimagi.com/default.asp?220534