### PR TITLE
Allow multimedia to fulfill itext requirement

### DIFF
--- a/src/javaRosa/itext.js
+++ b/src/javaRosa/itext.js
@@ -1,12 +1,14 @@
 define([
     'underscore',
     'jquery',
+    'vellum/javaRosa/util',
     'vellum/util',
     'vellum/xml',
     'vellum/core'
 ], function (
     _,
     $,
+    jrUtil,
     util,
     xml
 ) {
@@ -133,7 +135,7 @@ define([
         },
         hasHumanReadableItext: function() {
             var self = this;
-            return _.some(['default', 'long', 'short'], function(form) {
+            return _.some(['default', 'long', 'short'].concat(jrUtil.SUPPORTED_MEDIA_TYPES), function(form) {
                 return self.hasForm(form) && _.every(self.itextModel.languages, function(lang) {
                     return self.get(form, lang);
                 });

--- a/src/javaRosa/plugin.js
+++ b/src/javaRosa/plugin.js
@@ -569,6 +569,7 @@ define([
                     var itext = mug.p[property],
                         hasItext = itext && itext.hasHumanReadableItext();
                     if (!hasItext && mug.getPresence(property) === 'required') {
+                        name += " (or multimedia)";
                         if (itext.itextModel.languages.length === 1) {
                             return name + " is required.";
                         } else {


### PR DESCRIPTION
Followup for https://github.com/dimagi/Vellum/pull/703 : building an app requires that choices have labels, but their "labels" might be images, etc., not text.

@emord 

cc @biyeun 