### PR TITLE
hide undo after adding a question

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -154,6 +154,8 @@ define([
         util.eventuality(this);
         this.on('form-load-finished', function() {
             _this.fuse = new Fuse(_this);
+        }).on('question-create', function () {
+            _this.undomanager.resetUndo();
         });
         this.disconnectDataSources = function () {
             vellum.datasources.unbind(_this, "change");

--- a/tests/undomanager.js
+++ b/tests/undomanager.js
@@ -184,6 +184,17 @@ define([
             util.assertJSTreeState('select', '  choice1', '  choice2');
         });
 
+        it("should reset the undo manager after adding a question", function () {
+            util.addQuestion('Text', 'text');
+            util.addQuestion('Select', 'select');
+            util.assertJSTreeState('text', 'select', '  choice1', '  choice2');
+            util.clickQuestion('text');
+            $('.fd-button-remove').click();
+            util.assertJSTreeState('select', '  choice1', '  choice2');
+            util.addQuestion('Text', 'text');
+            assert.strictEqual($('.fd-undo-delete').length, 0);
+        });
+
         it("should undelete a multiple choice question when selected with others", function() {
             util.addQuestion('Text', 'text');
             util.addQuestion('Select', 'select');


### PR DESCRIPTION
This fixes half of http://manage.dimagi.com/default.asp?238232, and will probably solve most of the cases of this bug popping up again.

At the moment, it's a little unclear to me how best to have the undo manager check the node id for conflicting nodes. Right now that code is in `moveMug` and undo uses `insertMug` to insert. I want to think a little harder before moving/duplicating that code into `insertMug` or changing the way the undo puts mugs into its queue

@millerdev @orangejenny buddy @czue 