### PR TITLE
Fix easy ref wording

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -646,7 +646,7 @@ define([
 
         if (this.opts().features.rich_text) {
             formProperties.push({
-                label: "Use Raw References",
+                label: "Use Easy References",
                 slug: "richText",
                 type: "checkbox",
                 value: function(jq, val) {


### PR DESCRIPTION
@orangejenny from field/dev

> [10:56:11 AM] Jennifer Harlow: Oh, but "Use Raw References" was already checked.  But there were bubbles

buddy @NoahCarnahan 