### PR TITLE
fix dom leak

### DIFF
--- a/src/atwho.js
+++ b/src/atwho.js
@@ -164,10 +164,12 @@ define([
                 };
             };
 
-            $input.atwho(_atWhoOptions('/data/'));
-            if (options.useRichText) {
-                $input.atwho(_atWhoOptions('#'));
-            }
+            $input.on('focus', function () {
+                $input.atwho(_atWhoOptions('/data/'));
+                if (options.useRichText) {
+                    $input.atwho(_atWhoOptions('#'));
+                }
+            });
         }
 
         addAtWhoToInput();
@@ -177,12 +179,16 @@ define([
         });
 
         mug.on("teardown-mug-properties", function () {
-            $input.atwho('destroy');
+            if ($input.data('atwho')) {
+                $input.atwho('destroy');
+            }
         }, null, "teardown-mug-properties");
 
         mug.on("change-display-language", function() {
-            $input.atwho('destroy');
-            addAtWhoToInput();
+            if ($input.data('atwho')) {
+                $input.atwho('destroy');
+                addAtWhoToInput();
+            }
         });
     };
 

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -164,12 +164,10 @@ define([
                 };
             };
 
-            $input.on('focus', function () {
-                if (!$input.data('atwho')) {
-                    $input.atwho(_atWhoOptions('/data/'));
-                    if (options.useRichText) {
-                        $input.atwho(_atWhoOptions('#'));
-                    }
+            $input.one('focus', function () {
+                $input.atwho(_atWhoOptions('/data/'));
+                if (options.useRichText) {
+                    $input.atwho(_atWhoOptions('#'));
                 }
             });
         }

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -165,9 +165,11 @@ define([
             };
 
             $input.on('focus', function () {
-                $input.atwho(_atWhoOptions('/data/'));
-                if (options.useRichText) {
-                    $input.atwho(_atWhoOptions('#'));
+                if (!$input.data('atwho')) {
+                    $input.atwho(_atWhoOptions('/data/'));
+                    if (options.useRichText) {
+                        $input.atwho(_atWhoOptions('#'));
+                    }
                 }
             });
         }

--- a/tests/atwho.js
+++ b/tests/atwho.js
@@ -78,6 +78,7 @@ define([
                 var mug = util.clickQuestion('one')[0];
                 // TODO: This shouldn't rely on relevantAttr
                 var input = $('[name=property-relevantAttr]');
+                input.focus();
                 input.val('/data/').keyup();
                 assert.strictEqual(getDisplayedAtwhoViews().length, 1);
                 try {


### PR DESCRIPTION
Only adds autocomplete to inputs when input is focused.

With easy references there is a dom leak for atwho. hint/validation/help/something itext's are hidden by default. ckeditor initializes these with `contenteditable=false` (known: https://github.com/dimagi/Vellum/blob/f6cbe1ff9ff40dcc330fa0705a7a040f569463ae/src/richText.js#L234-L235) this means that atwho was initializing, but never destroying those elements or the references they held unless each input was focused everytime a user changed a question.

@orangejenny @snopoke 