### PR TITLE
Remove references in labels when deleting a question

### DIFF
--- a/src/logic.js
+++ b/src/logic.js
@@ -12,7 +12,13 @@ define([
             "dataParent",
             "repeat_count",
             "filter",
-            "defaultValue"
+            "defaultValue",
+        ],
+        LABEL_REFERENCES = [
+            "helpItext",
+            "constraintMsgItext",
+            "labelItext",
+            "hintItext",
         ],
         NO_SELF_REFERENCES = _.without(XPATH_REFERENCES, 'constraintAttr'),
         CASE_REF_ID = "#case/";
@@ -319,6 +325,7 @@ define([
                 update(property);
             } else {
                 _.each(XPATH_REFERENCES, update);
+                _.each(LABEL_REFERENCES, update);
             }
             mug.addMessages(messages);
         },

--- a/tests/logic.js
+++ b/tests/logic.js
@@ -51,6 +51,18 @@ define([
             assert(util.isTreeNodeValid(repeat), "repeat should be valid");
         });
 
+        it("should remove references for labels after removal", function () {
+            var form = util.loadXML(""),
+                logicManager = form._logicManager,
+                text;
+            util.addQuestion('Text', 'mug');
+            text = util.addQuestion('Text', 'text');
+            $('[name=itext-en-label]').val('<output value="/data/mug" />').change();
+            assert.equal(logicManager.forward[text.ufid].labelItext.length, 1);
+            util.deleteQuestion('/data/text');
+            assert.equal(logicManager.forward[text.ufid].labelItext.length, 0);
+        });
+
         describe("should add validation error for", function () {
             var properties = [
                     "relevantAttr",


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?234197

The logic manager did not remove references contained in itext labels when the question was deleted.

cc @snopoke 