### PR TITLE
Make collapsing decisions sticky

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -423,6 +423,13 @@ define([
                 }
             });
         });
+
+        this.$f.on('show.bs.collapse hide.bs.collapse', function(e) {
+            var $target = $(e.target),
+                section = $target.parent().find("legend").text().trim(),
+                shouldCollapse = $target.hasClass('in');
+            localStorage.setItem('collapse-' + section, shouldCollapse ? "1" : "");
+        });
     };
 
     fn.getToolsMenuItems = function () {
@@ -1720,10 +1727,14 @@ define([
 
     fn.getSectionDisplay = function (mug, options) {
         var _this = this,
+            collapseKey = "collapse-" + options.displayName,
+            isCollapsed = localStorage.hasOwnProperty(collapseKey)
+                ? localStorage.getItem(collapseKey)
+                : options.isCollapsed,
             $sec = $(question_fieldset({
                 fieldsetClass: "fd-question-edit-" + options.slug || "anon",
                 fieldsetTitle: options.displayName,
-                isCollapsed: !!options.isCollapsed,
+                isCollapsed: !!isCollapsed,
                 help: options.help
             })),
             $fieldsetContent = $sec.find('.fd-fieldset-content');
@@ -1987,6 +1998,7 @@ define([
                 slug: "data_source",
                 displayName: "Data Source",
                 properties: this.getDataSourceProperties(),
+                isCollapsed: true,
                 help: {
                     title: "Data Source",
                     text: "You can configure an external data source like a " +
@@ -1998,6 +2010,7 @@ define([
                 slug: "logic",
                 displayName: "Logic",
                 properties: this.getLogicProperties(),
+                isCollapsed: true,
                 help: {
                     title: "Logic",
                     text: "Use logic to control when questions are asked and what answers are valid. " +
@@ -2010,7 +2023,7 @@ define([
                 displayName: "Media",
                 slug: "content",
                 properties: this.getMediaProperties(),
-                isCollapsed: false,
+                isCollapsed: true,
                 help: {
                     title: "Media",
                     text: "This will allow you to add images, audio or video media to a question, or other custom content.",

--- a/src/core.js
+++ b/src/core.js
@@ -1728,9 +1728,9 @@ define([
     fn.getSectionDisplay = function (mug, options) {
         var _this = this,
             collapseKey = "collapse-" + options.displayName,
-            isCollapsed = localStorage.hasOwnProperty(collapseKey)
-                ? localStorage.getItem(collapseKey)
-                : options.isCollapsed,
+            isCollapsed = localStorage.hasOwnProperty(collapseKey) ?
+                localStorage.getItem(collapseKey) :
+                options.isCollapsed,
             $sec = $(question_fieldset({
                 fieldsetClass: "fd-question-edit-" + options.slug || "anon",
                 fieldsetTitle: options.displayName,

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -239,6 +239,10 @@ define([
             });
         call("jstree", "deselect_all", true);
         call("jstree", "select_node", ufids);
+
+        // Make all question properties visible
+        $(".collapse-toggle.collapsed").click();
+
         return mugs;
     }
 


### PR DESCRIPTION
In question properties, collapse all sections by default except for Basic. Then, whenever someone collapses or expands a section, remember that decision and respect it in the future.

Quick and dirty and testless, since the failure mode of this is not a big deal.

cc @calellowitz 
