### PR TITLE
Don't write type to select questions

### DIFF
--- a/src/mugs.js
+++ b/src/mugs.js
@@ -1515,6 +1515,7 @@ define([
                 deleteOnCopy: false,
             }
         },
+        dataType: "",
     });
 
     var MSelect = util.extend(BaseSelect, {

--- a/tests/questionTypes.js
+++ b/tests/questionTypes.js
@@ -4,14 +4,18 @@ define([
     'underscore',
     'tests/utils',
     'text!static/all_question_types.xml',
-    'text!static/questionTypes/image-capture.xml'
+    'text!static/questionTypes/image-capture.xml',
+    'text!static/javaRosa/select1-help.xml',
+    'text!static/questionTypes/select1-help-with-type.xml',
 ], function (
     chai,
     $,
     _,
     util,
     TEST_XML,
-    IMAGE_CAPTURE_XML
+    IMAGE_CAPTURE_XML,
+    SELECT1_HELP_XML,
+    SELECT1_HELP_WITH_TYPE_XML
 ) {
     var call = util.call,
         clickQuestion = util.clickQuestion,
@@ -619,6 +623,13 @@ define([
             util.loadXML(IMAGE_CAPTURE_XML);
             var image = call("getMugByPath", "/data/image");
             assert.strictEqual(image.p.imageSize, '');
+        });
+    });
+
+    describe("Select questions", function () {
+        it("should not write the type", function () {
+            util.loadXML(SELECT1_HELP_WITH_TYPE_XML);
+            util.assertXmlEqual(util.call('createXML'), SELECT1_HELP_XML);
         });
     });
 });

--- a/tests/questionTypes.js
+++ b/tests/questionTypes.js
@@ -627,6 +627,14 @@ define([
     });
 
     describe("Select questions", function () {
+        before(function (done) {
+            util.init({
+                core: {
+                    onReady: done,
+                },
+            });
+        });
+
         it("should not write the type", function () {
             util.loadXML(SELECT1_HELP_WITH_TYPE_XML);
             util.assertXmlEqual(util.call('createXML'), SELECT1_HELP_XML);

--- a/tests/static/questionTypes/select1-help-with-type.xml
+++ b/tests/static/questionTypes/select1-help-with-type.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/4CA64B95-95E9-420A-90A8-7649C745D336" uiVersion="1" version="1" name="Untitled Form">
+					<question1 />
+				</data>
+			</instance>
+			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="select1" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="question1-label">
+						<value>question1</value>
+					</text>
+					<text id="question1-help">
+						<value>help</value>
+					</text>
+					<text id="question1-item1-label">
+						<value>item1</value>
+					</text>
+					<text id="question1-item2-label">
+						<value>item2</value>
+					</text>
+				</translation>
+				<translation lang="hin">
+					<text id="question1-label">
+						<value>question1</value>
+					</text>
+					<text id="question1-help">
+						<value>help</value>
+					</text>
+					<text id="question1-item1-label">
+						<value>item1</value>
+					</text>
+					<text id="question1-item2-label">
+						<value>item2</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<select1 vellum:ref="#form/question1" ref="/data/question1">
+			<label ref="jr:itext('question1-label')" />
+			<help ref="jr:itext('question1-help')" />
+			<item>
+				<label ref="jr:itext('question1-item1-label')" />
+				<value>item1</value>
+			</item>
+			<item>
+				<label ref="jr:itext('question1-item2-label')" />
+				<value>item2</value>
+			</item>
+		</select1>
+	</h:body>
+</h:html>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?231052#1198906

Vellum has never looked at types in binds to determine select vs select1, so this is only an issue for forms imported elsewhere. Mobile uses the type over the tag in the control tree

cc @czue 