### PR TITLE
Fix copy bubble from label to expression input

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1159,6 +1159,7 @@ define([
                 }
                 hidePageSpinner();
             } catch (e) {
+                window.console.log(util.formatExc(e));
                 // hack: don't display the whole invalid XML block if it
                 // was a parse error
                 var msg = e.toString();

--- a/src/datasources.js
+++ b/src/datasources.js
@@ -232,7 +232,7 @@ define([
      * hashtag and/or xpath expression.
      */
     builders.dataNodes = function (that) {
-        function node(source, parentPath, info) {
+        function node(source, parentPath, info, index) {
             return function (item, id) {
                 if (_.contains(that.invalidCaseProperties, id)) {
                     return null;
@@ -253,6 +253,7 @@ define([
                     hashtagPrefix: hashtagPrefix,
                     parentPath: parentPath,
                     xpath: path,
+                    index: index || false,
                     sourceInfo: info,
                     getNodes: tree.getNodes,
                     recursive: tree.recursive,
@@ -309,7 +310,7 @@ define([
                         // magic: reference key: @case_id
                         var item = {reference: {subset: subset, key: "@case_id"}};
                         // magic: append "/index" to path
-                        return node(source, path + "/index", info)(item, relation);
+                        return node(source, path + "/index", info, true)(item, relation);
                     })
                     .sortBy("text")
                     .value()
@@ -340,7 +341,7 @@ define([
     builders.hashtags = function (that) {
         function walk(nodes, hashtags) {
             _.each(nodes, function (node) {
-                if (node.hashtag) {
+                if (node.hashtag && !node.index) {
                     hashtags.map[node.hashtag] = node.xpath;
                     hashtags.transforms[node.hashtagPrefix] = function (prop) {
                         return node.parentPath + "/" + prop;

--- a/src/escapedHashtags.js
+++ b/src/escapedHashtags.js
@@ -34,7 +34,8 @@ define([
     var OUTSIDE_HASHTAG = 0,
         INSIDE_HASHTAG = 1,
         DELIMITER = "`",
-        ID_CHAR = /^[\w.\-]/;
+        ID_CHAR = /^[\w.\-]/,
+        INVALID_PREFIX = "#invalid/xpath ";
 
     /*
      * transforms escaped hashtags based on transformFn
@@ -112,6 +113,23 @@ define([
         return output;
     }
 
+    /**
+     * Check for escaped invalid (cannot be parsed) hashtag expression
+     */
+    function isInvalid(value) {
+        return value.startsWith(INVALID_PREFIX);
+    }
+
+    /**
+     * Convert (possibly invalid) escaped hashtag expression to xpath
+     */
+    function unescapeXPath(value, form) {
+        //if (isInvalid(value)) {
+        //    value = value.slice(INVALID_PREFIX.length);
+        //}
+        return transform(value, form.normalizeXPath.bind(form));
+    }
+
     /*
      * extends xpath parser to be aware of escaped hashtags
      */
@@ -140,7 +158,7 @@ define([
 
         return {
             parse: function (input) {
-                if (input.startsWith("#invalid/xpath ")) {
+                if (isInvalid(input)) {
                     throw new Error("Invalid XPath");
                 }
                 // TODO eliminate transform(input) here; should not be needed.
@@ -164,6 +182,8 @@ define([
     }
 
     return {
+        isInvalid: isInvalid,
+        unescapeXPath: unescapeXPath,
         transform: transform,
         parser: parser,
     };

--- a/src/form.js
+++ b/src/form.js
@@ -4,7 +4,8 @@ define([
     'jquery',
     'vellum/tree',
     'vellum/logic',
-    'vellum/escapedHashtags',
+    'vellum/richText',
+    'vellum/xpath',
     'vellum/fuse',
     'vellum/undomanager',
     'vellum/util'
@@ -14,7 +15,8 @@ define([
     $,
     Tree,
     logic,
-    escapedHashtags,
+    richText,
+    xpath,
     Fuse,
     undomanager,
     util
@@ -143,7 +145,7 @@ define([
         this.enableInstanceRefCounting = opts.enableInstanceRefCounting;
         this.errors = [];
         this.question_counter = 1;
-        this.xpath = escapedHashtags.parser(this);
+        this.xpath = xpath.parser(this);
         this.undomanager = new undomanager();
 
         this.undomanager.on('reset', function(e) {
@@ -224,21 +226,17 @@ define([
                 delete this.hashtagMap[hashtag];
             }
         },
-        transform: function(input, transformFn) {
-            input = this.normalizeEscapedHashtag(input);
-            return escapedHashtags.transform(input, transformFn);
-        },
         normalize: function (methodName, xpath) {
-            // try catch is needed as workaround for having an itemset without
-            // the itemset plugin enabled and invalid xpaths
-            try {
-                return xpath ? this.xpath.parse(xpath)[methodName]() : xpath;
-            } catch (err) {
-                return escapedHashtags.isInvalid(xpath) ? xpath.slice(15) : xpath;
+            if (!xpath || (this.richText && richText.isInvalid(xpath))) {
+                return xpath;
             }
-         },
-        normalizeEscapedHashtag: function (xpath_) {
-            return this.normalize('toEscapedHashtag', xpath_);
+            // try catch is needed as workaround for having an itemset without
+            // the itemset plugin enabled
+            try {
+                return this.xpath.parse(xpath)[methodName]();
+            } catch (err) {
+                return xpath;
+            }
         },
         normalizeHashtag: function (xpath_) {
             return this.normalize('toHashtag', xpath_);

--- a/src/form.js
+++ b/src/form.js
@@ -234,7 +234,7 @@ define([
             try {
                 return xpath ? this.xpath.parse(xpath)[methodName]() : xpath;
             } catch (err) {
-                return xpath.startsWith('#invalid/xpath ') ? xpath.slice(15) : xpath;
+                return escapedHashtags.isInvalid(xpath) ? xpath.slice(15) : xpath;
             }
          },
         normalizeEscapedHashtag: function (xpath_) {

--- a/src/logic.js
+++ b/src/logic.js
@@ -171,7 +171,7 @@ define([
         },
         getText: function () {
             if (this._text && this.parsed) {
-                return this.parsed.toEscapedHashtag();
+                return this.parsed.toHashtag();
             } else {
                 return this._text;
             }

--- a/src/parser.js
+++ b/src/parser.js
@@ -668,7 +668,7 @@ define([
         var method = (noPop ? el.attr : el.popAttr).bind(el),
             vellumAttr = method('vellum:' + key),
             xmlAttr = method(key);
-        return form.normalizeEscapedHashtag(vellumAttr ? vellumAttr : xmlAttr);
+        return form.normalizeHashtag(vellumAttr ? vellumAttr : xmlAttr);
     }
 
     var _getInstances = function (xml) {

--- a/src/richText.js
+++ b/src/richText.js
@@ -400,7 +400,7 @@ define([
             steps, dispValue;
 
         if (topLevelPaths.length) {
-            steps = parsed.getTopLevelPaths()[0].steps;
+            steps = topLevelPaths[0].steps;
             dispValue = steps[steps.length-1].name;
         } else {
             steps = hashtags[0].toHashtag().split('/');

--- a/src/richText.js
+++ b/src/richText.js
@@ -576,7 +576,6 @@ define([
      *      invalid xpath prefix, otherwise the given value
      */
     function unescapeXPath(value, form) {
-        // TODO add whitespace to prevent run-on sub-expressions
         if (isInvalid(value)) {
             value = escapedHashtags.transform(
                 value.slice(INVALID_PREFIX.length),

--- a/src/util.js
+++ b/src/util.js
@@ -311,15 +311,15 @@ define([
         try {
             var expr = form.xpath.parse(hashtagOrXPath);
             xpath_ = expr.toXPath();
+            // TODO hashtag = hashtagOrXPath
+            // (do not convert hand-typed xpaths to hashtags)
             hashtag = expr.toHashtag();
         } catch (err) {
             if (form.richText) {
-                xmlWriter.writeAttributeString('vellum:' + vellumKey, "#invalid/xpath " + hashtagOrXPath);
+                // TODO hashtagOrXPath should already have this prefix
+                hashtag = "#invalid/xpath " + hashtagOrXPath;
             }
-            xmlWriter.writeAttributeString(key, escapedHashtags.transform(hashtagOrXPath, function(hashtag) {
-                return mug.form.normalizeXPath(hashtag);
-            }));
-            return;
+            xpath_ = escapedHashtags.unescapeXPath(hashtagOrXPath, form);
         }
 
         if (hashtag !== xpath_) {
@@ -344,5 +344,3 @@ define([
 
     return that;
 });
-
-

--- a/src/util.js
+++ b/src/util.js
@@ -35,7 +35,10 @@ define([
     });
 
     that.formatExc = function (error) {
-        return error && error.stack ? error.stack : String(error);
+        if (error && error.stack) {
+            return error + "\n" + error.stack;
+        }
+        return String(error);
     };
 
     that.validAttributeRegex = /^[^<&'">]*$/;

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -220,7 +220,7 @@ define([
 
             if (ret && widget.hasLogicReferences) {
                 // TODO should not be using hashtags when rich text is off
-                return mug.form.normalizeEscapedHashtag(ret);
+                return mug.form.normalizeHashtag(ret);
             } else {
                 return ret;
             }

--- a/src/xpath.js
+++ b/src/xpath.js
@@ -50,5 +50,9 @@ define([
             ret.models = ret.yy.xpathmodels;
             return ret;
         },
+        parser: function (hashtagInfo) {
+            var models = this.makeXPathModels(hashtagInfo);
+            return this.createParser(models);
+        },
     };
 });

--- a/tests/copy-paste.js
+++ b/tests/copy-paste.js
@@ -994,7 +994,7 @@ define([
                 ["id", "type", "calculateAttr"],
                 ["/invalid", "DataBindOnly", "(42"],
                 ["/invalid2", "DataBindOnly", "#invalid/xpath (42"],
-                ["/invalid3", "DataBindOnly", "#invalid/xpath (`#form/invalid`"],
+                ["/invalid3", "DataBindOnly", "#invalid/xpath (#form/invalid"],
             ]);
             util.clickQuestion('invalid');
             util.clickQuestion('invalid2');
@@ -1003,7 +1003,7 @@ define([
                 invalid3 = util.getMug('invalid3');
             assert.strictEqual(invalid.p.calculateAttr, '#invalid/xpath (42');
             assert.strictEqual(invalid2.p.calculateAttr, '#invalid/xpath (42');
-            assert.strictEqual(invalid3.p.calculateAttr, '#invalid/xpath (`#form/invalid`');
+            assert.strictEqual(invalid3.p.calculateAttr, '#invalid/xpath (#form/invalid');
             var widget = util.getWidget('property-calculateAttr');
             widget.input.promise.then(function () {
                 assert.strictEqual(widget.getValue(), '(42');
@@ -1012,7 +1012,7 @@ define([
                     ["id", "type", "calculateAttr"],
                     ["/invalid", "DataBindOnly", "#invalid/xpath (42"],
                     ["/invalid2", "DataBindOnly", "#invalid/xpath (42"],
-                    ["/invalid3", "DataBindOnly", "#invalid/xpath (`#form/invalid`"],
+                    ["/invalid3", "DataBindOnly", "#invalid/xpath (#form/invalid"],
                 ]);
                 done();
             });
@@ -1032,10 +1032,10 @@ define([
             assert.strictEqual(valid.p.calculateAttr, '#form/invalid');
             var widget = util.getWidget('property-calculateAttr');
             widget.input.promise.then(function () {
-                assert.strictEqual(widget.getValue(), '`#form/invalid`');
+                assert.strictEqual(widget.getValue(), '#form/invalid');
                 assert.strictEqual(
                     $('[name=property-calculateAttr]').find('span .label').data('value'),
-                    '`#form/invalid`'
+                    '#form/invalid'
                 );
                 util.selectAll();
                 eq(mod.copy(), [

--- a/tests/core.js
+++ b/tests/core.js
@@ -88,7 +88,7 @@ define([
             group.p.nodeID = "g8";
             assert.equal(q1.form.getAbsolutePath(q1), "/data/g8/question1");
             assert.strictEqual(q2.p.relevantAttr,
-                "`#form/g8/question1` = 'valley girl' and `#form/g8/question2` = 'dude'");
+                "#form/g8/question1 = 'valley girl' and #form/g8/question2 = 'dude'");
         });
 
         it("should show warning icons on invalid questions", function () {

--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -79,8 +79,7 @@ define([
         }];
 
     describe("The data browser", function () {
-        var escapedDobProp = '`#case/dob`',
-            dobProp = '#case/dob',
+        var dobProp = '#case/dob',
             dataTree;
 
         function getInstanceId(form, src) {
@@ -117,7 +116,7 @@ define([
                     widget = util.getWidget('property-calculateAttr');
                 widget.input.promise.then(function () { 
                     editor.on('change', function() {
-                        assert.equal(mug.p.calculateAttr, escapedDobProp);
+                        assert.equal(mug.p.calculateAttr, dobProp);
                         assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
                         assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
                         util.assertXmlEqual(call("createXML"), CHILD_REF_XML,
@@ -141,7 +140,7 @@ define([
                     widget = util.getWidget('property-calculateAttr');
                 widget.input.promise.then(function () { 
                     editor.on('change', function() {
-                        assert.equal(mug.p.calculateAttr, "`#case/parent/edd`");
+                        assert.equal(mug.p.calculateAttr, "#case/parent/edd");
                         assert.equal(getInstanceId(mug.form, sessionUri), "commcaresession");
                         assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
                         util.assertXmlEqual(call("createXML"), MOTHER_REF_XML,
@@ -336,7 +335,7 @@ define([
             });
 
             it("should error for unknown properties", function(done) {
-                widget.setValue(escapedDobProp);
+                widget.setValue(dobProp);
                 widget.handleChange();
                 assert(!util.isTreeNodeValid(blue), "expected validation error");
                 assert.lengthOf(widget.getControl().find('.label-datanode-unknown'), 1);
@@ -376,10 +375,10 @@ define([
             });
 
             it("should not error for known properties", function() {
-                assert.strictEqual(widget.getValue(), escapedDobProp);
+                assert.strictEqual(widget.getValue(), dobProp);
                 assert.lengthOf(widget.getControl().find('.label-datanode-unknown'), 0);
                 event.fire("loadCaseData");
-                assert.strictEqual(widget.getValue(), escapedDobProp);
+                assert.strictEqual(widget.getValue(), dobProp);
                 assert.lengthOf(widget.getControl().find('.label-datanode-unknown'), 0);
             });
 

--- a/tests/diffDataParent.js
+++ b/tests/diffDataParent.js
@@ -57,11 +57,11 @@ define([
                 form = call("getData").core.form;
 
             util.addQuestion("Group", 'group1');
-            text2.p.dataParent = '`#form/group1`';
+            text2.p.dataParent = '#form/group1';
 
             form.moveMug(text2, 'before', text1);
 
-            assert.equal(text2.p.dataParent, '`#form/group1`');
+            assert.equal(text2.p.dataParent, '#form/group1');
         });
 
         it("should update data tree after a change to data parent", function() {
@@ -74,7 +74,7 @@ define([
             text1.p.dataParent = '#form/group1';
             assert.equal(text1.p.dataParent, "#form/group1");
             form.moveMug(group1, 'into', group2);
-            assert.equal(text1.p.dataParent, "`#form/group2/group1`");
+            assert.equal(text1.p.dataParent, "#form/group2/group1");
         });
 
         it("should clear the data parent when moving to a repeat group", function() {

--- a/tests/form.js
+++ b/tests/form.js
@@ -70,7 +70,7 @@ define([
 
             blue.p.nodeID = "orange";
             assert.equal(green.p.nodeID, "blue");
-            assert.equal(black.p.calculateAttr, "`#form/orange` + `#form/blue`");
+            assert.equal(black.p.calculateAttr, "#form/orange + #form/blue");
             assert(util.isTreeNodeValid(blue), blue.getErrors().join("\n"));
             assert(util.isTreeNodeValid(green), green.getErrors().join("\n"));
             assert(util.isTreeNodeValid(black), black.getErrors().join("\n"));
@@ -90,7 +90,7 @@ define([
 
             form.moveMug(text, "into", null);
             assert.equal(text.p.nodeID, "text");
-            assert.equal(hid.p.calculateAttr, "`#form/text` + `#form/group/text`");
+            assert.equal(hid.p.calculateAttr, "#form/text + #form/group/text");
             assert(util.isTreeNodeValid(text), text.getErrors().join("\n"));
         });
 
@@ -156,7 +156,7 @@ define([
             form.duplicateMug(group);
             var green2 = util.getMug("copy-1-of-group/green");
             assert.equal(green2.p.relevantAttr,
-                "`#form/copy-1-of-group/blue` = 'red' and `#form/red` = 'blue'");
+                "#form/copy-1-of-group/blue = 'red' and #form/red = 'blue'");
         });
 
         it("should set non-standard form root node", function () {
@@ -212,7 +212,7 @@ define([
             repeat.p.repeat_count = '#form/text';
             assert.equal(repeat.p.repeat_count, '#form/text');
             text.p.nodeID = 'text2';
-            assert.equal(repeat.p.repeat_count, '`#form/text2`');
+            assert.equal(repeat.p.repeat_count, '#form/text2');
         });
 
         it ("should show warnings for duplicate choice value", function() {

--- a/tests/logic.js
+++ b/tests/logic.js
@@ -37,7 +37,7 @@ define([
             util.loadXML(TEST_XML_1);
             util.getMug("question1").p.nodeID = 'question';
             var mug = util.getMug("/data/question2");
-            assert.equal(mug.p.relevantAttr, "`#form/question` = 1");
+            assert.equal(mug.p.relevantAttr, "#form/question = 1");
         });
 
         it("should not update expressions for model iteration", function () {

--- a/tests/modeliteration.js
+++ b/tests/modeliteration.js
@@ -65,7 +65,7 @@ define([
                 idsQuery: "instance('casedb')/mother/child/@case_id"
             });
             assert.equal(phone.__className, "PhoneNumber");
-            assert.equal(hidden.p.calculateAttr, "`#form/group/item/phone` = '12345'");
+            assert.equal(hidden.p.calculateAttr, "#form/group/item/phone = '12345'");
             util.assertXmlEqual(call("createXML"), CASE_LIST_REPEAT_WITH_QUESTIONS_XML);
         });
 

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -144,7 +144,7 @@ define([
                 it("should override " + prop + " in question " + question, function() {
                     util.loadXML(OVERRIDE_XML);
                     var mug = util.getMug(question);
-                    assert.strictEqual(mug.p[prop], "`#form/question1`");
+                    assert.strictEqual(mug.p[prop], "#form/question1");
                 });
             });
 

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -104,10 +104,9 @@ define([
     function externalIcon () { return icon('fcc-fd-case-property'); }
     function externalUnknownIcon () { return icon('fa-exclamation-triangle'); }
 
-    function makeBubble(xpath, dispValue, icon, internal, output) {
+    function makeBubble(xpath, dispValue, icon, internal) {
         var span = $('<span>').addClass('label label-datanode').attr({
             'data-value': xpath,
-            'data-output-value': output || false,
         });
         if (internal && !_.isString(internal)) {
             span.addClass('label-datanode-internal');
@@ -122,10 +121,6 @@ define([
     }
     function outputValueTemplateFn(path) {
         return '<output value="' + path + '"></output>';
-    }
-
-    function makeOutputValue(xpath, dispValue, icon, internal) {
-        return makeBubble(xpath, dispValue, icon, internal, true);
     }
 
     function wrapWithDiv(el) { return $('<div>').append(el); }
@@ -171,7 +166,7 @@ define([
                 it("from text to html with output value: " + val[0], function() {
                     assert.strictEqual(
                         richText.toRichText(outputValueTemplateFn(val[0]), form),
-                        wrapWithDivP(makeOutputValue(val[0], val[1], val[2], val[3])).html()
+                        wrapWithDivP(makeBubble(val[0], val[1], val[2], val[3])).html()
                     );
                 });
             });
@@ -195,7 +190,7 @@ define([
                 it("from text to html with output value: " + val.xmlValue, function() {
                     assert.equal(
                         richText.toRichText(outputValueTemplateFn(val.xmlValue), form),
-                        wrapWithDivP(makeOutputValue(
+                        wrapWithDivP(makeBubble(
                             val.valueInBubble,
                             val.bubbleDispValue,
                             val.icon,
@@ -325,7 +320,7 @@ define([
                     var result = richText.bubbleOutputs(item[0], form, true),
                         expect = item[1].replace(/{(.*?)}/g, function (m, name) {
                             if (form.getIconByPath("#form/" + name)) {
-                                var output = makeOutputValue("#form/" + name, name, ico, true);
+                                var output = makeBubble("#form/" + name, name, ico, true);
                                 return output[0].outerHTML;
                             }
                             return m;
@@ -338,7 +333,6 @@ define([
         describe("serialize formats correctly", function () {
             it("should handle output refs", function() {
                 assert.equal(richText.applyFormats({
-                    outputValue: 1,
                     value: "#case/f_2685",
                 }), '&lt;output value="#case/f_2685" /&gt;');
             });
@@ -346,7 +340,6 @@ define([
             it("should handle dates", function() {
                 assert.equal(richText.applyFormats({
                     dateFormat: "%d/%n/%y",
-                    outputValue: 1,
                     value: "#form/question1",
                 }), '&lt;output value="format-date(date(#form/question1), \'%d/%n/%y\')" /&gt;');
             });

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -344,6 +344,21 @@ define([
                 }), '&lt;output value="format-date(date(#form/question1), \'%d/%n/%y\')" /&gt;');
             });
         });
+
+        describe("invalid xpath unescaper", function () {
+            it("should pass through xpath not marked as invalid", function() {
+                assert.equal(richText.unescapeXPath("/data/valid", form), "/data/valid");
+            });
+
+            _.each({
+                "#invalid/xpath `#form/text` xpath": "/data/text xpath",
+                "#invalid/xpath `#form/text`xpath": "/data/text xpath",
+            }, function (expect, expr) {
+                it("should unescape invalid xpath: " + expr + " -> " + expect, function() {
+                    assert.equal(richText.unescapeXPath(expr, form), expect);
+                });
+            });
+        });
     });
 
     describe("The rich text editor", function () {

--- a/tests/static/all_question_types.tsv
+++ b/tests/static/all_question_types.tsv
@@ -1,5 +1,5 @@
 Question	Type	Text (en)	Text (hin)	Audio (en)	Audio (hin)	Image (en)	Image (hin)	Video (en)	Video (hin)	Video Inline (en)	Video Inline (hin)	Display Condition	Validation Condition	Validation Message	Calculate Condition	Required
-/question1	Text	question1 en label	question1 hin label	jr://file/commcare/audio/data/question1.mp3	jr://file/commcare/audio/data/question1.mp3	jr://file/commcare/image/data/question1.png	jr://file/commcare/image/data/question1.png	jr://file/commcare/video/data/question1.3gp	jr://file/commcare/video/data/question1.3gp	jr://file/commcare/video-inline/data/question1.3gp	jr://file/commcare/video-inline/data/question1.3gp	`#form/question20`	`#form/question20` = 2	question1 en validation		yes
+/question1	Text	question1 en label	question1 hin label	jr://file/commcare/audio/data/question1.mp3	jr://file/commcare/audio/data/question1.mp3	jr://file/commcare/image/data/question1.png	jr://file/commcare/image/data/question1.png	jr://file/commcare/video/data/question1.3gp	jr://file/commcare/video/data/question1.3gp	jr://file/commcare/video-inline/data/question1.3gp	jr://file/commcare/video-inline/data/question1.3gp	#form/question20	#form/question20 = 2	question1 en validation		yes
 /question2	Label															no
 /question30	Label															no
 /question3	Multiple Choice															no

--- a/tests/widgets.js
+++ b/tests/widgets.js
@@ -108,7 +108,7 @@ define([
             util.loadXML("");
             util.addQuestion("Text", "text");
             var value = '/data/text',
-                escaped = '`#form/text`',
+                escaped = '#form/text',
                 hidden = util.addQuestion("DataBindOnly", "hidden", {
                     calculateAttr: escaped
                 });
@@ -228,7 +228,7 @@ define([
             disp.input.promise.then(function () { // wait for editor to be ready
                 util.findNode(tree, "hidden").data.handleDrop(disp.input);
                 disp.handleChange();
-                assert.equal(text.p.relevantAttr, '`#form/hidden`');
+                assert.equal(text.p.relevantAttr, '#form/hidden');
                 done();
             });
         });

--- a/tests/writer.js
+++ b/tests/writer.js
@@ -81,7 +81,7 @@ define([
             util.addQuestion("Int");
             var mug = util.addQuestion("Repeat");
             util.addQuestion("Text");
-            mug.p.repeat_count = "`#form/question1`";
+            mug.p.repeat_count = "#form/question1";
             util.assertXmlEqual(
                 util.call("createXML"),
                 REPEAT_WITH_COUNT_AS_QUESTION_XML,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?237816

Includes a major refactor of escaped hashtags: they're now only used inside the rich text widget and when writing invalid expressions in XML. Best to review commits individually 🐠 the commit messages are descriptive.

@emord 