### PR TITLE
Don't use spellchecking on xpaths

### DIFF
--- a/src/richText.js
+++ b/src/richText.js
@@ -159,6 +159,7 @@ define([
             newval = NOTSET,  // HACK work around async get/set
             editor = input.ckeditor({
                 contentsLangDirection: options.rtl ? 'rtl' : 'ltr',
+                disableNativeSpellChecker: options.disableNativeSpellChecker,
                 placeholder: options.placeholder,
             }).editor;
         wrapper = {

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -278,6 +278,7 @@ define([
 
         var opts = {
                 isExpression: options.widget === xPath || options.widget === droppableText,
+                disableNativeSpellChecker: options.disableNativeSpellChecker,
                 rtl: util.isRightToLeftLanguage(options.language),
                 placeholder: options.widgetPlaceholder,
             },
@@ -386,6 +387,7 @@ define([
     };
 
     var xPath = function (mug, options) {
+        options.disableNativeSpellChecker = true;
         var widget = richInput(mug, options),
             super_getValue = widget.getValue,
             super_setValue = widget.setValue;

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -515,6 +515,14 @@ define([
                         assert.strictEqual($widget.find(".label-datanode-unknown").length, 1);
                     });
                 });
+
+                it("should have native spellchecking on labels", function () {
+                    assert.strictEqual($('[name=itext-en-label]').attr('spellcheck'), 'true');
+                });
+
+                it("should not have native spellchecking on xpaths", function () {
+                    assert.strictEqual($('[name=property-relevantAttr]').attr('spellcheck'), 'false');
+                });
             });
 
             describe("popovers", function () {


### PR DESCRIPTION
@orangejenny I wasn't able to get the `lang` attribute to provide input language specific spellchecking. It's possible I misunderstood whatever blog post I saw.

buddy @czue 