### PR TITLE
Fix CKEditor skipping many spaces

### DIFF
--- a/src/less-style/inputs.less
+++ b/src/less-style/inputs.less
@@ -44,7 +44,7 @@
     height: 4.5em;
     overflow: auto;
     resize: both;
-    white-space: pre-wrap;
+    white-space: normal;
     word-break: break-word;
 
     &.fd-xpath-editor-text {


### PR DESCRIPTION
Took a long time to track this down. `pre-wrap` caused a string of normal spaces (char 32), rather than alternating space/`$nbsp;`, to be entered (at least in Chrome), which was a problem because normal spaces are skipped by CKEditor when navigating toward a widget with arrow keys or backspace/del.

This fix was tested in Firefox and Chrome.

@emord 