### PR TITLE
Multiple modals

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -702,6 +702,7 @@ define([
             });
         }
         if (immediate) {
+            // skip animation
             $modal.removeClass('fade');
         }
         $modal.modal('hide');

--- a/src/core.js
+++ b/src/core.js
@@ -693,13 +693,16 @@ define([
         });
     };
 
-    fn.closeModal = function (done) {
+    fn.closeModal = function (done, immediate) {
         var _this = this,
             $modal = _this.$f.find('.fd-modal-generic-container .modal');
         if (done) {
             $modal.one('hidden.bs.modal', function() {
                 done.apply(_this);
             });
+        }
+        if (immediate) {
+            $modal.removeClass('fade');
         }
         $modal.modal('hide');
     };
@@ -718,7 +721,7 @@ define([
             $modalContainer = _this.$f.find('.fd-modal-generic-container');
 
         // Close any existing modal - multiple modals is a bad state
-        _this.closeModal();
+        _this.closeModal(undefined, true);
 
         var $modal = $(modal_content({
                 title: title,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?238845

Closing one modal and then immediately opening another one doesn't play nicely with the fade transition. This looks like an issue with bootstrap, but an easy one to work around by turning off the transition in the case where we're closing a modal because we're about to open another one.

@millerdev 