### PR TITLE
Highlight label on tab

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -218,7 +218,7 @@ define([
 
         $(document).on('keyup', function (e) {
             if (e.which === 9 && $(e.target).hasClass("fd-textarea")) {
-                richText.editor($(e.target)).highlightContents();
+                richText.editor($(e.target)).highlight();
             }
         });
 

--- a/src/core.js
+++ b/src/core.js
@@ -205,6 +205,7 @@ define([
         }
         this.$f.addClass('formdesigner');
         this.$f.empty().append(main_template({ctrl: ctrl, alt: alt}));
+
         $(document).on("keydown", function (e) {
             var ctrlKey = (isMac && e.metaKey) || (!isMac && e.ctrlKey),
                 metaKey = (isMac && e.ctrlKey) || (!isMac && e.metaKey),
@@ -213,6 +214,12 @@ define([
                       (e.shiftKey ? "Shift+" : "") +
                       (metaKey ? "Meta+" : "") + e.keyCode;
             (hotkeys[key] || _.identity).call(_this, e);
+        });
+
+        $(document).on('keyup', function (e) {
+            if (e.which === 9 && $(e.target).hasClass("fd-textarea")) {
+                richText.editor($(e.target)).highlightContents();
+            }
         });
 
         this._init_toolbar();

--- a/src/core.js
+++ b/src/core.js
@@ -206,6 +206,7 @@ define([
         this.$f.addClass('formdesigner');
         this.$f.empty().append(main_template({ctrl: ctrl, alt: alt}));
 
+        // Global keyboard shortcuts
         $(document).on("keydown", function (e) {
             var ctrlKey = (isMac && e.metaKey) || (!isMac && e.ctrlKey),
                 metaKey = (isMac && e.ctrlKey) || (!isMac && e.metaKey),
@@ -216,9 +217,13 @@ define([
             (hotkeys[key] || _.identity).call(_this, e);
         });
 
+        // Highlight contents of rich text inputs when tabbing in
         $(document).on('keyup', function (e) {
-            if (e.which === 9 && $(e.target).hasClass("fd-textarea")) {
-                richText.editor($(e.target)).highlight();
+            if (e.which === 9) {
+                var $target = $(e.target);
+                if ($target.hasClass("fd-input") || $target.hasClass("fd-textarea")) {
+                    richText.editor($(e.target)).highlight();
+                }
             }
         });
 

--- a/src/richText.js
+++ b/src/richText.js
@@ -219,6 +219,18 @@ define([
             },
         };
 
+        $('body').on('keyup', function (e) {
+            if (e.which === 9 && $(e.target).hasClass("fd-textarea")) {
+                var selection = editor.getSelection();
+                if (selection.getRanges().length) {
+                    var range = editor.createRange();
+                    range.selectNodeContents( editor.editable() );
+                    selection.selectRanges( [ range ] );
+                    console.log("highlighted everything");
+                }
+            }
+        });
+
         editor.on('focus', function (e) {
             // workaround for https://code.google.com/p/chromium/issues/detail?id=313082
             editor.setReadOnly(false);
@@ -228,12 +240,14 @@ define([
                 editable.removeClass('placeholder');
                 editable.setHtml('');
             }
-            // highlight text
+            // set the cursor to the end of text
             var selection = editor.getSelection();
-            if (selection.getRanges().length) {
-                var range = editor.createRange();
-                range.selectNodeContents( editor.editable() );
-                selection.selectRanges( [ range ] );
+            var range = selection.getRanges()[0];
+            if (range) {
+                var pCon = range.startContainer.getAscendant({p:2},true);
+                var newRange = new CKEDITOR.dom.range(range.document);
+                newRange.moveToPosition(pCon, CKEDITOR.POSITION_BEFORE_END);
+                newRange.select();
             }
         });
 

--- a/src/richText.js
+++ b/src/richText.js
@@ -241,9 +241,11 @@ define([
             var range = selection.getRanges()[0];
             if (range) {
                 var pCon = range.startContainer.getAscendant({p:2},true);
-                var newRange = new CKEDITOR.dom.range(range.document);
-                newRange.moveToPosition(pCon, CKEDITOR.POSITION_BEFORE_END);
-                newRange.select();
+                if (pCon) {
+                    var newRange = new CKEDITOR.dom.range(range.document);
+                    newRange.moveToPosition(pCon, CKEDITOR.POSITION_BEFORE_END);
+                    newRange.select();
+                }
             }
         });
 

--- a/src/richText.js
+++ b/src/richText.js
@@ -185,6 +185,14 @@ define([
                     noSnapshot: true,
                 });
             },
+            highlight: function() {
+                var selection = editor.getSelection();
+                if (selection.getRanges().length) {
+                    var range = editor.createRange();
+                    range.selectNodeContents( editor.editable() );
+                    selection.selectRanges( [ range ] );
+                }
+            },
             insertExpression: function (xpath) {
                 if (options.isExpression) {
                     editor.insertHtml(bubbleExpression(xpath, form) + ' ');
@@ -218,18 +226,6 @@ define([
                 }
             },
         };
-
-        $('body').on('keyup', function (e) {
-            if (e.which === 9 && $(e.target).hasClass("fd-textarea")) {
-                var selection = editor.getSelection();
-                if (selection.getRanges().length) {
-                    var range = editor.createRange();
-                    range.selectNodeContents( editor.editable() );
-                    selection.selectRanges( [ range ] );
-                    console.log("highlighted everything");
-                }
-            }
-        });
 
         editor.on('focus', function (e) {
             // workaround for https://code.google.com/p/chromium/issues/detail?id=313082

--- a/src/richText.js
+++ b/src/richText.js
@@ -228,14 +228,12 @@ define([
                 editable.removeClass('placeholder');
                 editable.setHtml('');
             }
-            // set the cursor to the end of text
+            // highlight text
             var selection = editor.getSelection();
-            var range = selection.getRanges()[0];
-            if (range) {
-                var pCon = range.startContainer.getAscendant({p:2},true);
-                var newRange = new CKEDITOR.dom.range(range.document);
-                newRange.moveToPosition(pCon, CKEDITOR.POSITION_BEFORE_END);
-                newRange.select();
+            if (selection.getRanges().length) {
+                var range = editor.createRange();
+                range.selectNodeContents( editor.editable() );
+                selection.selectRanges( [ range ] );
             }
         });
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?233084

Global event because ckeditor doesn't support `keyup`, only a `key` event that doesn't trigger unless the initial keypress happens while focus is already in the input.

I've played with this a bit, but it might not be a bad idea for someone other than me to pull up this branch, tab around, and see if anything unexpectedly annoying happens. I can ask @dimagi/product to do so if whoever reviews this doesn't.