### PR TITLE
Fix print question type template collision

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2247,7 +2247,7 @@ define([
 
     fn.contributeToHeadXML = function (xmlWriter, form) {}; 
 
-    fn.initWidget = function (widget) {};
+    fn.initMediaUploaderWidget = function (widget) {};
 
     fn.destroy = function () {};
 

--- a/src/intentManager.js
+++ b/src/intentManager.js
@@ -61,8 +61,8 @@ define([
         return widget;
     }
 
-    function mediaWidget(mug, options) {
-        var widget = widgets.media(mug, options);
+    function printTemplateWidget(mug, options) {
+        var widget = widgets.abstractMediaWidget(mug, options);
         widget.getBaseMediaPath = function () {
             return "jr://file/commcare/text/" + mug.p.nodeID;
         };
@@ -312,7 +312,7 @@ define([
             docTemplate: {
                 lstring: 'Document Template',
                 visibility: 'visible',
-                widget: mediaWidget,
+                widget: printTemplateWidget,
             },
             androidIntentAppId: { visibility: 'hidden' },
         }

--- a/src/intentManager.js
+++ b/src/intentManager.js
@@ -151,7 +151,7 @@ define([
     }
 
     function syncMugWithIntent (tags, mug) {
-        // called when initializing a mug from a parsed form
+        // called when initializing a new mug or when parsing a form
         if (mug.__className === "AndroidIntent" ||
             mug.__className === "PrintIntent") {
             var nodeID = mug.p.nodeID,

--- a/src/intentManager.js
+++ b/src/intentManager.js
@@ -61,6 +61,14 @@ define([
         return widget;
     }
 
+    function mediaWidget(mug, options) {
+        var widget = widgets.media(mug, options);
+        widget.getBaseMediaPath = function () {
+            return "jr://file/commcare/text/" + mug.p.nodeID;
+        };
+        return widget;
+    }
+
     var parseInnerTags = function (tagObj, innerTag) {
         var store = {};
         _.each(tagObj.find(innerTag), function (inner) {
@@ -176,8 +184,6 @@ define([
             if (mug.p.androidIntentExtra['cc:print_template_reference']) {
                 mug.p.docTemplate = mug.p.androidIntentExtra['cc:print_template_reference'].replace(/^'|'$/g, '');
                 delete mug.p.androidIntentExtra['cc:print_template_reference'];
-            } else {
-                mug.p.docTemplate = "jr://file/commcare/text/" + mug.p.nodeID+ ".html";
             }
         }
     }
@@ -306,7 +312,7 @@ define([
             docTemplate: {
                 lstring: 'Document Template',
                 visibility: 'visible',
-                widget: widgets.media,
+                widget: mediaWidget,
             },
             androidIntentAppId: { visibility: 'hidden' },
         }

--- a/src/javaRosa/itextWidget.js
+++ b/src/javaRosa/itextWidget.js
@@ -478,7 +478,7 @@ define([
                 return null;
             };
 
-            widget.mug.form.vellum.initWidget(widget);
+            widget.mug.form.vellum.initMediaUploaderWidget(widget);
 
             return widget;
         };

--- a/src/javaRosa/itextWidget.js
+++ b/src/javaRosa/itextWidget.js
@@ -472,11 +472,15 @@ define([
                     // image: jr://file/commcare/image/form_id/question_id.png
                     // audio: jr://file/commcare/audio/form_id/question_id.mp3
                     var extension = DEFAULT_EXTENSIONS[form];
-                    return "jr://file/commcare/" + form + url_type +
-                           jrUtil.getDefaultItextRoot(widget.mug) + "." + extension;
+                    return widget.getBaseMediaPath() + "." + extension;
                 }
                 return null;
             };
+
+            widget.getBaseMediaPath = function () {
+                return "jr://file/commcare/" + form + url_type +
+                       jrUtil.getDefaultItextRoot(widget.mug);
+            }
 
             widget.mug.form.vellum.initMediaUploaderWidget(widget);
 

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -135,15 +135,7 @@ define([
             widget.form, objectMap, uploadControls);
 
         if (!widget.getBaseMediaPath) {
-            /**
-             * Get media path without file type extension
-             *
-             * Example: jr://file/commcare/text/name
-             */
-            widget.getBaseMediaPath = function () {
-                throw new Error("abstract method not implemented: " +
-                                "widget.getBaseMediaPath()");
-            };
+            throw new Error("required method not found: widget.getBaseMediaPath()");
         }
 
         widget.getRandomizedMediaPath = function (oldPath) {

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -64,21 +64,21 @@ define([
             }
         ],
     },
-        PREVIEW_TEMPLATES = {
+    PREVIEW_TEMPLATES = {
         image: multimedia_existing_image,
         audio: multimedia_existing_audio,
         video: multimedia_existing_video,
         'video-inline': multimedia_existing_video,
         text:  multimedia_existing_text,
     },
-        SLUG_TO_CLASS = {
+    SLUG_TO_CLASS = {
         image: 'CommCareImage',
         audio: 'CommCareAudio',
         video: 'CommCareVideo',
         'video-inline': 'CommCareVideo',
         text:  'CommCareMultimedia',
     },
-        SLUG_TO_UPLOADER_SLUG = {
+    SLUG_TO_UPLOADER_SLUG = {
         image: 'fd_hqimage',
         audio: 'fd_hqaudio',
         video: 'fd_hqvideo',
@@ -183,7 +183,7 @@ define([
 
             return $uiElem;
         };
-        
+
         widget.handleUploadComplete = function (event, data, objectMap) {
             if (data.ref && data.ref.path) {
                 var newExtension = '.' + data.ref.path.split('.').pop().toLowerCase(),
@@ -274,7 +274,7 @@ define([
                 return;
             }
 
-            this.data.deferredInit = function () {
+            this.data.uploader.deferredInit = function () {
                 this.data.uploader.uploadControls = {
                     'image': this.initUploadController({
                         uploaderSlug: 'fd_hqimage',
@@ -309,15 +309,15 @@ define([
                 };
             };
         },
-        initWidget: function (widget) {
+        initMediaUploaderWidget: function (widget) {
             this.__callOld();
             if (!this.data.uploader.uploadEnabled) {
                 return;
             }
 
-            var deferredInit = this.data.deferredInit;
+            var deferredInit = this.data.uploader.deferredInit;
             if (deferredInit !== null) {
-                this.data.deferredInit = null;
+                this.data.uploader.deferredInit = null;
                 deferredInit.apply(this);
             }
 
@@ -335,9 +335,9 @@ define([
             // Load the uploader and its dependencies in the background after
             // core dependencies are already loaded, since it's not necessary at
             // page load.
-            // uploadControls is referenced in the initWidget call path, but
-            // never actually used until the upload button is clicked.  We use
-            // an object here as a poor man's promise.
+            // uploadControls is referenced in the initMediaUploaderWidget call
+            // path, but never actually used until the upload button is clicked.
+            // We use an object here as a poor man's promise.
             // Feel free to undo this if it's not worth it.
           
             var uploadController = {value: null};

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -711,7 +711,7 @@ define([
             return widget.input.val(val);
         };
 
-        widget.mug.form.vellum.initWidget(widget);
+        widget.mug.form.vellum.initMediaUploaderWidget(widget);
         return widget;
     };
 

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -699,7 +699,7 @@ define([
         return widget;
     };
 
-    var media = function (mug, options) {
+    var abstractMediaWidget = function (mug, options) {
         var widget = normal(mug, options);
         widget.form = "text";
 
@@ -709,6 +709,18 @@ define([
 
         widget.setValue = function(val) {
             return widget.input.val(val);
+        };
+
+        /**
+         * Get media path without file type extension
+         *
+         * Example: jr://file/commcare/text/name
+         *
+         * This is an abstract method; it must be overridden.
+         */
+        widget.getBaseMediaPath = function () {
+            throw new Error("abstract method not implemented: " +
+                            "widget.getBaseMediaPath()");
         };
 
         widget.mug.form.vellum.initMediaUploaderWidget(widget);
@@ -806,7 +818,7 @@ define([
         xPath: xPath,
         baseKeyValue: baseKeyValue,
         readOnlyControl: readOnlyControl,
-        media: media,
+        abstractMediaWidget: abstractMediaWidget,
         util: {
             getWidget: getWidget,
             setWidget: setWidget,

--- a/tests/intentManager.js
+++ b/tests/intentManager.js
@@ -78,6 +78,19 @@ define([
             util.assertXmlEqual(util.call("createXML"), INTENT_WITH_NO_MUG_XML);
         });
 
+        it("should assign new document template path on upload", function () {
+            util.loadXML("");
+            var mug = util.addQuestion("PrintIntent", "print"),
+                media = util.getMediaUploader($(".fd-mm-upload-trigger")),
+                pathPattern = /jr:\/\/file\/commcare\/text\/print-\w+\.html/;
+            media.upload("temp.html");
+            var temp = mug.p.docTemplate;
+            assert.match(temp, pathPattern);
+            media.upload("file.html");
+            assert.match(mug.p.docTemplate, pathPattern);
+            assert.notEqual(mug.p.docTemplate, temp, "new upload should create a new path");
+        });
+
         describe("with multiple response pairs with matching keys", function () {
             var mug, xml, $xml;
             before(function () {

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -70,6 +70,20 @@ define([
             });
         });
 
+        it("should assign new media path on media upload", function () {
+            util.loadXML("");
+            var itext = util.addQuestion("Text", "text").p.labelItext,
+                pattern = /jr:\/\/file\/commcare\/image\/data\/text-\w+\.gif/;
+            $(".itext-block-label-add-form-image").click();
+            var media = util.getMediaUploader($(".fd-mm-upload-trigger:first"));
+            media.upload("old.gif");
+            var old = itext.get("image");
+            assert.match(old, pattern);
+            media.upload("new.gif");
+            assert.match(itext.get("image"), pattern);
+            assert.notEqual(itext.get("image"), old, "new upload should create a new path");
+        });
+
         describe("and non default language is first", function () {
             before(function (done) {
                 util.init({


### PR DESCRIPTION
Fixes:
- http://manage.dimagi.com/default.asp?229441
- http://manage.dimagi.com/default.asp?220337

This implements most of the items in the [proposed solution](http://manage.dimagi.com/default.asp?229441#BugEvent.1172875). Things not implemented:

- Itext MM paths are still assigned prior to upload, although the path changes each time a new file is uploaded.
- The button for uploading new MM content still changes its title as it did before.
- The new *Replace ... for all linked questions* button is not implemented.

Once this is merged each multimedia upload done in the form builder will create a unique new `jr://commcare/...` path, which means that the media map for a given app could grow to be larger than it would have previously if many media items are uploaded and then re-uploaded later. In other words, I think older abandoned media items will still be present in the media map because HQ does not clear them out if they are no longer referenced (except when uploading the app to the Exchange, I think). @dimagi/team-commcare-hq will this cause problems in HQ (I think not)? @ctsims will it cause problems on mobile?

Review commits individually 🐠 

@orangejenny or @emord 