### PR TITLE
Clean up rich text flags

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1206,7 +1206,6 @@ define([
         this.data.core.form = form = parser.parseXForm(
             formXML, options, this, _this.data.core.parseWarnings);
         form.formName = this.opts().core.formName || form.formName;
-        form.writeIgnoreRichText = this.opts().features.rich_text;
         form.noMarkdown = form.noMarkdown || false;
         if (formXML) {
             _this._resetMessages(_this.data.core.form.errors);

--- a/src/core.js
+++ b/src/core.js
@@ -1206,11 +1206,6 @@ define([
         this.data.core.form = form = parser.parseXForm(
             formXML, options, this, _this.data.core.parseWarnings);
         form.formName = this.opts().core.formName || form.formName;
-        if (this.opts().features.rich_text) {
-            form.richText = _.isBoolean(form.richText) ? form.richText : true;
-        } else {
-            form.richText = false;
-        }
         form.writeIgnoreRichText = this.opts().features.rich_text;
         form.noMarkdown = form.noMarkdown || false;
         if (formXML) {

--- a/src/core.js
+++ b/src/core.js
@@ -480,7 +480,7 @@ define([
             return mug._core_cachedDisplayNameValue;
         }
         mug._core_cachedDisplayNameKey = val;
-        if (mug.supportsRichText()) {
+        if (mug.form.richText) {
             val = richText.bubbleOutputs(val, this.data.core.form, true);
         } else {
             val = jrUtil.outputToXPath(val, mug.form.xpath, true);
@@ -1095,7 +1095,7 @@ define([
         } else {
             // for the currently selected mug, return a "."
             return (mug.ufid === this.getCurrentlySelectedMug().ufid) ? 
-                "." : (mug.supportsRichText() ? mug.hashtagPath : mug.absolutePath);
+                "." : (mug.form.richText ? mug.hashtagPath : mug.absolutePath);
         }
         // Instead of depending on the UI state (currently selected mug), it
         // would probably be better to have this be handled by the widget using

--- a/src/core.js
+++ b/src/core.js
@@ -1205,8 +1205,6 @@ define([
         }
         this.data.core.form = form = parser.parseXForm(
             formXML, options, this, _this.data.core.parseWarnings);
-        form.formName = this.opts().core.formName || form.formName;
-        form.noMarkdown = form.noMarkdown || false;
         if (formXML) {
             _this._resetMessages(_this.data.core.form.errors);
             _this._populateTree();

--- a/src/expressionEditor.js
+++ b/src/expressionEditor.js
@@ -76,7 +76,7 @@ define([
         };
 
         var setExpression = function(input, val) {
-            if (options.mug.supportsRichText()) {
+            if (options.mug.form.richText) {
                 richText.editor(input, form, richTextOptions).setValue(val);
             } else {
                 input.val(val);
@@ -84,7 +84,7 @@ define([
         };
 
         var getExpression = function(input) {
-            if (options.mug.supportsRichText()) {
+            if (options.mug.form.richText) {
                 return richText.editor(input, form, richTextOptions).getValue();
             } else {
                 return input.val();
@@ -109,7 +109,7 @@ define([
             } else {
                 atwho.autocomplete(input, options.mug, {
                     property: options.path,
-                    useRichText: options.mug.supportsRichText(),
+                    useRichText: options.mug.form.richText,
                 });
             }
         };
@@ -185,7 +185,7 @@ define([
 
             var newExpressionUIElement = function (expOp) {
                 var tag = 'input', tagArgs = '';
-                if (options.mug.supportsRichText()) {
+                if (options.mug.form.richText) {
                     tag = 'div';
                     tagArgs = 'contenteditable="true"';
                 }
@@ -198,7 +198,7 @@ define([
                     tagArgs: tagArgs,
                 }));
 
-                if (options.mug.supportsRichText()) {
+                if (options.mug.form.richText) {
                     $expUI.find('.fd-input').each(function () {
                         richText.editor($(this), form, richTextOptions);
                     });
@@ -233,7 +233,7 @@ define([
                 };
 
                 // add event handlers to validate the inputs
-                if (options.mug.supportsRichText()) {
+                if (options.mug.form.richText) {
                     $expUI.find('.xpath-edit-node').each(function () {
                         richText.editor($(this), form, richTextOptions).on('change', validateExpression);
                     });
@@ -361,7 +361,7 @@ define([
                     $div.find('.fd-add-exp').click();
                 }
             } else {
-                if (options.mug.supportsRichText()) {
+                if (options.mug.form.richText) {
                     showAdvancedMode(options.value);
                 } else {
                     showAdvancedMode(form.normalizeXPath(options.value));
@@ -401,7 +401,7 @@ define([
 
         var initXPathEditor = function() {
             var tag = 'textarea', tagArgs = 'rows="5"';
-            if (options.mug.supportsRichText()) {
+            if (options.mug.form.richText) {
                 tag = 'div';
                 tagArgs = 'contenteditable="true"';
             }

--- a/src/form.js
+++ b/src/form.js
@@ -125,7 +125,8 @@ define([
         this.vellum = vellum;
         this.mugTypes = mugTypes;
 
-        this.formName = 'New Form';
+        this.formName = vellum.opts().core.formName || "New Form";
+        this.noMarkdown = false;
         this.mugMap = {};
         this.instanceMetadata = [InstanceMetadata({})];
         // {<instance id>: { src or children: <instance src or children>}

--- a/src/form.js
+++ b/src/form.js
@@ -131,6 +131,10 @@ define([
         // {<instance id>: { src or children: <instance src or children>}
         this.knownInstances = {};
         this.richText = !!vellum.opts().features.rich_text;
+        // TODO remove mayDisableRichText once the rich_text feature is enabled
+        // by default. Otherwise instances of vellum loaded without rich_text
+        // specified in features will always write vellum:ignore="richText"
+        this.mayDisableRichText = this.richText;
 
         vellum.datasources.on("change", this._updateHashtags.bind(this), null, null, this);
         this._updateHashtags();

--- a/src/javaRosa/itextWidget.js
+++ b/src/javaRosa/itextWidget.js
@@ -134,7 +134,7 @@ define([
         $input.addClass('jstree-drop');
 
         if (options.path === 'labelItext') {
-            if (!mug.supportsRichText()) {
+            if (!mug.form.richText) {
                 $input.keydown(function (e) {
                     // deletion of entire output ref in one go
                     if (e && e.which === 8 || e.which === 46) {
@@ -179,7 +179,7 @@ define([
                 insertTpl: '<output value="${name}" />',
                 property: "labelItext",
                 outputValue: true,
-                useRichText: mug.supportsRichText(),
+                useRichText: mug.form.richText,
             });
         }
 
@@ -206,7 +206,7 @@ define([
                 lang = widget.language;
             }
             value = itextItem && itextItem.get(widget.form, lang);
-            if (mug.supportsRichText()) {
+            if (mug.form.richText) {
                 return jrUtil.outputToHashtag(value, widget.mug.form.xpath);
             } else {
                 return jrUtil.outputToXPath(value, widget.mug.form.xpath);
@@ -216,7 +216,7 @@ define([
         widget.setItextValue = function (value) {
             var itextItem = widget.getItextItem();
             // TODO should not be using hashtags when rich text is off
-            //if (mug.supportsRichText()) {
+            //if (mug.form.richText) {
             value = jrUtil.outputToHashtag(value, widget.mug.form.xpath);
             //}
             if (itextItem) {

--- a/src/javaRosa/util.js
+++ b/src/javaRosa/util.js
@@ -252,8 +252,7 @@ define([
     var insertOutputRef = function(vellum, target, path, mug, dateFormat) {
         var output = getOutputRef(path, dateFormat),
             form = vellum.data.core.form;
-        if ((!mug && form.richText) ||
-            (mug && mug.supportsRichText())) {
+        if (form.richText) {
             richText.editor(target).insertOutput(output);
         } else {
             util.insertTextAtCursor(target, output, true);

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -473,9 +473,6 @@ define([
             }
             return this.parentMug && this.parentMug.isInRepeat();
         },
-        supportsRichText: function() {
-            return this.form.richText;
-        }
     };
 
     Object.defineProperty(Mug.prototype, "absolutePath", {

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -474,7 +474,7 @@ define([
             return this.parentMug && this.parentMug.isInRepeat();
         },
         supportsRichText: function() {
-            return this.options.richText && this.form.richText;
+            return this.form.richText;
         }
     };
 
@@ -1648,8 +1648,7 @@ define([
     function MugTypesManager(baseSpec, mugTypes, opts) {
         var _this = this,
             // Nestable Field List not supported in CommCare before v2.16
-            group_in_field_list = opts.features.group_in_field_list,
-            richText = opts.features.rich_text;
+            group_in_field_list = opts.features.group_in_field_list;
         Image.resize_enabled = opts.features.image_resize;
 
         this.auxiliaryTypes = mugTypes.auxiliary;
@@ -1699,7 +1698,6 @@ define([
 
         _.each(this.allTypes, function (Mug, name) {
             Mug.__className = name;
-            Mug.richText = richText;
 
             // set on this for easy access
             _this[name] = Mug;

--- a/src/parser.js
+++ b/src/parser.js
@@ -54,10 +54,6 @@ define([
         if($(xml).find('parsererror').length > 0) {
             throw 'PARSE ERROR!:' + $(xml).find('parsererror').find('div').html();
         }
-        
-        if(title.length > 0) {
-            form.formName = $(title).text();
-        }
 
         ignore = ignore ? ignore.split(" ") : [];
         if (_.contains(ignore, 'richText')) {
@@ -97,7 +93,7 @@ define([
                 'No Data block was found in the form.  Please check that your form is valid!');
         }
        
-        parseDataTree(form, data[0]);
+        parseDataTree(form, data[0], title.length ? title.text() : "");
         parseBindList(form, binds);
 
         parseSetValues(form, setValues);
@@ -130,7 +126,7 @@ define([
     }
 
     // DATA PARSING FUNCTIONS
-    function parseDataTree (form, dataEl) {
+    function parseDataTree (form, dataEl, titleText) {
         var root = $(dataEl),
             tree = form.tree,
             recFunc;
@@ -164,7 +160,14 @@ define([
         form.formJRM = root.attr("xmlns:jrm");
         form.formUIVersion = root.attr("uiVersion");
         form.formVersion = root.attr("version");
-        form.formName = root.attr("name") || form.formName;
+
+        var optionsName = form.vellum.opts().core.formName,
+            formName = optionsName || root.attr("name") || titleText;
+        if (formName) {
+            form.formName = formName;
+        } else {
+            form.parseWarnings.push('Form does not have a Name! The default form name will be used');
+        }
 
         if (!form.formUuid || form.formUuid === "undefined") {
             form.formUuid = "http://openrosa.org/formdesigner/" + util.generate_xmlns_uuid();
@@ -177,9 +180,6 @@ define([
         }
         if (!form.formVersion) {
             form.parseWarnings.push('Form does not have a Version attribute (in the data block), one will be added automatically');
-        }
-        if (!form.formName) {
-            form.parseWarnings.push('Form does not have a Name! The default form name will be used');
         }
     }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -59,8 +59,6 @@ define([
             form.formName = $(title).text();
         }
 
-        // TODO set this to vellum.opts().features.rich_text ??
-        form.richText = true;
         ignore = ignore ? ignore.split(" ") : [];
         if (_.contains(ignore, 'richText')) {
             form.richText = false;
@@ -78,7 +76,7 @@ define([
         });
         form.updateKnownInstances();
 
-        if (vellum.opts().features.rich_text && !form.vellum.datasources.isReady()) {
+        if (form.richText && !form.vellum.datasources.isReady()) {
             // load hashtags from form to prevent unknown hashtag warnings
             // WARNING hashtag values will not be written correctly (on save
             // or edit XML) unil after data sources are loaded.
@@ -443,7 +441,7 @@ define([
                     if (repeat.length === 1) {
                         var adapt = function (mug, form) {
                             mug = makeMugAdaptor('Repeat')(mug, form);
-                            mug.p.repeat_count = repeat.popAttr('vellum:jr__count') || repeat.popAttr('jr:count') || null;
+                            mug.p.repeat_count = parseVellumAttrs(form, repeat, 'jr:count') || null;
                             mug.p.rawRepeatAttributes = getAttributes(repeat);
                             return mug;
                         };
@@ -668,9 +666,9 @@ define([
 
     function parseVellumAttrs(form, el, key, noPop) {
         var method = (noPop ? el.attr : el.popAttr).bind(el),
-            vellumAttr = method('vellum:' + key),
+            vellumAttr = method('vellum:' + key.replace(/:/g, "__")),
             xmlAttr = method(key);
-        return form.normalizeHashtag(vellumAttr ? vellumAttr : xmlAttr);
+        return form.normalizeHashtag(form.richText && vellumAttr ? vellumAttr : xmlAttr);
     }
 
     var _getInstances = function (xml) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -43,6 +43,7 @@ define([
 
         var xmlDoc = $.parseXML(xmlString),
             xml = $(xmlDoc),
+            ignore = xml.find('h\\:html, html').attr('vellum:ignore'),
             head = xml.find('h\\:head, head'),
             title = head.children('h\\:title, title'),
             binds = head.find('bind'),
@@ -60,10 +61,9 @@ define([
 
         // TODO set this to vellum.opts().features.rich_text ??
         form.richText = true;
-        if(xml.find('[vellum\\:ignore=richText]').length > 0) {
+        if (ignore === 'richText') {
             form.richText = false;
-        }
-        if(xml.find('[vellum\\:ignore=markdown]').length > 0) {
+        } else if (ignore === 'markdown') {
             form.noMarkdown = true;
         }
         

--- a/src/parser.js
+++ b/src/parser.js
@@ -61,9 +61,11 @@ define([
 
         // TODO set this to vellum.opts().features.rich_text ??
         form.richText = true;
-        if (ignore === 'richText') {
+        ignore = ignore ? ignore.split(" ") : [];
+        if (_.contains(ignore, 'richText')) {
             form.richText = false;
-        } else if (ignore === 'markdown') {
+        }
+        if (_.contains(ignore, 'markdown')) {
             form.noMarkdown = true;
         }
         

--- a/src/parser.js
+++ b/src/parser.js
@@ -164,7 +164,7 @@ define([
         form.formJRM = root.attr("xmlns:jrm");
         form.formUIVersion = root.attr("uiVersion");
         form.formVersion = root.attr("version");
-        form.formName = root.attr("name");
+        form.formName = root.attr("name") || form.formName;
 
         if (!form.formUuid || form.formUuid === "undefined") {
             form.formUuid = "http://openrosa.org/formdesigner/" + util.generate_xmlns_uuid();

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -305,7 +305,7 @@ define([
     };
 
     var richInput = function(mug, options) {
-        if (mug.supportsRichText()) {
+        if (mug.form.richText) {
             options.singleLine = true;
             return richText(mug, options);
         } else {
@@ -314,7 +314,7 @@ define([
     };
 
     var richTextarea = function(mug, options) {
-        if (mug.supportsRichText()) {
+        if (mug.form.richText) {
             options.singleLine = false;
             return richText(mug, options);
         } else {
@@ -436,7 +436,7 @@ define([
 
         atwho.autocomplete(widget.input, mug, {
             property: options.path,
-            useRichText: mug.supportsRichText()
+            useRichText: mug.form.richText,
         });
 
         widget.hasLogicReferences = true;

--- a/src/writer.js
+++ b/src/writer.js
@@ -93,16 +93,15 @@ define([
         xmlWriter.writeAttributeString( "xmlns:xsd", "http://www.w3.org/2001/XMLSchema" );
         xmlWriter.writeAttributeString( "xmlns:jr", "http://openrosa.org/javarosa" );
         xmlWriter.writeAttributeString( "xmlns:vellum", "http://commcarehq.org/xforms/vellum" );
-        // TODO <html vellum:ignore="..."> is used to ignore both markdown
-        // and rich text, which means only one or the other can be ignored.
-        // Should it be changed so they can both be ignored at the same time?
-        // todo: remove writeIgnoreRichText once bubbles is released
-        // Here for future compatibility
+        var ignore = [];
         if (form.writeIgnoreRichText && !form.richText) {
-            xmlWriter.writeAttributeString("vellum:ignore", 'richText');
+            ignore.push('richText');
         }
         if (form.noMarkdown) {
-            xmlWriter.writeAttributeString("vellum:ignore", 'markdown');
+            ignore.push('markdown');
+        }
+        if (ignore.length) {
+            xmlWriter.writeAttributeString("vellum:ignore", ignore.join(" "));
         }
     }
 

--- a/src/writer.js
+++ b/src/writer.js
@@ -94,7 +94,7 @@ define([
         xmlWriter.writeAttributeString( "xmlns:jr", "http://openrosa.org/javarosa" );
         xmlWriter.writeAttributeString( "xmlns:vellum", "http://commcarehq.org/xforms/vellum" );
         var ignore = [];
-        if (form.writeIgnoreRichText && !form.richText) {
+        if (form.mayDisableRichText && !form.richText) {
             ignore.push('richText');
         }
         if (form.noMarkdown) {

--- a/src/writer.js
+++ b/src/writer.js
@@ -93,6 +93,9 @@ define([
         xmlWriter.writeAttributeString( "xmlns:xsd", "http://www.w3.org/2001/XMLSchema" );
         xmlWriter.writeAttributeString( "xmlns:jr", "http://openrosa.org/javarosa" );
         xmlWriter.writeAttributeString( "xmlns:vellum", "http://commcarehq.org/xforms/vellum" );
+        // TODO <html vellum:ignore="..."> is used to ignore both markdown
+        // and rich text, which means only one or the other can be ignored.
+        // Should it be changed so they can both be ignored at the same time?
         // todo: remove writeIgnoreRichText once bubbles is released
         // Here for future compatibility
         if (form.writeIgnoreRichText && !form.richText) {

--- a/tests/escapedHashtags.js
+++ b/tests/escapedHashtags.js
@@ -105,8 +105,7 @@ define([
             util.loadXML(INVALID_XPATH_XML);
             var text = util.getMug('text'),
                 hidden = util.getMug('hidden');
-            // TODO fix this - should read non-vellum: attrs when rich text is disabled
-            assert.strictEqual(text.p.relevantAttr, '#invalid/xpath (`#form/hidden`');
+            assert.strictEqual(text.p.relevantAttr, '(/data/hidden');
             assert.strictEqual(hidden.p.calculateAttr, '#form/text');
         });
     });

--- a/tests/logic.js
+++ b/tests/logic.js
@@ -154,6 +154,10 @@ define([
         });
 
         describe("sends case references to HQ", function () {
+            before(function (done) {
+                util.init({core: {onReady: function () { done(); }}});
+            });
+
             it("should be the correct format", function() {
                 var form = util.loadXML(MOTHER_REF_XML),
                     manager = form._logicManager;

--- a/tests/static/form/name-template.xml
+++ b/tests/static/form/name-template.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<%=title%>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/E5EA8911-36D1-418B-99DE-9DA98BB0F333" uiVersion="1" version="1" <%=dataName%> />
+			</instance>
+			<itext>
+				<translation lang="en" default="" />
+			</itext>
+		</model>
+	</h:head>
+	<h:body />
+</h:html>

--- a/tests/static/writer/ignore-richtext-and-markdown.xml
+++ b/tests/static/writer/ignore-richtext-and-markdown.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum" vellum:ignore="richText markdown">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/145B4E0A-2CE5-48A2-B0E0-8D1585CFCA47" uiVersion="1" version="1" name="Untitled Form" />
+			</instance>
+			<itext>
+				<translation lang="en" default=""/>
+				<translation lang="hin"/>
+			</itext>
+		</model>
+	</h:head>
+	<h:body />
+</h:html>

--- a/tests/writer.js
+++ b/tests/writer.js
@@ -2,6 +2,7 @@ define([
     'chai',
     'jquery',
     'tests/utils',
+    'text!static/writer/ignore-richtext-and-markdown.xml',
     'text!static/writer/repeat-without-count.xml',
     'text!static/writer/repeat-noAddRemove-false.xml',
     'text!static/writer/repeat-with-count.xml',
@@ -11,13 +12,14 @@ define([
     chai,
     $,
     util,
+    INGORE_RICHTEXT_AND_MARKDWON,
     REPEAT_WITHOUT_COUNT_XML,
     REPEAT_NO_ADD_REMOVE_FALSE_XML,
     REPEAT_WITH_COUNT_XML,
     REPEAT_WITH_COUNT_NO_ADD_REMOVE_FALSE_XML,
     REPEAT_WITH_COUNT_AS_QUESTION_XML
 ) {
-    //var assert = chai.assert;
+    var assert = chai.assert;
 
     describe("The XML writer", function () {
         beforeEach(function (done) {
@@ -85,6 +87,17 @@ define([
             util.assertXmlEqual(
                 util.call("createXML"),
                 REPEAT_WITH_COUNT_AS_QUESTION_XML,
+                {normalize_xmlns: true}
+            );
+        });
+
+        it("should be able to ignore both richText and markdown", function () {
+            var form = util.loadXML(INGORE_RICHTEXT_AND_MARKDWON);
+            assert(!form.richText, "richText should be disabled");
+            assert(form.noMarkdown, "markdown should be disabled");
+            util.assertXmlEqual(
+                util.call("createXML"),
+                INGORE_RICHTEXT_AND_MARKDWON,
                 {normalize_xmlns: true}
             );
         });


### PR DESCRIPTION
This is mostly refactoring and a few new tests and minor bug fixes. Makes it easier for me to reason about where rich text gets enabled/disabled. The biggest change is that vellum now ignores `vellum:attr="..."` attributes when rich text is disabled. 

Review commits individually 🐠 the messages are descriptive.

@emord @orangejenny 