### PR TITLE
update at.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
         "require-css": "~0.1.5",
         "requirejs-tpl": "jfparadis/requirejs-tpl",
         "requirejs-plugins": "~1.0.2",
-        "At.js": "emord/At.js#override-insert",
+        "At.js": "emord/At.js#res-branch",
         "Caret.js": "0.2.2",
         "fuse.js": "~2.3.0",
 

--- a/src/less-style/atwho.less
+++ b/src/less-style/atwho.less
@@ -1,7 +1,7 @@
 // Styling related to the atwho widget
 @import "lib/main";
 
-.atwho-container .atwho-view {
+.atwho-view ul {
     overflow: hidden;
 }
 


### PR DESCRIPTION
Finally getting around to PRing my change to At.js, but had to deal with some merge conflicts.

https://github.com/ichord/At.js/blob/master/CHANGELOG.md

`override-insert` was based off of 1.3.0 with https://github.com/ichord/At.js/commit/e24b563e4d85681d683b8c1f7e345c98f2da3cb2 patched

`res-branch` is the conflict resolution branch and is now based on 1.5.1

buddy: @NoahCarnahan 