### PR TITLE
prop not attr for DOM properties

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -614,7 +614,7 @@ define([
                         .html($overwriteForm);
                     _this._resizeFullScreenModal($modal);
 
-                    $modal.find('.btn-info').attr('disabled', 'disabled');
+                    $modal.find('.btn-info').prop('disabled', true);
                 }
             }
         ], "Cancel", "fa fa-warning");

--- a/src/javaRosa/itextBlock.js
+++ b/src/javaRosa/itextBlock.js
@@ -197,7 +197,7 @@ define([
                         $addButton
                             .addClass('disabled')
                             .removeClass('btn-primary')
-                            .attr('disabled', 'disabled');
+                            .prop('disabled', true);
                     } else {
                         $addButton
                             .removeClass('disabled')


### PR DESCRIPTION
jQuery 3 migration plugin has been complaining about this.

> As of jQuery 1.6, the .attr() method returns undefined for attributes that have not been set. To retrieve and change DOM properties such as the checked, selected, or disabled state of form elements, use the .prop() method.

(http://api.jquery.com/attr/)

@biyeun / @emord 