### PR TITLE
Contextual title for expression editor

### DIFF
--- a/src/templates/xpath.html
+++ b/src/templates/xpath.html
@@ -2,14 +2,14 @@
 
     <fieldset class="xpath-advanced hide">
         <legend> 
-            <i class="fa fa-cog"></i> Edit Expression (Advanced)
+            <i class="fa fa-cog"></i> Edit <span class='property-name'>Expression</span> (Advanced)
             <button type="button" class="btn btn-default fd-xpath-show-simple-button pull-right xpath-mode-toggle">
                 Show Simple Mode
             </button>
         </legend>
         <div class="alert alert-info xpath-advanced-notice hide">
             <i class="fa fa-info-circle"></i>
-            You are currently in Advanced Mode because your logic is too complicated for the Expression Editor.
+            You are currently in Advanced Mode because your logic is too complicated for Simple Mode.
         </div>
         <div class="form-group">
             <label class="control-label col-sm-2">
@@ -31,7 +31,7 @@
 
     <fieldset class="xpath-simple hide fieldset-condensed">
         <legend>
-            Edit Expression
+            Edit <span class='property-name'>Expression</span>
             <button type="button" class="btn btn-default pull-right xpath-mode-toggle fd-xpath-show-advanced-button">
                 <i class="fa fa-cog"></i> Show Advanced Mode
             </button>

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -421,7 +421,10 @@ define([
                     leftAutocompleteChoices: autocompleteChoices,
                     value: super_getValue(),
                     xpathType: widget.definition.xpathType,
-                    onLoad: function ($ui) { setWidget($ui, widget); },
+                    onLoad: function ($ui) {
+                        setWidget($ui, widget);
+                        $ui.find(".property-name").text(options.lstring || "Expression");
+                    },
                     done: function (val) {
                         if (val !== false) {
                             super_setValue(val);


### PR DESCRIPTION
@emord 

I'd expected to do this by tweaking a template, and then learned that the expression editor has a generic outer template, and making it question-specific looked like a bear.

<img width="724" alt="screen shot 2016-11-11 at 3 55 13 pm" src="https://cloud.githubusercontent.com/assets/1486591/20229980/734cf27c-a827-11e6-9488-b15fa34c2a22.png">
