### PR TITLE
Watch for zero-width spaces when matching for atwho

### DIFF
--- a/src/atwho.js
+++ b/src/atwho.js
@@ -101,7 +101,9 @@ define([
                     callbacks: {
                         matcher: function(flag, subtext) {
                             var match, regexp;
-                            regexp = new RegExp('(\\s+|^)' + RegExp.escape(flag) + '([\\w_/]*)$', 'gi');
+                            // Match text that starts with the flag and then looks like a path.
+                            // CKEditor reserves the right to insert arbitrary zero-width spaces, so watch for those.
+                            regexp = new RegExp('([\\s\u200b]+|^)' + RegExp.escape(flag) + '([\\w_/]*)$', 'gi');
                             match = regexp.exec(subtext);
                             return match ? match[2] : null;
                         },


### PR DESCRIPTION
CKEditor sometimes inserts zero-width spaces into the editor, which is "not a bug" (https://dev.ckeditor.com/ticket/10031) but does interfere with our ability to decide whether or not a given string matches the pattern that should cause atwho to pop up.

This has been manifesting as the following bug:
- Type a valid hashtag like `#case/child/dob`
- Type `[space]`, which turns the path into a bubble (as of https://github.com/dimagi/Vellum/pull/671)
- Type `#` which should pop up atwho, but doesn't, because ckeditor inserted some zws characters after the bubble.

@emord 