### PR TITLE
Fix name in tree after change choice node ID 

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -887,16 +887,6 @@ define([
             }
 
             return function () {
-                var event = {
-                    type: 'mug-property-change',
-                    mug: mug,
-                    property: property,
-                    val: value,
-                    previous: previous
-                };
-                mug.validate(property);
-                this.fire(event);
-
                 // legacy, enables auto itext ID behavior, don't add
                 // additional dependencies on this code.  Some sort of
                 // data binding would be better.
@@ -906,6 +896,16 @@ define([
                     val: value,
                     previous: previous
                 });
+
+                var event = {
+                    type: 'mug-property-change',
+                    mug: mug,
+                    property: property,
+                    val: value,
+                    previous: previous
+                };
+                mug.validate(property);
+                this.fire(event);
 
                 this.fireChange(mug);
             }.bind(this);

--- a/tests/core.js
+++ b/tests/core.js
@@ -199,6 +199,18 @@ define([
             );
         });
 
+        it("should update choice name in tree on change question ID", function () {
+            util.loadXML("");
+            util.addQuestion("Select", "select");
+            util.clickQuestion("select/choice1");
+            $("[name=property-nodeID]").val("yes").change();
+            util.assertJSTreeState(
+                "select",
+                "  yes",
+                "  choice2"
+            );
+        });
+
         it("should not change mugs on collapse", function () {
             util.loadXML("");
             var group1 = util.addQuestion("Group", "group"),

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -127,7 +127,7 @@ define([
     function wrapWithDivP(el) { return wrapWithDiv($('<p>').append(el)); }
     function html(value) { return wrapWithDiv(value).html(); }
 
-    before(function (done) {
+    function setupGlobalForm(done) {
         util.init({
             javaRosa: {langs: ['en']},
             core: {
@@ -142,9 +142,11 @@ define([
                 },
             },
         });
-    });
+    }
 
     describe("Rich text utilities", function() {
+        before(setupGlobalForm);
+
         describe("simple conversions", function() {
             // path, display value, icon
             var simpleConversions = [
@@ -362,6 +364,8 @@ define([
     });
 
     describe("The rich text editor", function () {
+        before(setupGlobalForm);
+
         describe("", function() {
             var el = $("<div id='cktestparent'><div contenteditable /><div contenteditable /></div>"),
                 options = {isExpression: false},


### PR DESCRIPTION
This fix was hard to figure out and I'm not proud of it, but it works so I'm going with it. The event dependencies are messy. Mug `property-changed` [appears to be sort of deprecated](https://github.com/dimagi/Vellum/blob/6516916bfcb99a2783f264fc931398a1b5a887ec/src/form.js#L890-L892), but I couldn't think of a better way to implement it without a massive refactor and I'm not sure what Mike White had in mind by "some sort of data binding."

The first commit is an unrelated debugging annoyance fix.

http://manage.dimagi.com/default.asp?243656

@emord @orangejenny 