### PR TITLE
Kill link to highlight question in tree

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -199,18 +199,6 @@ define([
             (hotkeys[key] || _.identity).call(_this, e);
         });
 
-        $(document).on('click', '.jstree-hover', function(e) {
-            e.preventDefault();
-            _this.jstree("hover_node", $(this).data("ufid"));
-            var $node = $(".jstree-hovered");
-            if ($node.length) {
-                var $scrollable = $node.closest(".fd-scrollable");
-                $scrollable.scrollTop($node.position().top - $scrollable.position().top);
-            }
-            analytics.fbUsage("Clicked link to show in tree");
-            analytics.workflow("Clicked on easy reference popover's link to show in tree");
-        });
-
         this._init_toolbar();
         this._createJSTree();
         this.datasources = datasources.init(

--- a/src/jquery-extensions.js
+++ b/src/jquery-extensions.js
@@ -87,30 +87,4 @@ define([
         	}
         } );
     }
-
-    // Delay popover closing so that user has time to move cursor
-    // into popover and can then interact with popover content.
-    // http://jsfiddle.net/hermanho/4886bozw/
-    var popoverLeave = $.fn.popover.Constructor.prototype.leave;
-    $.fn.popover.Constructor.prototype.leave = function(obj){
-        var self = obj instanceof this.constructor ?
-            obj : $(obj.currentTarget)[this.type](this.getDelegateOptions()).data('bs.' + this.type);
-        var container,
-            timeout;
-
-        popoverLeave.call(this, obj);
-
-        if (obj.currentTarget) {
-            container = $('.popover');  // Works even if there are multiple popovers
-            timeout = self.timeout;
-            container.one('mouseenter', function() {
-                // Entered the actual popover
-                clearTimeout(timeout);
-                // Monitor popover content instead
-                container.one('mouseleave', function() {
-                    $.fn.popover.Constructor.prototype.leave.call(self, self);
-                });
-            });
-        }
-    };
 });

--- a/src/richText.js
+++ b/src/richText.js
@@ -38,7 +38,6 @@ define([
     'underscore',
     'jquery',
     'tpl!vellum/templates/date_format_popover',
-    'tpl!vellum/templates/easy_reference_popover',
     'vellum/dateformats',
     'vellum/escapedHashtags',
     'vellum/logic',
@@ -52,7 +51,6 @@ define([
     _,
     $,
     date_format_popover,
-    easy_reference_popover,
     dateformats,
     escapedHashtags,
     logic,
@@ -741,36 +739,12 @@ define([
                 placement: 'bottom',
                 title: getTitle,
                 html: true,
-                content: easy_reference_popover({
-                    text: labelText.text(),
-                    ufid: isFormRef ? labelMug.ufid : "",
-                }),
+                content: '<p>' + labelText.text() + '</p>',
                 template: '<div contenteditable="false" class="popover rich-text-popover">' +
                     '<div class="popover-inner">' +
                     '<div class="popover-title"></div>' +
                     (isFormRef ? '<div class="popover-content"><p></p></div>' : '') +
                     '</div></div>',
-                delay: {
-                    show: 0,
-                    hide: 200,
-                },
-            }).on('shown.bs.popover', function() {
-                var type = isFormRef ? 'form' : 'case';
-                analytics.fbUsage("Hovered over easy " + type + " reference");
-                analytics.workflow("Hovered over easy reference");
-                if (isDate || $this.attr("data-date-format")) {
-                    var pos = $(this).offset(),
-                        x = pos.left,
-                        y = pos.top + $(this).height();
-                    $("#" + dateFormatID).click(function () {
-                        $imgs.popover('hide');
-                        dateformats.showMenu(x, y, function (format) {
-                            $this.attr("data-date-format", format);
-                            editor.fire("saveSnapshot");
-                        }, true);
-                        return false;
-                    });
-                }
             });
 
             ckwidget.on('destroy', function (e)  {

--- a/src/templates/easy_reference_popover.html
+++ b/src/templates/easy_reference_popover.html
@@ -1,8 +1,0 @@
-<p><%= text %></p>
-<% if (ufid) { %>
-    <p>
-        <a href="#" class="jstree-hover" data-ufid="<%= ufid %>">
-            show in question list
-        </a>
-    </p>
-<% } %>

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -607,7 +607,7 @@ define([
                     });
                 });
 
-                it("should show xpath and tree reference link on popover", function (done) {
+                it("should show xpath on popover", function (done) {
                     util.loadXML(BURPEE_XML);
                     util.clickQuestion("total_num_burpees");
                     var widget = util.getWidget('property-calculateAttr');
@@ -616,13 +616,8 @@ define([
                         assert(bubble.length, "No bubbles detected");
                         try {
                             bubble.mouseenter();
-                            var $popover = $('.popover-content:last');
-                            assert.strictEqual($popover.find('p:first').text(),
+                            assert.strictEqual($('.popover-content').text(),
                                                "How many burpees did you do on #form/new_burpee_data/burpee_date ?");
-                            var $link = $popover.find("a");
-                            assert($link.length);
-                            $link.click();
-                            assert.strictEqual($(".jstree-hovered").length, 1);
                         } finally {
                             $(".popover").remove();
                         }
@@ -639,7 +634,7 @@ define([
                         assert(bubble.length, "No bubbles detected");
                         try {
                             bubble.mouseenter();
-                            var $popover = $('.popover-content:last p:first');
+                            var $popover = $('.popover-content:last');
                             assert.strictEqual($popover.text(),
                                 "How many burpees did you do on #form/new_burpee_data/burpee_date ?");
 


### PR DESCRIPTION
This was done as an experiment, and it didn't see enough usage to justify keeping it: ~88,000 hovers over easy references, but only ~300 clicks on the link.