### PR TITLE
Don't use ready 'event'

### DIFF
--- a/src/window.js
+++ b/src/window.js
@@ -37,9 +37,7 @@ define([
             // start with accessory pane collapsed
             $(window).resize(adjustToWindow);
             $(document).scroll(adjustToWindow);
-            $(function() {
-                _this.adjustToWindow();
-            });
+            $(adjustToWindow);
             _this.adjustToWindow();
         },
         adjustToWindow: function() {

--- a/src/window.js
+++ b/src/window.js
@@ -37,7 +37,9 @@ define([
             // start with accessory pane collapsed
             $(window).resize(adjustToWindow);
             $(document).scroll(adjustToWindow);
-            $(document).ready(adjustToWindow);
+            $(function() {
+                _this.adjustToWindow();
+            });
             _this.adjustToWindow();
         },
         adjustToWindow: function() {


### PR DESCRIPTION
Shot in the dark at http://manage.dimagi.com/default.asp?234272 ...wondering if the issue is that the onready handler that calls `adjustToWindow` isn't reliable. See https://jquery.com/upgrade-guide/3.0/#breaking-change-on-quot-ready-quot-fn-removed

@emord 