### PR TITLE
Make tests/options.js part of build

### DIFF
--- a/build.js
+++ b/build.js
@@ -145,6 +145,16 @@
                 //'deferred-components', 
                 'local-deps'
             ]
+        },
+        {
+            create: true,
+            name: 'options',
+            include: [
+                '../tests/options'
+            ],
+            exclude: [
+                'exclude'
+            ]
         }
         // end buildmain.py delimiter
     ]


### PR DESCRIPTION
Would like to have access to the test version of vellum options from HQ pages.

@emord 