### PR TITLE
Fix cursor hiding after insert expression bubble

### DIFF
--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -188,7 +188,7 @@ define([
                     widget = util.getWidget('itext-en-label');
                 widget.input.promise.then(function () { 
                     editor.on('change', _.debounce(function() {
-                        assert.equal(mug.p.labelItext.get(), '<output value="#case/dob" />');
+                        assert.equal(mug.p.labelItext.get(), '<output value="#case/dob" /> ');
                         assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
                         assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
                         util.assertXmlEqual(call("createXML"), CHILD_REF_OUTPUT_VALUE_XML,
@@ -234,7 +234,7 @@ define([
                     widget.input.promise.then(function () { 
                         editor.on('change', _.debounce(function() {
                             assert.equal(mug.p.labelItext.get(), '');
-                            assert.equal(mug.p.labelItext.get(null, 'hin'), '<output value="#case/dob" />');
+                            assert.equal(mug.p.labelItext.get(null, 'hin'), '<output value="#case/dob" /> ');
                             assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
                             assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
                             util.assertXmlEqual(call("createXML"), CHILD_REF_OUTPUT_VALUE_OTHER_LANG_XML,

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -413,8 +413,8 @@ define([
             _.each([
                 ["one two", 3, "one/data/text two"],
                 ["one two", 4, "one /data/text two"],
-                ["one\n\ntwo", 3, "one/data/text\n\ntwo"],
-                ["one\n\ntwo", 4, "one\n/data/text\ntwo"],
+                ["one\n\ntwo", 3, "one/data/text \n\ntwo"],
+                ["one\n\ntwo", 4, "one\n/data/text \ntwo"],
                 /* TODO make these tests pass
                 ["one\n\ntwo", 5, "one\n\n/data/text two"],
                 ["11\n\n22\n\n33", 5, "11\n\n2/data/text 2\n\n33"],


### PR DESCRIPTION
Second attempt at http://manage.dimagi.com/default.asp?232759 (first #695)

There are still strange editing behaviors related to whitespace after widgets (bubbles) in CKEditor. The most annoying to me is on backspace or left-arrow to remove or move within spaces following a bubble (sometimes the widget is selected instead of the conventional action of deleting or moving past the space before the cursor). Also selecting a different mug and then returning causes the ZWS chars to be removed or converted to regular spaces, which can cause a mildly inconsistent editing experience.

@emord 