### PR TITLE
jstree 3.3.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
         "fuse.js": "~2.5.0",
 
         "bootstrap": "3.3.7",
-        "jstree": "~3.3.2",
+        "jstree": "~3.3.3",
         "langcodes": "dimagi/langcodes",
         "XMLWriter": "dimagi/XMLWriter#master",
         "MediaUploader": "dimagi/MediaUploader#master",


### PR DESCRIPTION
keeping it up to date

markdown-it has a new version out as well, but I'm not confident in one of the changes in 8.0.0. Need to test it out to see the differences in form builder before upgrading it

@esoergel 