### PR TITLE
Remove parse fields

### DIFF
--- a/src/intentManager.js
+++ b/src/intentManager.js
@@ -203,21 +203,6 @@ define([
         }
     }
 
-    function parseFields (html) {
-        var field_regex = /{{\s*([^}\s]+)\s*}}/gm,
-            match = field_regex.exec(html),
-            fields = {};
-
-        while (match) {
-            _.each(match.splice(1), function(field) {
-                fields[field] = field;
-            });
-            match = field_regex.exec(html);
-        }
-
-        return fields;
-    }
-
     var AndroidIntent = util.extend(mugs.defaultOptions, {
         typeName: 'Android App Callout',
         dataType: 'intent',
@@ -395,10 +380,4 @@ define([
             return ret;
         },
     });
-
-    return {
-        test: {
-            parseFields: parseFields,
-        }
-    };
 });

--- a/tests/intentManager.js
+++ b/tests/intentManager.js
@@ -179,36 +179,6 @@ define([
             });
         });
 
-        describe("field parsing", function() {
-            var tests = [
-                ['{{ } }}', {}],
-                ['{{field1}}', { field1: 'field1' }],
-                ['{{ field1 }}', { field1: 'field1' }],
-                ['field1 }}', {}],
-                ['{{ field1', {}],
-                ['field1', {}],
-                ['{{ field1 }} {{ field2 }}', {
-                    field1: 'field1',
-                    field2: 'field2',
-                }],
-                ['{{ field1 }}\n{{ field2 }}', {
-                    field1: 'field1',
-                    field2: 'field2',
-                }],
-                ['{{ field1 }}\n{{ field2 }} {{ field3 }}', {
-                    field1: 'field1',
-                    field2: 'field2',
-                    field3: 'field3',
-                }],
-            ];
-
-            _.each(tests, function(testcase) {
-                it(testcase[0] + " should be parsed as " + JSON.stringify(testcase[1]), function() {
-                    assert.deepEqual(intentManager.test.parseFields(testcase[0]), testcase[1]);
-                });
-            });
-        });
-
         describe("custom intents", function() {
             var vellum, mug, customIndex;
             before(function(done) {


### PR DESCRIPTION
This was for the original spec of the printing widget. It was removed due to a bug in the uploader and then we switched to binary zebra print templates. I don't think it will ever be used again


@snopoke 