### PR TITLE
Fix save to case case id setvalue

### DIFF
--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -631,6 +631,9 @@ define([
             _.each(values, function(value) {
                 if (caseIdRegex.test(value.ref)) {
                     mug.p.case_id = value.value;
+                    mug.form.dropSetValues(function(inner) {
+                        return value.value === inner.value;
+                    });
                 }
             });
         },

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -222,5 +222,12 @@ define([
                 calculate: 'uuid()'
             });
         });
+
+        it("should remove case_id setvalue when removing create property", function () {
+            util.loadXML(CREATE_PROPERTY_XML);
+            util.deleteQuestion('/data/save_to_case');
+            var deletedXML = call("createXML");
+            assert.equal($(deletedXML).find('setvalue').length, 0);
+        });
     });
 });


### PR DESCRIPTION
This was tracking the same setvalue in two different places. once in the form, the other in the mug. this removes it from the form once it is tracked in the mug.

@czue 