### PR TITLE
Don't error for #case refs

### DIFF
--- a/src/logic.js
+++ b/src/logic.js
@@ -517,7 +517,7 @@ define([
             var _this = this,
                 form = _this.form,
                 tableData = {},
-                formRefs = _this.reverse;
+                formRefs = _.omit(_this.reverse, CASE_REF_ID);
 
             _.each(formRefs, function (refsToUsedMug, usedMugUfid) {
                 var usedMug = form.getMugByUFID(usedMugUfid),

--- a/tests/logic.js
+++ b/tests/logic.js
@@ -29,7 +29,7 @@ define([
         before(function (done) {
             util.init({
                 core: {onReady: function () { done(); }},
-                features: {rich_text: false},
+                features: {rich_text: true},
             });
         });
 
@@ -37,7 +37,7 @@ define([
             util.loadXML(TEST_XML_1);
             util.getMug("question1").p.nodeID = 'question';
             var mug = util.getMug("/data/question2");
-            assert.equal(mug.p.relevantAttr, "#form/question = 1");
+            assert.equal(mug.p.relevantAttr, "#form/question = #case/dob");
         });
 
         it("should not update expressions for model iteration", function () {
@@ -51,16 +51,25 @@ define([
             assert(util.isTreeNodeValid(repeat), "repeat should be valid");
         });
 
-        it("should remove references for labels after removal", function () {
-            var form = util.loadXML(""),
-                logicManager = form._logicManager,
-                text;
-            util.addQuestion('Text', 'mug');
-            text = util.addQuestion('Text', 'text');
-            $('[name=itext-en-label]').val('<output value="/data/mug" />').change();
-            assert.equal(logicManager.forward[text.ufid].labelItext.length, 1);
-            util.deleteQuestion('/data/text');
-            assert.deepEqual(logicManager.forward[text.ufid], {});
+        describe("without rich text", function () {
+            before(function (done) {
+                util.init({
+                    core: {onReady: function () { done(); }},
+                    features: {rich_text: false},
+                });
+            });
+
+            it("should remove references for labels after removal", function () {
+                var form = util.loadXML(""),
+                    logicManager = form._logicManager,
+                    text;
+                util.addQuestion('Text', 'mug');
+                text = util.addQuestion('Text', 'text');
+                $('[name=itext-en-label]').val('<output value="/data/mug" />').change();
+                assert.equal(logicManager.forward[text.ufid].labelItext.length, 1);
+                util.deleteQuestion('/data/text');
+                assert.deepEqual(logicManager.forward[text.ufid], {});
+            });
         });
 
         describe("should add validation error for", function () {

--- a/tests/static/logic/test-xml-1.xml
+++ b/tests/static/logic/test-xml-1.xml
@@ -11,7 +11,7 @@
 				</data>
 			</instance>
 			<bind vellum:nodeset="#form/question1" nodeset="/data/question1" type="xsd:string" />
-			<bind vellum:nodeset="#form/question2" nodeset="/data/question2" type="xsd:string" vellum:relevant="#form/question1 = 1" relevant="/data/question1 = 1" />
+			<bind vellum:nodeset="#form/question2" nodeset="/data/question2" type="xsd:string" vellum:relevant="#form/question1 = #case/dob" relevant="/data/question1 = instance('casedb')/cases/case[@case_id = instance('commcaresession')/session/data/case_id]/dob" />
 			<bind vellum:nodeset="#form/question3" nodeset="/data/question3" type="xsd:string" vellum:relevant="#form/question2 = #form/question1" relevant="/data/question2 = /data/question1" />
 			<itext>
 				<translation lang="en" default="">


### PR DESCRIPTION
Right now all case references are stored under `#case/` in `this.reverse`. the full path is stored inside the reference but it will take a slightly larger refactor to get that to work.

Probably not obvious but it's tested as there are functions later that test that it is not returned by `findUsages`

@dannyroberts @proteusvacuum 