### PR TITLE
User properties

### DIFF
--- a/src/atwho.js
+++ b/src/atwho.js
@@ -197,10 +197,10 @@ define([
                 afterMatchFailed: function(at, $el) {
                     if (options.useRichText && $el.html()) {
                         // If user typed out a full legitimate hashtag, or something that isn't
-                        // legit but looks vaguely like a case property, turn it into a bubble.
+                        // legit but looks like a valid hashtag reference, turn it into a bubble.
                         var content = $el.html().trim().replace(/^.*\s/, ""),
-                            isUnknownHashtag = richText.REF_REGEX.test(content) && !form.isValidHashtagPrefix(content),
-                            shouldBubble = form.isValidHashtag(content) || isUnknownHashtag;
+                            shouldBubble = form.isValidHashtag(content) ||
+                                           form.hasValidHashtagPrefix(content);
 
                         if (shouldBubble) {
                             options.functionOverrides.insert.call(this, content);

--- a/src/atwho.js
+++ b/src/atwho.js
@@ -185,12 +185,7 @@ define([
                     });
                 },
                 beforeInsert: function(value, $li) {
-                    var category;
-                    if (util.isCaseReference(value)) {
-                        category = "Case Reference";
-                    } else {
-                        category = "Form Reference";
-                    }
+                    var category = util.getReferenceName(value);
                     analytics.usage(category, "Autocomplete", options.property);
                     return value;
                 },

--- a/src/core.js
+++ b/src/core.js
@@ -850,7 +850,8 @@ define([
                 target.val(target.val() + path).change();
             }
 
-            var targetType, category;
+            var targetType,
+                category = util.getReferenceName(path);
             switch (target[0].id) {
                 case 'property-relevantAttr':
                     targetType = "Display";
@@ -864,11 +865,6 @@ define([
                 default:
                     targetType = "Expression Editor";
                     break;
-            }
-            if (_this.data.core.form.isCaseReference(path)) {
-                category = "Case Reference";
-            } else {
-                category = "Form Reference";
             }
             analytics.usage(category, "Drag and Drop", targetType);
         }

--- a/src/databrowser.js
+++ b/src/databrowser.js
@@ -138,11 +138,14 @@ define([
         }
         function handleDrop(node, info, target) {
             var widget = widgets.util.getWidget(target, vellum),
-                path = widget.mug.form.richText ? node.hashtag : node.xpath;
+                path = widget.mug.form.richText ? node.hashtag : node.xpath,
+                id;
             while (info) {
-                var id = widget.addInstanceRef({id: info.id, src: info.uri});
-                if (id !== info.id) {
-                    path = widget.mug.form.updateInstanceQuery(path, id, info.id);
+                if (info.id && info.uri) {
+                    id = widget.addInstanceRef({id: info.id, src: info.uri});
+                    if (id !== info.id) {
+                        path = widget.mug.form.updateInstanceQuery(path, id, info.id);
+                    }
                 }
                 info = info._parent;
             }

--- a/src/datasources.js
+++ b/src/datasources.js
@@ -26,6 +26,11 @@
  *                      hashtag: string (optional hashtag prefix)
  *                      source: string (optional data source id, defaults to this data source)
  *                      subset: string (optional subset id)
+ *                      subset_key: string (optional subset key, if omitted then
+ *                                  the first subset with an `id` matching
+ *                                  this reference's `subset` will be used)
+ *                      subset_filter: boolean (optional, if true include
+ *                                     subset filter in xpath expression)
  *                      key: string (referenced property)
  *                  }
  *              },
@@ -281,14 +286,18 @@ define([
                             info.hashtag = '#case/' + ref.subset;
                         }
                     }
-                    path = "instance('" + source.id + "')" + source.path +
-                           "[" + ref.key + " = " + path + "]";
+                    var keyPath = path;
+                    path = "instance('" + source.id + "')" + source.path;
+                    if (ref.subset_filter && ref.subset_key && ref.subset) {
+                        path += "[" + ref.subset_key + " = '" + ref.subset + "']";
+                    }
+                    path += "[" + ref.key + " = " + keyPath + "]";
                     if (source.subsets && ref.subset) {
-                        // magic: match key: "@case_type"
-                        source = _.findWhere(
-                            source.subsets,
-                            {id: ref.subset, key: "@case_type"}
-                        ) || source;
+                        var where = {id: ref.subset};
+                        if (ref.subset_key) {
+                            where.key = ref.subset_key;
+                        }
+                        source = _.findWhere(source.subsets, where) || source;
                     }
                     var name = source.name || source.id;
                     if (name) {

--- a/src/datasources.js
+++ b/src/datasources.js
@@ -19,7 +19,7 @@
  *                  structure: {
  *                      inner-element: { }
  *                  }
- *                  name: "Element" (the text used in dropdown for this element)
+ *                  name: "Element" (the text used to represent this element)
  *              },
  *              ref-element: {
  *                  reference: {
@@ -27,6 +27,13 @@
  *                      subset: string (optional subset id)
  *                      key: string (referenced property)
  *                  }
+ *              },
+ *              path-element: {
+ *                  merge: true (optional flag. When set, the element name
+ *                               will be appended to the path used to construct
+ *                               children and any children will be merged with
+ *                               this elements siblings.)
+ *                  structure: { ... }
  *              },
  *              @attribute: { }
  *          },
@@ -300,7 +307,14 @@ define([
         }
         function getNodes(source, path, info) {
             var nodes = _.chain(source && source.structure)
-                .map(node(source, path, info))
+                .map(function (item, id) {
+                    if (item.merge) {
+                        return getNodes(item, path + "/" + id, {_parent: info});
+                    } else {
+                        return node(source, path, info)(item, id);
+                    }
+                })
+                .flatten()
                 .compact() // TODO remove with invalidCaseProperties
                 .sortBy("text")
                 .value();

--- a/src/form.js
+++ b/src/form.js
@@ -261,7 +261,7 @@ define([
             return this._logicManager.knownExternalReferences();
         },
         referenceHashtag: function(hashtag, mug, property) {
-            if (/^#case\//.test(hashtag.toHashtag())) {
+            if (this.hasValidHashtagPrefix(hashtag)) {
                 this.referenceInstance('casedb', mug, property);
                 this.referenceInstance('commcaresession', mug, property);
             }

--- a/src/form.js
+++ b/src/form.js
@@ -214,10 +214,10 @@ define([
          * Check if tag has a valid hashtag prefix
          *
          * A valid hashtag prefix ends with a slash, and the given value must
-         * contain at least one character after the slash.
+         * contain at least one character after the slash. This does a raw
+         * string analysis, it does not convert xpath expressions to hashtags.
          */
         hasValidHashtagPrefix: function(tag) {
-            tag = this.normalizeHashtag(tag);
             var lastSlashIndex = tag.lastIndexOf("/");
             return lastSlashIndex !== -1 &&
                 tag.length > lastSlashIndex + 1 &&

--- a/src/form.js
+++ b/src/form.js
@@ -210,12 +210,18 @@ define([
             tag = this.normalizeHashtag(tag);
             return this.hashtagTransformations.hasOwnProperty(tag);
         },
+        /**
+         * Check if tag has a valid hashtag prefix
+         *
+         * A valid hashtag prefix ends with a slash, and the given value must
+         * contain at least one character after the slash.
+         */
         hasValidHashtagPrefix: function(tag) {
             tag = this.normalizeHashtag(tag);
             var lastSlashIndex = tag.lastIndexOf("/");
             return lastSlashIndex !== -1 &&
-                this.hashtagTransformations.hasOwnProperty(tag.substring(0, lastSlashIndex + 1)) &&
-                tag.substring(lastSlashIndex + 1) !== "";
+                tag.length > lastSlashIndex + 1 &&
+                this.hashtagTransformations.hasOwnProperty(tag.substring(0, lastSlashIndex + 1));
         },
         addHashtag: function(hashtag, xpath) {
             this.hashtagMap[hashtag] = xpath;

--- a/src/form.js
+++ b/src/form.js
@@ -108,7 +108,8 @@ define([
         }
         return that;
     };
-    var INSTANCE_REGEXP = /(^)instance\((['"])([^'"]+)\2\)/i;
+    var INSTANCE_REGEXP = /(^)instance\((['"])([^'"]+)\2\)/i,
+        HASHTAG_NAMESPACE = /^#([^\/]+)/;
 
     function Form (opts, vellum, mugTypes) {
         var _this = this;
@@ -182,7 +183,7 @@ define([
                 form.hashtagTransformations = vellum.datasources.getHashtagTransforms({});
                 form.hasCaseHashtags = vellum.datasources.isReady();
                 _.each(form.hashtagTransformations, function (x, prefix) {
-                    form.hashtagNamespaces[/^#([^\/]+)/.exec(prefix)[1]] = true;
+                    form.hashtagNamespaces[HASHTAG_NAMESPACE.exec(prefix)[1]] = true;
                 });
             } else {
                 form.hashtagMap = {};

--- a/src/form.js
+++ b/src/form.js
@@ -1144,9 +1144,6 @@ define([
             this.undomanager.undo();
             this.vellum.selectSomethingOrHideProperties();
         },
-        isCaseReference: function (path) {
-            return /^#case/.test(path);
-        },
         findUsages: function (path) {
             return this._logicManager.findUsages(path);
         },

--- a/src/form.js
+++ b/src/form.js
@@ -174,12 +174,16 @@ define([
             var form = this,
                 vellum = form.vellum,
                 oldHashtags = form.hashtagMap;
+            form.hashtagNamespaces = {form: true};
             if (form.richText) {
                 // TODO always load hashtags, even when rich text is disabled
                 form.hashtagMap = _.clone(vellum.datasources.getHashtagMap({}));
                 form.invertedHashtagMap = _.invert(form.hashtagMap);
                 form.hashtagTransformations = vellum.datasources.getHashtagTransforms({});
                 form.hasCaseHashtags = vellum.datasources.isReady();
+                _.each(form.hashtagTransformations, function (x, prefix) {
+                    form.hashtagNamespaces[/^#([^\/]+)/.exec(prefix)[1]] = true;
+                });
             } else {
                 form.hashtagMap = {};
                 form.invertedHashtagMap = {};
@@ -230,6 +234,7 @@ define([
         initHashtag: function(hashtag, xpath) {
             if (!this.hashtagMap[hashtag]) {
                 this.addHashtag(hashtag, xpath);
+                this.hashtagNamespaces[/^#([^\/]+)/.exec(hashtag)[1]] = true;
             }
         },
         removeHashtag: function(hashtag) {

--- a/src/javaRosa/plugin.js
+++ b/src/javaRosa/plugin.js
@@ -80,12 +80,7 @@ define([
                 } else {
                     jrUtil.insertOutputRef(_this, target, path, mug);
                 }
-                var category;
-                if (_this.data.core.form.isCaseReference(path)) {
-                    category = "Case Reference";
-                } else {
-                    category = "Form Reference";
-                }
+                var category = util.getReferenceName(path);
                 analytics.usage(category, "Drag and Drop", "Label");
             } else {
                 _this.__callOld();

--- a/src/logic.js
+++ b/src/logic.js
@@ -260,7 +260,7 @@ define([
                     pathString = isHashtag ? xpath : xobj.pathWithoutPredicates(),
                     pathWithoutRoot = isHashtag ? '' : pathString.substring(1 + pathString.indexOf('/', 1)),
                     refMug = form.getMugByPath(pathString),
-                    isHashRef = form.hasValidHashtagPrefix(pathString),
+                    isHashRef = form.hasValidHashtagPrefix(xpath),
                     knownHashtag = isHashRef && form.isValidHashtag(xpath);
 
                 // last part is hack to allow root node in data parents

--- a/src/richText.js
+++ b/src/richText.js
@@ -61,9 +61,7 @@ define([
     analytics,
     CKEDITOR
 ){
-    var CASE_REF_REGEX = /^#case\//,
-        FORM_REF_REGEX = /^#form\//,
-        REF_REGEX = /^#(form|case)\//,
+    var FORM_REF_REGEX = /^#form\//,
         INVALID_PREFIX = "#invalid/xpath ",
         // http://stackoverflow.com/a/16459606/10840
         bubbleWidgetDefinition = {
@@ -424,12 +422,12 @@ define([
      */
     function makeBubble(form, xpath) {
         function _parseXPath(xpath, form) {
-            if (CASE_REF_REGEX.test(xpath)) {
+            if (!FORM_REF_REGEX.test(xpath)) {
                 if (form.isValidHashtag(xpath)) {
                     return {
                         classes: ['label-datanode-external', 'fcc fcc-fd-case-property']
                     };
-                } else if (form.hasValidHashtagPrefix(xpath)) {
+                } else if (form.hasValidHashtagPrefix(form.normalizeHashtag(xpath))) {
                     return {
                         classes: ['label-datanode-external-unknown', 'fa fa-exclamation-triangle']
                     };
@@ -463,7 +461,7 @@ define([
         var info = extractXPathInfo($(output)),
             xpath = form.normalizeHashtag(info.value),
             attrs = _.omit(info, 'value'),
-            startsWithRef = REF_REGEX.test(xpath),
+            startsWithRef = FORM_REF_REGEX.test(xpath) || form.hasValidHashtagPrefix(xpath),
             containsWhitespace = /\s/.test(xpath);
 
         if (!startsWithRef || (startsWithRef && containsWhitespace)) {
@@ -784,7 +782,6 @@ define([
     }
 
     return {
-        REF_REGEX: REF_REGEX,
         applyFormats: applyFormats,
         bubbleOutputs: bubbleOutputs,
         editor: editor,

--- a/src/templates/external_sources_tree.html
+++ b/src/templates/external_sources_tree.html
@@ -1,7 +1,7 @@
 <div class="fd-external-sources-container">
     <div class="fd-head fd-head-external-sources">
         <div class="fd-head-max-indicator"><i class="fa fa-arrow-circle-o-down"></i></div>
-        <h2>Case Properties</h2>
+        <h2>App Properties</h2>
     </div>
     <div class="fd-scrollable">
         <div class="fd-external-resource-search">

--- a/src/util.js
+++ b/src/util.js
@@ -363,8 +363,13 @@ define([
         ], lang);
     };
 
-    that.isCaseReference = function (value) {
-        return value.startsWith('#case/');
+    that.getReferenceName = function (value) {
+        var ref = /^#([^\/]+)\//.exec(value);
+        if (!ref) {
+            return "Form Reference";
+        }
+        ref = ref[1][0].toUpperCase() + ref[1].substring(1).toLowerCase();
+        return ref + " Reference";
     };
 
     return that;

--- a/src/xpath.js
+++ b/src/xpath.js
@@ -10,13 +10,14 @@ define([
         //   hashtagMap: {hashtag expression: XPath expression}
         //   invertedHashtagMap: {XPath expression: hashtag expression}
         //   hashtagTransformations: {hashtag prefix: function to return property}
+        //   hashtagNamespaces: {namespace: true}
         // NOTE hashtagInfo is not the same as hashtagConfig passed to
         // `xpath.makeXPathModels(hashtagConfig)`
         makeXPathModels: function (hashtagInfo, configDecorator) {
             configDecorator = configDecorator || function (v) { return v; };
             return xpath.makeXPathModels(configDecorator({
                 isValidNamespace: function (namespace) {
-                    return namespace === 'form' || namespace === 'case';
+                    return hashtagInfo.hashtagNamespaces.hasOwnProperty(namespace);
                 },
                 hashtagToXPath: function (hashtagExpr) {
                     if (hashtagInfo.hashtagMap.hasOwnProperty(hashtagExpr)) {

--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -493,6 +493,7 @@ define([
                             structure: {
                                 case_id: {
                                     reference: {
+                                        hashtag: "#case",
                                         source: "casedb",
                                         subset: "case",
                                         subset_key: "@case_type",

--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -481,5 +481,119 @@ define([
                 assert.equal(getInstanceId(mug.form, casedbUri), "casedb");
             });
         });
+
+        describe("with user properties", function () {
+            var CASE_AND_USER_DATA = [{
+                    id: "commcaresession",
+                    uri: "jr://instance/session",
+                    path: "/session",
+                    name: 'Session',
+                    structure: {
+                        data: {
+                            structure: {
+                                case_id: {
+                                    reference: {
+                                        source: "casedb",
+                                        subset: "case",
+                                        subset_key: "@case_type",
+                                        key: "@case_id",
+                                    },
+                                },
+                            },
+                        },
+                        context: {
+                            structure: {
+                                userid: {
+                                    reference: {
+                                        hashtag: "#user",
+                                        source: "casedb",
+                                        subset: "commcare-user",
+                                        subset_key: "@case_type",
+                                        subset_filter: true,
+                                        key: "hq_user_id",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                }, {
+                    id: "casedb",
+                    uri: "jr://instance/casedb",
+                    path: "/casedb/case",
+                    name: 'Cases',
+                    structure: {
+                        name: {},
+                    },
+                    subsets: [{
+                        id: "case",
+                        name: "child",
+                        key: "@case_type",
+                        structure: {
+                            dob: {},
+                            invalid: {}
+                        },
+                    }, {
+                        id: "commcare-user",
+                        name: "user",
+                        key: "@case_type",
+                        structure: {
+                            code_name: {},
+                            user_role: {},
+                        }
+                    }],
+                }];
+
+            before(function (done) {
+                util.init({
+                    plugins: plugins,
+                    javaRosa: {langs: ['en']},
+                    core: {
+                        dataSourcesEndpoint: function (callback) { callback(CASE_AND_USER_DATA); },
+                        invalidCaseProperties: ['invalid'],
+                        onReady: function () {
+                            databrowser.initDataBrowser(this);
+                            dataTree = this.$f.find(".fd-external-sources-tree").jstree(true);
+                            done();
+                        }
+                    }
+                });
+            });
+
+            it("should drag/drop case property", function (done) {
+                util.loadXML("");
+                var mug = util.addQuestion("DataBindOnly", "mug"),
+                    input = $("[name=property-calculateAttr]"),
+                    editor = input.ckeditor().editor,
+                    widget = util.getWidget('property-calculateAttr');
+                widget.input.promise.then(function () {
+                    editor.on('change', function() {
+                        assert.equal(mug.p.calculateAttr, "#case/dob");
+                        done();
+                    });
+                    assert(!mug.p.calculateAttr, "unexpected: " + mug.p.calculateAttr);
+                    util.findNode(dataTree, "dob").data.handleDrop(input);
+                });
+            });
+
+            it("should drag/drop user property", function (done) {
+                var form = util.loadXML(""),
+                    mug = util.addQuestion("DataBindOnly", "mug"),
+                    input = $("[name=property-calculateAttr]"),
+                    editor = input.ckeditor().editor,
+                    widget = util.getWidget('property-calculateAttr');
+                widget.input.promise.then(function () {
+                    editor.on('change', function() {
+                        assert.equal(mug.p.calculateAttr, "#user/code_name");
+                        assert.equal(form.normalizeXPath("#user/code_name"),
+                            "instance('casedb')/casedb/case[@case_type = 'commcare-user']" +
+                            "[hq_user_id = instance('commcaresession')/session/context/userid]" +
+                            "/code_name");
+                        done();
+                    });
+                    assert(!mug.p.calculateAttr, "unexpected: " + mug.p.calculateAttr);
+                    util.findNode(dataTree, "code_name").data.handleDrop(input);
+                });
+            });
+        });
     });
 });

--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -336,7 +336,10 @@ define([
                                 callback(CASE_DATA);
                             });
                         },
-                        form: "",
+                        // need form with <hashtags> containing a case property
+                        // so the form knows about the #case namespace and shows
+                        // errors for unknown case properties
+                        form: MOTHER_REF_XML,
                         onReady: function () {
                             vellum = this;
                             blue = util.addQuestion("DataBindOnly", "blue");

--- a/tests/databrowser.js
+++ b/tests/databrowser.js
@@ -490,6 +490,7 @@ define([
                     name: 'Session',
                     structure: {
                         data: {
+                            merge: true,
                             structure: {
                                 case_id: {
                                     reference: {
@@ -503,6 +504,7 @@ define([
                             },
                         },
                         context: {
+                            merge: true,
                             structure: {
                                 userid: {
                                     reference: {

--- a/tests/datasources.js
+++ b/tests/datasources.js
@@ -51,6 +51,7 @@ define([
                             reference: {
                                 source: "casedb",
                                 subset: "case",
+                                subset_key: "@case_type",
                                 key: "@case_id",
                             },
                         },
@@ -64,6 +65,8 @@ define([
                                 hashtag: "#user",
                                 source: "casedb",
                                 subset: "commcare-user",
+                                subset_key: "@case_type",
+                                subset_filter: true,
                                 key: "hq_user_id",
                             },
                         },

--- a/tests/datasources.js
+++ b/tests/datasources.js
@@ -49,6 +49,7 @@ define([
                     structure: {
                         "case_id": {
                             reference: {
+                                hashtag: "#case",
                                 source: "casedb",
                                 subset: "case",
                                 subset_key: "@case_type",
@@ -86,7 +87,12 @@ define([
                     dob: {},
                 },
                 related: {
-                    parent: "parent",
+                    parent: {
+                        hashtag: "#case/parent",
+                        subset: "parent",
+                        subset_key: "@case_type",
+                        key: "@case_id",
+                    }
                 },
             }, {
                 id: "parent",
@@ -96,7 +102,12 @@ define([
                     edd: {},
                 },
                 related: {
-                    parent: "grandparent",
+                    parent: {
+                        hashtag: "#case/grandparent",
+                        subset: "grandparent",
+                        subset_key: "@case_type",
+                        key: "@case_id",
+                    },
                 }
             }, {
                 id: "grandparent",

--- a/tests/datasources.js
+++ b/tests/datasources.js
@@ -61,6 +61,7 @@ define([
                     structure: {
                         "userid": {
                             reference: {
+                                hashtag: "#user",
                                 source: "casedb",
                                 subset: "commcare-user",
                                 key: "hq_user_id",
@@ -96,7 +97,7 @@ define([
                 }
             }, {
                 id: "grandparent",
-                name: "grandparent (household)",
+                name: "household",
                 key: "@case_type",
                 structure: {
                     address: {},
@@ -161,6 +162,23 @@ define([
                     "instance('commcaresession')/session/data/case_id");
                 assert.equal(nodes.user.xpath,
                     "instance('commcaresession')/session/context/userid");
+            });
+
+            it("should use reference.hashtag", function() {
+                assert.equal(nodes.user.nodes.role.hashtag, "#user/role");
+            });
+
+            it("should construct #case hashtag with reference.subset", function() {
+                assert.equal(nodes.child.nodes.dob.hashtag, "#case/dob");
+            });
+
+            it("should construct #case/parent hashtag with related subset", function() {
+                assert.equal(nodes.child.nodes.mother.nodes.edd.hashtag, "#case/parent/edd");
+            });
+
+            it("should construct #case/grandparent hashtag with related subset", function() {
+                var house = nodes.child.nodes.mother.nodes.household.nodes;
+                assert.equal(house.address.hashtag, "#case/grandparent/address");
             });
         });
 

--- a/tests/datasources.js
+++ b/tests/datasources.js
@@ -19,7 +19,7 @@ define([
     var assert = chai.assert,
         clickQuestion = util.clickQuestion,
         plugins = _.union(util.options.options.plugins || [], ["itemset"]),
-        FIXTURE_DATA = [{
+        DATA_SOURCES = [{
             id: "some-fixture",
             uri: "jr://fixture/item-list:some-fixture",
             path: "/some-fixture_list/some-fixture",
@@ -133,7 +133,7 @@ define([
                 plugins: plugins,
                 javaRosa: {langs: ['en']},
                 core: {
-                    dataSourcesEndpoint: function (callback) { callback(FIXTURE_DATA); },
+                    dataSourcesEndpoint: function (callback) { callback(DATA_SOURCES); },
                     onReady: function () {
                         vellum = this;
                         done();

--- a/tests/escapedHashtags.js
+++ b/tests/escapedHashtags.js
@@ -25,8 +25,8 @@ define([
             },
             hashtagInfo = {
                 hashtagMap: hashtagMap,
-                invertedHashtagMap: _.object(_.map(
-                    hashtagMap, function (v, k) { return [v, k]; }))
+                invertedHashtagMap: _.invert(hashtagMap),
+                hashtagNamespaces: {form: true, "case": true},
             };
 
         describe("#transform()", function() {

--- a/tests/form.js
+++ b/tests/form.js
@@ -530,19 +530,23 @@ define([
         });
 
         describe("hashtag logic", function () {
-            var form;
+            var form, longPaths = {};
             before(function () {
                 form = util.loadXML("");
             });
 
-            _.each({
+            longPaths["instance('casedb')/cases/case[" +
+                "@case_id = instance('commcaresession')/session/data/case_id" +
+                "]/dob"] = "xpath"
+
+            _.each(_.extend({
                 "": null,
                 "#": null,
 
                 "#form": null,
-                /* TODO should these pass? (they don't)
+                /* should these pass? (they don't)
                 "#form/": "is",
-                "#form/prop": "has",
+                "#form/prop": "has xpath",
                 */
 
                 "/data": null,
@@ -552,12 +556,8 @@ define([
                 "#case": null,
                 "#case/": "is",
                 "#case/prop": "has xpath",
-                /* TODO should these pass? (they don't)
-                "#case/ ": null,
-                "#case/+": null,
-                */
 
-            }, function (valid, path) {
+            }, longPaths), function (valid, path) {
                 function may(name) {
                     return valid[name] ? "" : "not ";
                 }

--- a/tests/form.js
+++ b/tests/form.js
@@ -537,7 +537,7 @@ define([
 
             longPaths["instance('casedb')/cases/case[" +
                 "@case_id = instance('commcaresession')/session/data/case_id" +
-                "]/dob"] = "xpath"
+                "]/dob"] = "xpath";
 
             _.each(_.extend({
                 "": null,
@@ -557,6 +557,9 @@ define([
                 "#case/": "is",
                 "#case/prop": "has xpath",
 
+                "#user": null,
+                "#user/": "is",
+                "#user/prop": "has xpath",
             }, longPaths), function (valid, path) {
                 function may(name) {
                     return valid[name] ? "" : "not ";

--- a/tests/form.js
+++ b/tests/form.js
@@ -527,7 +527,61 @@ define([
                     }
                 });
             });
+        });
 
+        describe("hashtag logic", function () {
+            var form;
+            before(function () {
+                form = util.loadXML("");
+            });
+
+            _.each({
+                "": null,
+                "#": null,
+
+                "#form": null,
+                /* TODO should these pass? (they don't)
+                "#form/": "is",
+                "#form/prop": "has",
+                */
+
+                "/data": null,
+                "/data/": null,
+                "/data/prop": "xpath",
+
+                "#case": null,
+                "#case/": "is",
+                "#case/prop": "has xpath",
+                /* TODO should these pass? (they don't)
+                "#case/ ": null,
+                "#case/+": null,
+                */
+
+            }, function (valid, path) {
+                function may(name) {
+                    return valid[name] ? "" : "not ";
+                }
+                valid = _.object(_.map((valid || "").split(" "), function (key) {
+                    return [key, true];
+                }));
+
+                it("should " + may("is") + "recognize " + path + " as hashtag prefix", function () {
+                    assert.equal(form.isValidHashtagPrefix(path), !!valid.is);
+                });
+
+                it("should " + may("has") + "recognize " + path + " as having hashtag prefix", function () {
+                    assert.equal(form.hasValidHashtagPrefix(path), !!valid.has);
+                });
+
+                it("should " + may("xpath") + "parse " + path + " to valid xpath", function () {
+                    try {
+                        form.xpath.parse(path).toXPath();
+                        assert(valid.xpath, "valid?! " + path);
+                    } catch (err) {
+                        assert(!valid.xpath, "not valid: " + path + "\nerror: " + err);
+                    }
+                });
+            });
         });
     });
 });

--- a/tests/logic.js
+++ b/tests/logic.js
@@ -349,8 +349,8 @@ define([
             },
             hashtagInfo = {
                 hashtagMap: hashtagMap,
-                invertedHashtagMap: _.object(_.map(
-                    hashtagMap, function (v, k) { return [v, k]; }))
+                invertedHashtagMap: _.invert(hashtagMap),
+                hashtagNamespaces: {form: true},
             },
             xpathParser = xpath.createParser(xpath.makeXPathModels(hashtagInfo));
 

--- a/tests/options.js
+++ b/tests/options.js
@@ -3,14 +3,33 @@ define(["underscore"], function (_) {
         {
             id: "commcaresession",
             uri: "jr://instance/session",
-            path: "/session/data",
+            path: "/session",
             name: 'Session',
             structure: {
-                "case_id": {
-                    reference: {
-                        source: "casedb",
-                        subset: "case",
-                        key: "@case_id",
+                data: {
+                    structure: {
+                        "case_id": {
+                            reference: {
+                                source: "casedb",
+                                subset: "case",
+                                subset_key: "@case_type",
+                                key: "@case_id",
+                            },
+                        },
+                    },
+                },
+                context: {
+                    structure: {
+                        "userid": {
+                            reference: {
+                                hashtag: "#user",
+                                source: "casedb",
+                                subset: "commcare-user",
+                                subset_key: "@case_type",
+                                subset_filter: true,
+                                key: "hq_user_id",
+                            },
+                        },
                     },
                 },
             },
@@ -38,6 +57,14 @@ define(["underscore"], function (_) {
                 },
                 related: {
                     parent: "grandparent",
+                }
+            }, {
+                id: "commcare-user",
+                name: "user",
+                key: "@case_type",
+                structure: {
+                    role: {},
+                    username: {},
                 }
             }, {
                 id: "case",

--- a/tests/options.js
+++ b/tests/options.js
@@ -10,6 +10,7 @@ define(["underscore"], function (_) {
                     structure: {
                         "case_id": {
                             reference: {
+                                hashtag: "#case",
                                 source: "casedb",
                                 subset: "case",
                                 subset_key: "@case_type",
@@ -56,7 +57,12 @@ define(["underscore"], function (_) {
                     edd: {},
                 },
                 related: {
-                    parent: "grandparent",
+                    parent: {
+                        hashtag: "#case/grandparent",
+                        subset: "grandparent",
+                        subset_key: "@case_type",
+                        key: "@case_id",
+                    }
                 }
             }, {
                 id: "commcare-user",
@@ -97,7 +103,12 @@ define(["underscore"], function (_) {
                     f_9814: {},
                 },
                 related: {
-                    parent: "parent",
+                    parent: {
+                        hashtag: "#case/parent",
+                        subset: "parent",
+                        subset_key: "@case_type",
+                        key: "@case_id",
+                    }
                 },
             }]
         }, {

--- a/tests/options.js
+++ b/tests/options.js
@@ -7,6 +7,7 @@ define(["underscore"], function (_) {
             name: 'Session',
             structure: {
                 data: {
+                    merge: true,
                     structure: {
                         "case_id": {
                             reference: {
@@ -20,6 +21,7 @@ define(["underscore"], function (_) {
                     },
                 },
                 context: {
+                    merge: true,
                     structure: {
                         "userid": {
                             reference: {


### PR DESCRIPTION
Add support for new data sources schema elements that allow user properties to be specified and referenced with hashtag expressions (`#user/property`). It also removes magic/ambiguity from the data sources schema. Finally, all hard-coded references to `#case` hashtags have been removed since the data sources schema may define arbitrary hashtag names.

All changes here should be entirely backward-compatible with the existing data sources schema provided by HQ. Until HQ is updated to provide a new schema containing user properties, the only end-user visible change is c51fd69.

Spec: https://docs.google.com/document/d/1kPVwZketyWl6aRo1ZNCM3EngkrTsgmFbnBXAv-FThKU

Review commits individually 🐠 

@emord @orangejenny 