### PR TITLE
Associate question ID help with question ID instead of section

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2002,9 +2002,7 @@ define([
                 properties: this.getMainProperties(),
                 help: {
                     title: "Basic",
-                    text: "<p>The <strong>Question ID</strong> is an internal identifier for a question. " +
-                        "It does not appear on the phone. It is the name of the question in data exports.</p>" +
-                        "<p>The <strong>Label</strong> is text that appears in the application. " +
+                    text: "<p>The <strong>Label</strong> is text that appears in the application. " +
                         "This text will not appear in data exports.</p> ",
                     link: "https://confluence.dimagi.com/display/commcarepublic/Form+Builder"
                 }

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -800,6 +800,8 @@ define([
                     mug.p.nodeID = value;
                 },
                 widget: widgets.identifier,
+                help: "The <strong>Question ID</strong> is an internal identifier for a question. " +
+                      "It does not appear on the phone. It is the name of the question in data exports.",
                 validationFunc: function (mug) {
                     var caseWarning = {
                             key: "mug-nodeID-case-warning",


### PR DESCRIPTION
@emord 

Left the label help at the section level, rather than have it repeated for every language.