### PR TITLE
parser references form instead of dictionary

### DIFF
--- a/src/escapedHashtags.js
+++ b/src/escapedHashtags.js
@@ -186,8 +186,8 @@ define([
     /*
      * extends xpath parser to be aware of escaped hashtags
      */
-    function parser(hashtagDictionary, hashtagTransformations) {
-        var xpathParser = xpath.createParser(xpath.makeXPathModels(hashtagDictionary, hashtagTransformations));
+    function parser(form) {
+        var xpathParser = xpath.createParser(xpath.makeXPathModels(form));
         return {
             parse: function (input) {
                 if (input.startsWith("#invalid/xpath ")) {

--- a/src/form.js
+++ b/src/form.js
@@ -138,7 +138,7 @@ define([
         this.enableInstanceRefCounting = opts.enableInstanceRefCounting;
         this.errors = [];
         this.question_counter = 1;
-        this.xpath = escapedHashtags.parser(this.hashtagDictionary, this.hashtagTransformations);
+        this.xpath = escapedHashtags.parser(_this);
         this.richText = !!vellum.opts().features.rich_text;
         this.undomanager = new undomanager();
 

--- a/src/xpath.js
+++ b/src/xpath.js
@@ -4,14 +4,14 @@ define([
     xpath
 ) {
     return {
-        makeXPathModels: function (hashtagToXPath, hashtagToTransformation) {
+        makeXPathModels: function (form) {
             return xpath.makeXPathModels({
                 isValidNamespace: function (namespace) {
                     return namespace === 'form' || namespace === 'case';
                 },
                 hashtagToXPath: function (hashtagExpr) {
-                    if (hashtagToXPath.hasOwnProperty(hashtagExpr)) {
-                        return hashtagToXPath[hashtagExpr];
+                    if (form.hashtagDictionary.hasOwnProperty(hashtagExpr)) {
+                        return form.hashtagDictionary[hashtagExpr];
                     }
 
                     // If full hashtag isn't recognized, remove the property name and check
@@ -20,17 +20,17 @@ define([
                     if (lastSlashIndex !== -1) {
                         var prefix = hashtagExpr.substring(0, lastSlashIndex + 1),
                             property = hashtagExpr.substring(lastSlashIndex + 1);
-                        if (hashtagToTransformation.hasOwnProperty(prefix)) {
-                            return hashtagToTransformation[prefix](property);
+                        if (form.hashtagTransformations.hasOwnProperty(prefix)) {
+                            return form.hashtagTransformations[prefix](property);
                         }
                     }
                     return hashtagExpr;
                 },
                 toHashtag: function (xpath_) {
                     function toHashtag(xpathExpr) {
-                        for (var key in hashtagToXPath) {
-                            if (hashtagToXPath.hasOwnProperty(key)) {
-                                if (hashtagToXPath[key] === xpathExpr)
+                        for (var key in form.hashtagDictionary) {
+                            if (form.hashtagDictionary.hasOwnProperty(key)) {
+                                if (form.hashtagDictionary[key] === xpathExpr)
                                     return key;
                             }
                         }

--- a/tests/escapedHashtags.js
+++ b/tests/escapedHashtags.js
@@ -63,7 +63,7 @@ define([
                     "#form/text1": "/data/text1",
                     "#form/text2": "/data/text2",
                 },
-                xpathParser = xpath.createParser(xpath.makeXPathModels(translationDict));
+                xpathParser = xpath.createParser(xpath.makeXPathModels({hashtagDictionary: translationDict}));
 
             testCases.forEach(function(testCase) {
                 it("should parse " + testCase[0] + " into " + testCase[1], function() {
@@ -80,7 +80,7 @@ define([
                     "#form/text1": "/data/text1",
                     "#form/text2": "/data/text2",
                 },
-                xpathParser = xpath.createParser(xpath.makeXPathModels(translationDict));
+                xpathParser = xpath.createParser(xpath.makeXPathModels({hashtagDictionary: translationDict}));
 
             testCases.forEach(function(testCase) {
                 it("should parse " + testCase[0] + " into " + testCase[1], function() {

--- a/tests/logic.js
+++ b/tests/logic.js
@@ -276,7 +276,7 @@ define([
                 "#form/text1": "/data/text1",
                 "#form/text2": "/data/text2",
             },
-            xpathParser = xpath.createParser(xpath.makeXPathModels(translationDict));
+            xpathParser = xpath.createParser(xpath.makeXPathModels({hashtagDictionary: translationDict}));
 
             function compareHashtags(expr, expected) {
                 var tags = _.map(expr.getHashtags(), getHashtags);


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?235588

introduced in https://github.com/dimagi/Vellum/pull/720/commits/52436344d4d1fd4effc0e6139c2993b9bce22f9e
hashtagDictionary changes addresses, so when the form's
hashtagdictionary changes, the parser's does not

cc @snopoke