### PR TITLE
Bootstrap 3.3.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
         "Caret.js": "0.2.2",
         "fuse.js": "~2.3.0",
 
-        "bootstrap": "3.3.6",
+        "bootstrap": "3.3.7",
         "jstree": "~3.2.1",
         "langcodes": "dimagi/langcodes",
         "XMLWriter": "dimagi/XMLWriter#master",

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -530,6 +530,17 @@ define([
                     });
                 });
 
+                it("should not change saved state", function (done) {
+                    util.loadXML(BURPEE_XML);
+                    assert(!util.saveButtonEnabled(), "Save button should not be enabled");
+                    util.clickQuestion("total_num_burpees");
+                    widget = util.getWidget('property-calculateAttr');
+                    widget.input.promise.then(function () {
+                        assert(!util.saveButtonEnabled(), "Save button should not be enabled");
+                        done();
+                    });
+                });
+
                 it("should show xpath on popover", function (done) {
                     util.loadXML(BURPEE_XML);
                     util.clickQuestion("total_num_burpees");
@@ -564,17 +575,6 @@ define([
                         // popover destroy just fades the popover
                         assert.strictEqual($('.popover:not(.fade)').length, 0);
 
-                        done();
-                    });
-                });
-
-                it("should not change saved state", function (done) {
-                    util.loadXML(BURPEE_XML);
-                    assert(!util.saveButtonEnabled(), "Save button should not be enabled");
-                    util.clickQuestion("total_num_burpees");
-                    widget = util.getWidget('property-calculateAttr');
-                    widget.input.promise.then(function () {
-                        assert(!util.saveButtonEnabled(), "Save button should not be enabled");
                         done();
                     });
                 });


### PR DESCRIPTION
@emord The `should destroy popover after destroy` test is the one that's problematic. It's fine in the browser, but when run in the console, it seems to cause later tests to fail. Reordering it to be the last test in its `describe` block makes all tests pass. Which doesn't feel great, but I'm not enthused about spending more time on figuring out what's going wrong.