### PR TITLE
Move full screen button into tools menu

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -168,29 +168,6 @@ define([
             unsavedMessage: 'Are you sure you want to exit? All unsaved changes will be lost!',
             csrftoken: _this.opts().csrftoken
         });
-        var setFullscreenIcon = function () {
-            var $i = $('i', _this.data.core.$fullscreenButton).addClass("fa");
-            if (_this.data.windowManager.fullscreen) {
-                $i.addClass('fa-compress').removeClass('fa-expand');
-            } else {
-                $i.removeClass('fa-compress').addClass('fa-expand');
-            }
-        };
-        setTimeout(setFullscreenIcon, 0);
-        this.data.core.$fullscreenButton = $('<button class="btn btn-default"><i/></button>').click(function (e) {
-            e.preventDefault();
-            if (window.analytics) {
-                window.analytics.usage('Form Builder', 'Full Screen Mode',
-                          _this.opts().core.formId);
-            }
-            if (_this.data.windowManager.fullscreen) {
-                _this.data.windowManager.fullscreen = false;
-            } else {
-                _this.data.windowManager.fullscreen = true;
-            }
-            setFullscreenIcon();
-            _this.adjustToWindow();
-        });
 
         bindBeforeUnload(this.data.core.saveButton.beforeunload);
         this.data.core.currentErrors = [];
@@ -300,8 +277,6 @@ define([
 
         var $saveButtonContainer = this.$f.find('.fd-save-button');
         this.data.core.saveButton.ui.appendTo($saveButtonContainer);
-        var $fullscerenButtonContainer = this.$f.find('.fd-fullscreen-button');
-        this.data.core.$fullscreenButton.appendTo($fullscerenButtonContainer);
     };
 
     fn._getQuestionGroups = function () {
@@ -428,6 +403,27 @@ define([
     fn.getToolsMenuItems = function () {
         var _this = this;
         return [
+            {
+                name: "Show in Full Screen",
+                action: function (done) {
+                    var $fullScreenMenuItem = $(_.find(_this.$f.find('.fd-tools-menu a'), function(a) {
+                        return a.text.match(/full screen/i);
+                    }));
+                    var text = $fullScreenMenuItem.text();
+                    if (window.analytics) {
+                        window.analytics.usage('Form Builder', 'Full Screen Mode',
+                                  _this.opts().core.formId);
+                    }
+                    if (_this.data.windowManager.fullscreen) {
+                        _this.data.windowManager.fullscreen = false;
+                        $fullScreenMenuItem.text(text.replace(/Exit/, "Show in"));
+                    } else {
+                        _this.data.windowManager.fullscreen = true;
+                        $fullScreenMenuItem.text(text.replace(/Show in/, "Exit"));
+                    }
+                    _this.adjustToWindow();
+                }
+            },
             {
                 name: "Export Form Contents",
                 action: function (done) {

--- a/src/core.js
+++ b/src/core.js
@@ -404,7 +404,7 @@ define([
         var _this = this;
         return [
             {
-                name: "Show in Full Screen",
+                name: "Enter Full Screen",
                 action: function (done) {
                     var $fullScreenMenuItem = $(_.find(_this.$f.find('.fd-tools-menu a'), function(a) {
                         return a.text.match(/full screen/i);
@@ -416,10 +416,10 @@ define([
                     }
                     if (_this.data.windowManager.fullscreen) {
                         _this.data.windowManager.fullscreen = false;
-                        $fullScreenMenuItem.text(text.replace(/Exit/, "Show in"));
+                        $fullScreenMenuItem.text(text.replace(/Exit/, "Enter"));
                     } else {
                         _this.data.windowManager.fullscreen = true;
-                        $fullScreenMenuItem.text(text.replace(/Show in/, "Exit"));
+                        $fullScreenMenuItem.text(text.replace(/Enter/, "Exit"));
                     }
                     _this.adjustToWindow();
                 }

--- a/src/templates/main.html
+++ b/src/templates/main.html
@@ -1,7 +1,6 @@
 <div class="fd-ui-container">
     <div class="fd-toolbar">
         <div class="fd-form-actions pull-right btn-toolbar">
-            <div class="btn-group fd-fullscreen-button"></div>
             <div class="btn-group">
                 <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#">
                     <i class="fa fa-wrench"></i> Tools


### PR DESCRIPTION
Don't think this is important enough to be always visible, and user testing has pushed me to want to reduce clutter in vellum. @dimagi/product feel free to register an objection.

before
<img width="212" alt="screen shot 2016-10-28 at 5 58 43 pm" src="https://cloud.githubusercontent.com/assets/1486591/19823726/43144168-9d38-11e6-9581-befc3b839004.png">

after
<img width="184" alt="screen shot 2016-10-28 at 5 57 44 pm" src="https://cloud.githubusercontent.com/assets/1486591/19823736/483c0162-9d38-11e6-8d30-aa91d489555b.png">
<img width="174" alt="screen shot 2016-10-28 at 5 57 57 pm" src="https://cloud.githubusercontent.com/assets/1486591/19823738/4af86a62-9d38-11e6-8e0c-8140773ad77c.png">

cc @calellowitz 
