### PR TITLE
Don't bubble if expression has more than a reference

### DIFF
--- a/src/richText.js
+++ b/src/richText.js
@@ -451,9 +451,11 @@ define([
     function replacePathWithBubble(form, value) {
         var info = extractXPathInfoFromOutputValue(value),
             xpath = form.normalizeEscapedHashtag(info.reference),
-            extraAttrs = _.omit(info, 'reference');
+            extraAttrs = _.omit(info, 'reference'),
+            startsWithRef = REF_REGEX.test(xpath),
+            containsWhitespace = /\s/.test(xpath);
 
-        if (!REF_REGEX.test(xpath)) {
+        if (!startsWithRef || (startsWithRef && containsWhitespace)) {
             return $('<span>').text(xml.normalize(value)).html();
         }
 

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -305,6 +305,7 @@ define([
                      '{text} &lt;tag /&gt; {othertext}'],
                     ["{blah}", "{blah}"],
                     ['<output value="unknown(#form/text)" />', '&lt;output value="unknown(#form/text)" /&gt;'],
+                    ['<output value="#form/text + now()" />', '&lt;output value="#form/text + now()" /&gt;'],
                 ],
                 ico = icon('fcc-fd-text');
 


### PR DESCRIPTION
This erroneously bubbled things like `<output value="#form/today - now()" />` because it started with a form ref

buddy @czue 