### PR TITLE
creating popovers is not undoable

### DIFF
--- a/src/richText.js
+++ b/src/richText.js
@@ -243,6 +243,7 @@ define([
             editor.addCommand('createPopover', {
                 exec: options.createPopover,
                 editorFocus: false,
+                canUndo: false,
             });
         }
 

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -567,6 +567,17 @@ define([
                         done();
                     });
                 });
+
+                it("should not change saved state", function (done) {
+                    util.loadXML(BURPEE_XML);
+                    assert(!util.saveButtonEnabled(), "Save button should not be enabled");
+                    util.clickQuestion("total_num_burpees");
+                    widget = util.getWidget('property-calculateAttr');
+                    widget.input.promise.then(function () {
+                        assert(!util.saveButtonEnabled(), "Save button should not be enabled");
+                        done();
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?232527

@millerdev 

We use the undo plugin to gain access to a change event. If `canUndo !== false` then `execCommand` will send a change event which enables the save button

cc: @NoahCarnahan 