### PR TITLE
Fix loading case ids with same string

### DIFF
--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -632,7 +632,7 @@ define([
                 if (caseIdRegex.test(value.ref)) {
                     mug.p.case_id = value.value;
                     mug.form.dropSetValues(function(inner) {
-                        return value.value === inner.value;
+                        return value.ref === inner.ref;
                     });
                 }
             });

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -194,7 +194,7 @@ define([
             var create1 = util.getMug("create1"),
                 create2 = util.getMug("create2");
             assert.equal(create1.p.case_id, "1");
-            assert.equal(create2.p.case_id, "2");
+            assert.equal(create2.p.case_id, "1");
             util.assertXmlEqual(call("createXML"), CREATE_2_PROPERTY_XML);
         });
 

--- a/tests/static/saveToCase/create_2_property.xml
+++ b/tests/static/saveToCase/create_2_property.xml
@@ -38,7 +38,7 @@
 			<bind nodeset="/data/create2/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />
 			<bind nodeset="/data/create2/case/@user_id" calculate="/data/meta/userID" />
 			<setvalue event="xforms-ready" ref="/data/create1/case/@case_id" value="1" />
-			<setvalue event="xforms-ready" ref="/data/create2/case/@case_id" value="2" />
+			<setvalue event="xforms-ready" ref="/data/create2/case/@case_id" value="1" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="name-label">


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?234647#1200207

This wouldn't correctly load the case id if multiple save to case questions were using the the same value for the case_id. Example: create two cases in a form and use 'uuid()' to give them id, only one of them in vellum would have kept the value

@millerdev @snopoke 