### PR TITLE
Don't support delimiters within hashtags

### DIFF
--- a/src/escapedHashtags.js
+++ b/src/escapedHashtags.js
@@ -142,10 +142,7 @@ define([
                     text += current;
                 }
             } else if (state === INSIDE_HASHTAG) {
-                if (current === DELIMITER && next === DELIMITER) {
-                    currentReference += DELIMITER;
-                    i++;
-                } else if (current === DELIMITER) {
+                if (current === DELIMITER) {
                     state = OUTSIDE_HASHTAG;
                     text += transformFn(currentReference);
                     currentReference = "";

--- a/tests/escapedHashtags.js
+++ b/tests/escapedHashtags.js
@@ -34,8 +34,8 @@ define([
                 ["`🍠", "`🍠", "`🍠"], // u1f360 conflicts with ` (u0060)
                 ["`#case/type/prop` = `", "#case/type/prop = `",  "prop = `"],
                 ["`#case/type/prop` = ``", "#case/type/prop = `", "prop = `"],
-                ["`#case/type/``prop` = ``", "#case/type/`prop = `", "`prop = `"],
-                ["``#case/type/``prop` = ``", "`#case/type/`prop` = `", "`#case/type/`prop` = `"],
+                ["`#case/prop1``#case/prop2` = ``", "#case/prop1#case/prop2 = `", "prop1prop2 = `"],
+                ["``#case/type/``prop` = ``", "`#case/type/`prop = `", "`#case/type/`prop = `"],
             ];
 
             testCases.forEach(function (testCase) {


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?234894#1200992

The bug was due to having an invalid xpath ``` `#hashtag1``#hashtag2` ```. Hashtags shouldn't have ` in them anyways, so dropping support for that in the form builder

@orangejenny @snopoke 