### PR TITLE
Fix drag/drop in data source widgets

### DIFF
--- a/src/dataSourceWidgets.js
+++ b/src/dataSourceWidgets.js
@@ -85,6 +85,7 @@ define([
             super_setValue = widget.setValue,
             currentValue = null;
 
+        widget.options.richText = false;
         widget.getUIElement = function () {
             var query = getUIElementWithEditButton(
                     getUIElement(widget.input, labelText),
@@ -159,13 +160,14 @@ define([
             hasValue = true;
         }
 
-        var widget = widgets.dropdown(mug, options), 
+        var widget = widgets.dropdown(mug, options),
             super_getValue = widget.getValue,
             super_setValue = widget.setValue,
             getSource = options.getSource ? options.getSource : local_getValue,
             setSource = options.setSource ? options.setSource : local_setValue,
             hasValue = false;
 
+        widget.options.richText = false;
         widget.addOption(EMPTY_VALUE, "Loading...");
         var disconnect = mug.form.vellum.datasources.onChangeReady(function () {
             var data = mug.form.vellum.datasources.getDataSources(),
@@ -200,6 +202,9 @@ define([
                                 source: getSource(mug),
                                 headerText: labelText,
                                 loadEditor: loadDataSourceEditor,
+                                onLoad: function ($ui) {
+                                    widgets.util.setWidget($ui, widget);
+                                },
                                 done: function (source) {
                                     if (!_.isUndefined(source)) {
                                         setSource(source, mug);


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?243450

Not particularly proud of this one. There are no tests because the data source widgets don't have tests. Also, they haven't been updated to support rich text. Hashtags do work, but no bubbles (obviously) and no auto-complete.

@emord 