### PR TITLE
Use parent path if current path isn't real

### DIFF
--- a/src/logic.js
+++ b/src/logic.js
@@ -528,8 +528,12 @@ define([
                 _.each(refsToUsedMug, function (refs, usedInMugUfid) {
                     _.each(refs, function (ref) {
                         var usedInMug = form.getMugByUFID(usedInMugUfid),
+                            usedInMugPath = usedInMug.hashtagPath,
                             readablePropName = usedInMug.spec[ref.property].lstring;
-                        mugReferences[usedInMug.hashtagPath] = readablePropName;
+                        if (!usedInMugPath) {
+                            usedInMugPath = usedInMug.parentMug.hashtagPath;
+                        }
+                        mugReferences[usedInMugPath] = readablePropName;
                     });
                 });
                 tableData[usedMug.hashtagPath] = mugReferences;

--- a/tests/itemset.js
+++ b/tests/itemset.js
@@ -165,6 +165,17 @@ define([
             util.assertXmlEqual(call('createXML'), ITEMSET_WITH_QUESTION_REF_XML, {normalize_xmlns: true});
         });
 
+        it("should include filter usage in logic manager", function () {
+            var form = util.loadXML(ITEMSET_WITH_QUESTION_REF_XML);
+            assert.deepEqual(form.findUsages(),
+                {
+                    "#form/state": {
+                        "#form/district": "Filter"
+                    }
+                }
+            );
+        });
+
         describe("without access to lookup tables", function() {
             before(function (done) {
                 util.init({


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?241382

The nodes in the tree and question nodes in xml are not 1:1, so if that's the case use the parent path. I think we've done this before, but I can't remember/find where it's been done before, seems like something that could be pushed to the mug if it gets done a lot though

buddy @esoergel 