### PR TITLE
don't show help bubble

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1694,7 +1694,7 @@ define([
                 fieldsetClass: "fd-question-edit-" + options.slug || "anon",
                 fieldsetTitle: options.displayName,
                 isCollapsed: !!options.isCollapsed,
-                help: options.help || {}
+                help: options.help
             })),
             $fieldsetContent = $sec.find('.fd-fieldset-content');
         options.properties.map(function (prop) {


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?236076#1209421

This already checks if help exists, so we don't need a default object

https://github.com/dimagi/Vellum/blob/master/src/templates/question_fieldset.html#L8

@phillipm 

buddy @czue