### PR TITLE
Fix datasources state

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -217,7 +217,10 @@ define([
 
         this._init_toolbar();
         this._createJSTree();
-        this.datasources = datasources.init(this.opts().core.dataSourcesEndpoint);
+        this.datasources = datasources.init(
+            this.opts().core.dataSourcesEndpoint,
+            this.opts().core.invalidCaseProperties
+        );
     };
 
     fn.postInit = function () {
@@ -1192,14 +1195,6 @@ define([
             _this._resetMessages(_this.data.core.form.errors);
             _this._populateTree();
         }
-        form.disconnectDataSources = this.datasources.onChangeReady(function () {
-            form.updateKnownInstances(
-                _.chain(_this.datasources.getDataSources([]))
-                 .map(function (source) { return [source.id, source.uri]; })
-                 .object()
-                 .value()
-            );
-        });
 
         form.on('question-type-change', function (e) {
             _this.jstree("set_type", e.mug.ufid, e.qType);

--- a/src/core.js
+++ b/src/core.js
@@ -217,7 +217,7 @@ define([
 
         this._init_toolbar();
         this._createJSTree();
-        datasources.init(this);
+        this.datasources = datasources.init(this.opts().core.dataSourcesEndpoint);
     };
 
     fn.postInit = function () {
@@ -1175,6 +1175,9 @@ define([
             allowedDataNodeReferences: this.opts().core.allowedDataNodeReferences, 
             enableInstanceRefCounting: true
         }, options);
+        if (this.data.core.form) {
+            this.data.core.form.disconnectDataSources();
+        }
         this.data.core.form = form = parser.parseXForm(
             formXML, options, this, _this.data.core.parseWarnings);
         form.formName = this.opts().core.formName || form.formName;
@@ -1189,9 +1192,9 @@ define([
             _this._resetMessages(_this.data.core.form.errors);
             _this._populateTree();
         }
-        datasources.getDataSources(function (data) {
+        form.disconnectDataSources = this.datasources.onChangeReady(function () {
             form.updateKnownInstances(
-                _.chain(data)
+                _.chain(_this.datasources.getDataSources([]))
                  .map(function (source) { return [source.id, source.uri]; })
                  .object()
                  .value()

--- a/src/dataSourceWidgets.js
+++ b/src/dataSourceWidgets.js
@@ -2,13 +2,11 @@ define([
     'jquery',
     'underscore',
     'vellum/widgets',
-    'vellum/datasources',
     'tpl!vellum/templates/data_source_editor'
 ], function (
     $,
     _,
     widgets,
-    datasources,
     edit_source
 ) {
     /**
@@ -169,8 +167,9 @@ define([
             hasValue = false;
 
         widget.addOption(EMPTY_VALUE, "Loading...");
-        datasources.getDataSources(function (data) {
-            var value;
+        var disconnect = mug.form.vellum.datasources.onChangeReady(function () {
+            var data = mug.form.vellum.datasources.getDataSources(),
+                value;
             if (options.dataSourcesFilter) {
                 data = options.dataSourcesFilter(data);
             }
@@ -190,6 +189,7 @@ define([
                 options.onOptionsLoaded(data);
             }
         });
+        mug.on('teardown-mug-properties', disconnect, null, "teardown-mug-properties");
 
         if (options.hasAdvancedEditor) {
             widget.getUIElement = function () {

--- a/src/databrowser.js
+++ b/src/databrowser.js
@@ -27,8 +27,6 @@ define([
                 pane = this.$f.find(".fd-accessory-pane"),
                 head, headHeight, searchBar, paneRatio;
             vellum.data.core.databrowser = {
-                dataHashtags: {},
-                dataHashtagTransformations: {},
                 errorContainer: pane,
                 panelHeight: null,
             };

--- a/src/databrowser.js
+++ b/src/databrowser.js
@@ -105,7 +105,7 @@ define([
                         // load children of recursive node
                         callback.call(this, node.data.getNodes());
                     } else {
-                        if (vellum.datasources.getDataSources()) {
+                        if (vellum.datasources.isReady()) {
                             fillTree();
                         } else {
                             vellum.datasources.on("change", fillTree, null, "change");

--- a/src/databrowser.js
+++ b/src/databrowser.js
@@ -75,15 +75,6 @@ define([
                 .clickExceptAfterDrag(toggle);
             head.click(toggle);
         },
-        contributeToHeadXML: function (xmlWriter, form) {
-            var hashtags = form.knownExternalReferences();
-            if (!_.isEmpty(hashtags) && form.richText) {
-                xmlWriter.writeStartElement('vellum:hashtags');
-                xmlWriter.writeString(JSON.stringify(hashtags));
-                xmlWriter.writeEndElement();
-            }
-            this.__callOld();
-        },
     });
 
     function _initDataBrowser(vellum) {

--- a/src/databrowser.js
+++ b/src/databrowser.js
@@ -76,9 +76,8 @@ define([
             head.click(toggle);
         },
         contributeToHeadXML: function (xmlWriter, form) {
-            var hashtags = this.data.core.form.knownExternalReferences();
-            //var hashtags = form.knownExternalReferences();
-            if (!_.isEmpty(hashtags)) {
+            var hashtags = form.knownExternalReferences();
+            if (!_.isEmpty(hashtags) && form.richText) {
                 xmlWriter.writeStartElement('vellum:hashtags');
                 xmlWriter.writeString(JSON.stringify(hashtags));
                 xmlWriter.writeEndElement();

--- a/src/datasources.js
+++ b/src/datasources.js
@@ -93,8 +93,8 @@ define([
             invalidCaseProperties: invalidCaseProperties,
         });
 
-        that.reset = function (retryTimeout) {
-            that.retryTimeout = retryTimeout || 1000;
+        that.reset = function () {
+            that.retryTimeout = 1000;
             that.cache = {};
         };
 
@@ -124,9 +124,8 @@ define([
          * @return a function that unbinds the callback.
          */
         that.onChangeReady = function (callback) {
-            var sources = that.getDataSources(),
-                context = {};
-            if (sources) {
+            var context = {};
+            if (that.isReady()) {
                 callback();
             }
             that.on("change", callback, null, null, context);

--- a/src/datasources.js
+++ b/src/datasources.js
@@ -98,6 +98,10 @@ define([
             that.cache = {};
         };
 
+        that.isReady = function () {
+            return getValue(that, "sources") !== undefined;
+        };
+
         that.getDataSources = function (defaultValue) {
             return getValue(that, "sources", defaultValue);
         };

--- a/src/form.js
+++ b/src/form.js
@@ -163,8 +163,8 @@ define([
             var form = this,
                 vellum = form.vellum,
                 oldHashtags = form.hashtagMap;
-            // TODO add support for hashtags when rich text is disabled.
             if (form.richText) {
+                // TODO always load hashtags, even when rich text is disabled
                 form.hashtagMap = _.clone(vellum.datasources.getHashtagMap({}));
                 form.invertedHashtagMap = _.invert(form.hashtagMap);
                 form.hashtagTransformations = vellum.datasources.getHashtagTransforms({});

--- a/src/fuse.js
+++ b/src/fuse.js
@@ -19,8 +19,8 @@ define([
         this.form = form;
 
         form.vellum.datasources.on("change", function() {
-            _this.dataset = generateNewFuseData(_this.form);
-        });
+            _this.dataset = generateNewFuseData(form);
+        }, null, null, form);  // context=form for form.disconnectDataSources()
 
         if (!this.dataset) {
             this.dataset = generateNewFuseData(form);
@@ -82,8 +82,8 @@ define([
 
     function generateNewFuseData(form) {
         var caseData = [];
-        if (form.vellum.data.core.databrowser && form.richText) {
-            caseData = _.chain(form.vellum.data.core.databrowser.dataHashtags)
+        if (form.richText) {
+            caseData = _.chain(form.vellum.datasources.getHashtagMap({}))
              .map(function(absolutePath, hashtag) {
                  return {
                      name: hashtag,

--- a/src/fuse.js
+++ b/src/fuse.js
@@ -1,12 +1,10 @@
 define([
     'underscore',
     'fusejs',
-    'vellum/datasources',
     'vellum/util',
 ], function (
     _,
     fusejs,
-    datasources,
     util
 ) {
     var FUSE_CONFIG = {
@@ -20,7 +18,7 @@ define([
         var _this = this;
         this.form = form;
 
-        datasources.getDataSources(function() {
+        form.vellum.datasources.on("change", function() {
             _this.dataset = generateNewFuseData(_this.form);
         });
 
@@ -82,7 +80,7 @@ define([
         return null;
     }
 
-    function generateNewFuseData (form) {
+    function generateNewFuseData(form) {
         var caseData = [];
         if (form.vellum.data.core.databrowser && form.richText) {
             caseData = _.chain(form.vellum.data.core.databrowser.dataHashtags)

--- a/src/itemset.js
+++ b/src/itemset.js
@@ -16,7 +16,6 @@ define([
     'underscore',
     'jquery',
     'vellum/widgets',
-    'vellum/datasources',
     'vellum/dataSourceWidgets',
     'vellum/mugs',
     'vellum/parser',
@@ -27,7 +26,6 @@ define([
     _,
     $,
     widgets,
-    datasources,
     datasourceWidgets,
     mugs,
     parser,
@@ -167,7 +165,7 @@ define([
                 visibility: 'visible',
                 leftPlaceholder: '',
                 autocompleteChoices: function(mug) {
-                    var sources = getDataSources(),
+                    var sources = getDataSources(mug),
                         src = mug.p.itemsetData.instance.src;
                     return datasourceWidgets.autocompleteChoices(sources, src);
                 },
@@ -182,7 +180,7 @@ define([
         if (children.length) {
             return children[0];
         }
-        var sources = getDataSources(),
+        var sources = getDataSources(mug),
             newMug = form.createQuestion(mug, 'into', "Itemset", true);
         if (sources.length) {
             var src = sources[0].uri,
@@ -375,16 +373,12 @@ define([
         return {value: nodeset, filter: ''};
     }
 
-    function getDataSources() {
-        // HACK synchronously get asynchronously loaded data (if available)
-        var sources = [];
-        datasources.getDataSources(function (data) {
-            // will execute synchronously if data sources have been loaded
-            if (opts.dataSourcesFilter) {
-                data = opts.dataSourcesFilter(data);
-            }
-            sources = data;
-        });
+    function getDataSources(mug) {
+        // get asynchronously loaded data if available
+        var sources = mug.form.vellum.datasources.getDataSources([]);
+        if (opts.dataSourcesFilter) {
+            sources = opts.dataSourcesFilter(sources);
+        }
         return sources;
     }
 
@@ -518,7 +512,7 @@ define([
         var value = mug.p.itemsetData,
             instance = value ? value.instance : null,
             src = instance ? instance.src : "",
-            choices = datasourceWidgets.autocompleteChoices(getDataSources(), src);
+            choices = datasourceWidgets.autocompleteChoices(getDataSources(mug), src);
 
         atwho.questionAutocomplete(widget.input, mug, {choices: choices});
 
@@ -531,7 +525,7 @@ define([
                 mugAttr = mug.p[attr],
                 instance = itemsetData.instance,
                 instanceSrc = instance ? instance.src : '',
-                sources = getDataSources(),
+                sources = getDataSources(mug),
                 fixtures = datasourceWidgets.getPossibleFixtures(sources),
                 notCustom = _.some(fixtures, function (fixture) {
                     return fixture.src === instanceSrc;

--- a/src/javaRosa/itextWidget.js
+++ b/src/javaRosa/itextWidget.js
@@ -215,7 +215,10 @@ define([
 
         widget.setItextValue = function (value) {
             var itextItem = widget.getItextItem();
+            // TODO should not be using hashtags when rich text is off
+            //if (mug.supportsRichText()) {
             value = jrUtil.outputToHashtag(value, widget.mug.form.xpath);
+            //}
             if (itextItem) {
                 if (widget.isDefaultLang) {
                     widget.mug.fire({

--- a/src/parser.js
+++ b/src/parser.js
@@ -74,7 +74,23 @@ define([
             ); 
         });
         form.updateKnownInstances();
-        
+
+        // TODO do not parse hashtags if form.richText is true
+        if (!form.vellum.datasources.getDataSources()) {
+            // load hashtags from form to prevent unknown hashtag warnings
+            // WARNING hashtag values will not be written correctly (on save
+            // or edit XML) unil after data sources are loaded.
+            var hashtags = head.children('vellum\\:hashtags, hashtags');
+            try {
+                hashtags = JSON.parse($.trim(hashtags.text()));
+            } catch (err) {
+                hashtags = {};
+            }
+            _.each(hashtags, function (xpath, hash) {
+                form.initHashtag(hash, xpath);
+            });
+        }
+
         // TODO! adapt
         if(data.length === 0) {
             form.parseErrors.push(

--- a/src/parser.js
+++ b/src/parser.js
@@ -58,6 +58,7 @@ define([
             form.formName = $(title).text();
         }
 
+        // TODO set this to vellum.opts().features.rich_text ??
         form.richText = true;
         if(xml.find('[vellum\\:ignore=richText]').length > 0) {
             form.richText = false;
@@ -75,8 +76,7 @@ define([
         });
         form.updateKnownInstances();
 
-        // TODO do not parse hashtags if form.richText is true
-        if (!form.vellum.datasources.isReady()) {
+        if (vellum.opts().features.rich_text && !form.vellum.datasources.isReady()) {
             // load hashtags from form to prevent unknown hashtag warnings
             // WARNING hashtag values will not be written correctly (on save
             // or edit XML) unil after data sources are loaded.

--- a/src/parser.js
+++ b/src/parser.js
@@ -76,7 +76,7 @@ define([
         form.updateKnownInstances();
 
         // TODO do not parse hashtags if form.richText is true
-        if (!form.vellum.datasources.getDataSources()) {
+        if (!form.vellum.datasources.isReady()) {
             // load hashtags from form to prevent unknown hashtag warnings
             // WARNING hashtag values will not be written correctly (on save
             // or edit XML) unil after data sources are loaded.

--- a/src/util.js
+++ b/src/util.js
@@ -313,7 +313,7 @@ define([
             xpath_ = expr.toXPath();
             hashtag = expr.toHashtag();
         } catch (err) {
-            if (form.richText ) {
+            if (form.richText) {
                 xmlWriter.writeAttributeString('vellum:' + vellumKey, "#invalid/xpath " + hashtagOrXPath);
             }
             xmlWriter.writeAttributeString(key, escapedHashtags.transform(hashtagOrXPath, function(hashtag) {

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -219,6 +219,7 @@ define([
             var ret = input.val().replace(/&#10;/g, '\n');
 
             if (ret && widget.hasLogicReferences) {
+                // TODO should not be using hashtags when rich text is off
                 return mug.form.normalizeEscapedHashtag(ret);
             } else {
                 return ret;

--- a/src/writer.js
+++ b/src/writer.js
@@ -43,6 +43,13 @@ define([
         
         xmlWriter.writeEndElement(); //CLOSE MODEL
 
+        var hashtags = form.knownExternalReferences();
+        if (form.richText && !_.isEmpty(hashtags)) {
+            xmlWriter.writeStartElement('vellum:hashtags');
+            xmlWriter.writeString(JSON.stringify(hashtags));
+            xmlWriter.writeEndElement();
+        }
+
         form.vellum.contributeToHeadXML(xmlWriter, form);
 
         xmlWriter.writeEndElement(); //CLOSE HEAD

--- a/tests/atwho.js
+++ b/tests/atwho.js
@@ -177,45 +177,50 @@ define([
 
             it("should show questions with #form", function() {
                 displayAtwho('#form', function(mug) {
-                    var atwhoEntries = getDisplayedAtwhoViews().find('li');
-                    _.map(atwhoEntries, function(li) {
-                        var text = $.trim($(li).text());
-                        assert(text.startsWith('#form'));
-                    });
-                    assert.strictEqual(atwhoEntries.length, 3);
+                    var atwhoEntries = getDisplayedAtwhoViews().find('li'),
+                        tags = _.map(atwhoEntries, function(li) {
+                            return $.trim($(li).text()).replace(/\n[^]*$/, "");
+                        });
+                    assert.deepEqual(tags, [
+                        "#form/dash-dash",
+                        "#form/text",
+                        "#form/text2",
+                    ]);
                 });
             });
 
             it("should show questions after a dash", function () {
                 displayAtwho('#dash-dash', function(mug) {
-                    var atwhoEntries = getDisplayedAtwhoViews().find('li');
-                    _.map(atwhoEntries, function(li) {
-                        var text = $.trim($(li).text());
-                        assert(text.startsWith('#form'));
-                    });
-                    assert.strictEqual(atwhoEntries.length, 1);
+                    var atwhoEntries = getDisplayedAtwhoViews().find('li'),
+                        tags = _.map(atwhoEntries, function(li) {
+                            return $.trim($(li).text()).replace(/\n[^]*$/, "");
+                        });
+                    assert.deepEqual(tags, ["#form/dash-dash"]);
                 });
             });
 
             it("should show case properties with #case", function() {
                 displayAtwho('#case', function(mug) {
-                    var atwhoEntries = getDisplayedAtwhoViews().find('li');
-                    _.map(atwhoEntries, function(li) {
-                        var text = $.trim($(li).text());
-                        assert(text.startsWith('#case'));
-                    });
-                    assert.strictEqual(atwhoEntries.length, 1);
+                    var atwhoEntries = getDisplayedAtwhoViews().find('li'),
+                        tags = _.map(atwhoEntries, function(li) {
+                            return $.trim($(li).text()).replace(/\n[^]*$/, "");
+                        });
+                    assert.deepEqual(tags, ["#case/child/dob"]);
                 });
             });
 
             it("should show case properties and form questions with #", function() {
                 displayAtwho('#', function(mug) {
-                    var atwhoEntries = getDisplayedAtwhoViews().find('li');
-                    _.map(atwhoEntries, function(li) {
-                        var text = $.trim($(li).text());
-                        assert(text.startsWith('#case') || text.startsWith('#form'));
-                    });
-                    assert.strictEqual(atwhoEntries.length, 4);
+                    var atwhoEntries = getDisplayedAtwhoViews().find('li'),
+                        tags = _.map(atwhoEntries, function(li) {
+                            return $.trim($(li).text()).replace(/\n[^]*$/, "");
+                        });
+                    assert.deepEqual(tags, [
+                        "#case/child/dob",
+                        "#form/dash-dash",
+                        "#form/text",
+                        "#form/text2",
+                    ]);
                 });
             });
         });

--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -431,7 +431,6 @@ define([
                 util.loadXML(CASE_PROPERTY_XML);
                 util.assertXmlEqual(util.call("createXML"), CASE_PROPERTY_XML);
                     //CASE_PROPERTY_XML.replace(/ vellum:\w+=".*?"/g, ""));
-                assert(false);
             });
         });
 

--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -15,6 +15,7 @@ define([
     'text!static/databrowser/child-ref-output-value-other-lang.xml',
     'text!static/databrowser/preloaded-hashtags.xml',
     'text!static/databrowser/unknown-property-preloaded-hashtags.xml',
+    'text!static/datasources/case-property.xml',
 ], function (
     options,
     util,
@@ -30,7 +31,8 @@ define([
     CHILD_REF_OUTPUT_VALUE_XML,
     CHILD_REF_OUTPUT_VALUE_OTHER_LANG_XML,
     PRELOADED_HASHTAGS_XML,
-    UNKNOWN_PROPERTY_PRELOADED_HASHTAGS_XML
+    UNKNOWN_PROPERTY_PRELOADED_HASHTAGS_XML,
+    CASE_PROPERTY_XML
 ) {
     var assert = chai.assert,
         call = util.call,
@@ -331,6 +333,7 @@ define([
                 });
             }
             before(function (done) {
+                datasources.reset();
                 util.init({
                     plugins: plugins,
                     javaRosa: {langs: ['en']},
@@ -348,6 +351,28 @@ define([
                             widget.input.promise.then(done);
                         }
                     }
+                });
+            });
+
+            it("should not cause null xpath", function () {
+                util.loadXML(CASE_PROPERTY_XML);
+                //databrowser.initDataBrowser(_this);
+                event.fire("loadCaseData");
+                util.loadXML(CASE_PROPERTY_XML);
+                util.assertXmlEqual(util.call("createXML"), CASE_PROPERTY_XML);
+                    //CASE_PROPERTY_XML.replace(/ vellum:\w+=".*?"/g, ""));
+                assert(false);
+            });
+
+            it("should error for unknown properties", function(done) {
+                widget.setValue(escapedDobProp);
+                widget.handleChange();
+                assert(!util.isTreeNodeValid(blue), "expected validation error");
+                assert.lengthOf(widget.getControl().find('.label-datanode-unknown'), 1);
+                event.fire("loadCaseData");
+                loadDataTree(function() {
+                    assert(util.isTreeNodeValid(blue), blue.getErrors().join("\n"));
+                    done();
                 });
             });
 
@@ -418,18 +443,6 @@ define([
                         assert.strictEqual(parsedResult, '/data/text');
                         done();
                     });
-                });
-            });
-
-            it("should error for unknown properties", function(done) {
-                widget.setValue(escapedDobProp);
-                widget.handleChange();
-                assert(!util.isTreeNodeValid(blue), "expected validation error");
-                assert.lengthOf(widget.getControl().find('.label-datanode-unknown'), 1);
-                event.fire("loadCaseData");
-                loadDataTree(function() {
-                    assert(util.isTreeNodeValid(blue), blue.getErrors().join("\n"));
-                    done();
                 });
             });
         });

--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -426,11 +426,9 @@ define([
 
             it("should not cause null xpath", function () {
                 util.loadXML(CASE_PROPERTY_XML);
-                //databrowser.initDataBrowser(vellum);
                 event.fire("loadCaseData");
                 util.loadXML(CASE_PROPERTY_XML);
                 util.assertXmlEqual(util.call("createXML"), CASE_PROPERTY_XML);
-                    //CASE_PROPERTY_XML.replace(/ vellum:\w+=".*?"/g, ""));
             });
         });
 

--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -156,13 +156,8 @@ define([
             });
 
             it("should hashtagify refs when written", function() {
-                // this won't write the hashtags as the logic manager won't
-                // have the #case reference but it will properly hashtagify
-                // once the databrowser is loaded
                 util.loadXML(CHILD_REF_NO_HASHTAG_XML);
-                util.assertXmlEqual(call("createXML"), CHILD_REF_XML.replace(
-                    "<vellum:hashtags>{&quot;#case/dob&quot;:null}</vellum:hashtags>", ''
-                ));
+                util.assertXmlEqual(call("createXML"), CHILD_REF_XML);
             });
 
             it("is not overwritten by the forms preloaded tags", function() {

--- a/tests/datasources.js
+++ b/tests/datasources.js
@@ -204,7 +204,7 @@ define([
             });
 
             it("should not cause null xpath", function () {
-                // bug only appears on load XML with vellum:attr="value" attributes
+                // bug only appeared on load XML with vellum:attr="value" attributes
                 util.loadXML(CASE_PROPERTY_XML);
                 callback(options.dataSources);
                 util.assertXmlEqual(util.call("createXML"),

--- a/tests/datasources.js
+++ b/tests/datasources.js
@@ -7,6 +7,7 @@ define([
     'underscore',
     'vellum/datasources',
     'vellum/itemset',
+    'text!static/datasources/case-property.xml',
 ], function (
     options,
     util,
@@ -14,7 +15,8 @@ define([
     $,
     _,
     datasources,
-    itemset
+    itemset,
+    CASE_PROPERTY_XML
 ) {
     var assert = chai.assert,
         clickQuestion = util.clickQuestion,
@@ -40,7 +42,7 @@ define([
             }
         }];
 
-    describe("The data source widget", function () {
+    describe("The data sources loader", function () {
         function beforeFn(done) {
             util.init({
                 plugins: plugins,
@@ -84,7 +86,6 @@ define([
                 util.loadXML("");
                 util.addQuestion("SelectDynamic", "select1");
                 clickQuestion('select1/itemset');
-                assert(true);
             });
         });
 
@@ -199,6 +200,14 @@ define([
                 assert.equal(data.val(),
                     '{"id":"bar","src":"jr://fixture/foo","query":"instance(\'bar\')root/inner"}');
                 assert.equal(data.find("option:selected").text(), "outer - inner");
+            });
+
+            it("should not cause null xpath", function () {
+                // bug only appears on load XML with vellum:attr="value" attributes
+                util.loadXML(CASE_PROPERTY_XML);
+                callback(options.dataSources);
+                util.assertXmlEqual(util.call("createXML"),
+                    CASE_PROPERTY_XML.replace(/ vellum:\w+=".*?"/g, ""));
             });
         });
     });

--- a/tests/datasources.js
+++ b/tests/datasources.js
@@ -203,13 +203,23 @@ define([
                 assert.equal(data.find("option:selected").text(), "outer - inner");
             });
 
+            /*
+            TODO make this test pass
+            Should not lose xpath expression when rich text is off.
+            Changing this seems to be a whack-a-mo--hashtag game. Vellum
+            inconsistently writes hashtags in non-vellum: attributes, which
+            should only ever contain valid xpath expressions.
+
             it("should not cause null xpath", function () {
                 // bug only appeared on load XML with vellum:attr="value" attributes
                 util.loadXML(CASE_PROPERTY_XML);
                 callback(options.dataSources);
                 util.assertXmlEqual(util.call("createXML"),
-                    CASE_PROPERTY_XML.replace(/ vellum:\w+=".*?"/g, ""));
+                    CASE_PROPERTY_XML
+                        .replace(/ vellum:\w+=".*?"/g, "")
+                        .replace(/<vellum:hashtags.*>/, ""));
             });
+            */
         });
     });
 });

--- a/tests/datasources.js
+++ b/tests/datasources.js
@@ -5,7 +5,6 @@ define([
     'chai',
     'jquery',
     'underscore',
-    'vellum/datasources',
     'vellum/itemset',
     'text!static/datasources/case-property.xml',
 ], function (
@@ -14,7 +13,6 @@ define([
     chai,
     $,
     _,
-    datasources,
     itemset,
     CASE_PROPERTY_XML
 ) {
@@ -90,20 +88,23 @@ define([
         });
 
         describe("async options loader", function() {
-            var callback;
+            var vellum, callback;
             before(function (done) {
                 util.init({
                     plugins: plugins,
                     javaRosa: {langs: ['en']},
                     core: {
                         dataSourcesEndpoint: function (cb) { callback = cb; },
-                        onReady: done
+                        onReady: function () {
+                            vellum = this;
+                            done();
+                        },
                     },
                     features: {rich_text: false},
                 });
             });
             beforeEach(function () {
-                datasources.reset();
+                vellum.datasources.reset();
                 callback = null;
             });
 

--- a/tests/itemset.js
+++ b/tests/itemset.js
@@ -41,15 +41,19 @@ define([
             util.init({
                 plugins: plugins,
                 javaRosa: {langs: ['en']},
-                core: {onReady: done},
+                core: {onReady: function () {
+                    vellum = this;
+                    done();
+                }},
                 features: {
                     lookup_tables: true,
                     advanced_itemsets: false,
                 },
             });
         }
+        var vellum;
         before(beforeFn);
-        beforeEach(datasources.reset);
+        beforeEach(function () { vellum.datasources.reset(); });
 
         it("adds a new instance to the form", function () {
             util.loadXML(TEST_XML_1);
@@ -287,19 +291,23 @@ define([
     });
 
     describe("The Dynamic Itemset plugin with no fixtures", function () {
-        var DATA_SOURCES = [{id: "ignored", uri: "jr://not-a-fixture"}];
+        var DATA_SOURCES = [{id: "ignored", uri: "jr://not-a-fixture"}],
+            vellum;
         before(function (done) {
             util.init({
                 plugins: plugins,
                 javaRosa: {langs: ['en']},
                 core: {
                     dataSourcesEndpoint: function (callback) { callback(DATA_SOURCES); },
-                    onReady: done,
+                    onReady: function () {
+                        vellum = this;
+                        done();
+                    },
                 },
                 features: {lookup_tables: true},
             });
         });
-        beforeEach(datasources.reset);
+        beforeEach(function () { vellum.datasources.reset(); });
 
         it("should be able to configure Lookup Table Data", function() {
             util.addQuestion("SelectDynamic", "select");

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -482,6 +482,7 @@ define([
             vellumUtil.setCaretPosition(target[0], 4);
             call("handleDropFinish", target, mug1.absolutePath, mug1);
             var val = mug2.p.labelItext.get('default', 'en');
+            // wtf?? rich text is off
             assert.equal(val, 'test<output value="#form/question1" /> string');
             assert.equal(target.val(), 'test<output value="/data/question1" /> string');
         });

--- a/tests/options.js
+++ b/tests/options.js
@@ -210,6 +210,7 @@ define(["underscore"], function (_) {
     };
 
     return {
-        options: OPTIONS
+        options: OPTIONS,
+        dataSources: dataSources,
     };
 });

--- a/tests/static/datasources/case-property.xml
+++ b/tests/static/datasources/case-property.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/C8476EEA-C514-44FE-BF1D-F287BC8BD28C" uiVersion="1" version="1" name="Untitled Form">
+					<dob />
+				</data>
+			</instance>
+			<instance src="jr://instance/casedb" id="casedb" />
+			<instance src="jr://instance/session" id="commcaresession" />
+			<bind vellum:nodeset="#form/dob" nodeset="/data/dob" vellum:calculate="#case/dob" calculate="instance('casedb')/cases/case[@case_id = instance('commcaresession')/session/data/case_id]/dob" />
+			<itext>
+				<translation lang="en" default="" />
+			</itext>
+		</model>
+		<vellum:hashtags>{&quot;#case/dob&quot;:null}</vellum:hashtags>
+	</h:head>
+	<h:body />
+</h:html>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?237032

This bug was really hard to figure out and fix because of a timing issue between loading of the data browser and data sources. This is a major refactor of how the form object gets a list of valid hashtags from data sources. Hashtags and hashtag transformations are now available immediately when data sources are loaded rather than after the data browser is initialized. The data browser now does only one thing: display a tree of case properties, and it no longer mutates the form during its initialization phase.

A few other cleanup items were done to make it easier to think about the state of vellum in tests:
- data sources state is now local to a vellum instance rather than global
- the data browser no longer has global state.

Probably easiest to review commits individually. 00af9dd was a stab at making the commented-out test in it pass, but I got exhausted trying to figure out where hashtags should be used and where they should not be. Renaming questions is finicky and might even be broken in some cases when rich text is disabled (although that has not changed in this PR).

@emord 