### PR TITLE
Don't display right-hand content when there aren't any questions

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1212,8 +1212,6 @@ define([
                 _this.data.core.form.fire('form-load-finished');
 
                 if (formString) {
-                    //re-enable all buttons and inputs in case they were disabled before.
-                    _this.showQuestionProperties();
                     if (updateSaveButton) {
                         _this.data.core.saveButton.fire('change');
                     }


### PR DESCRIPTION
Noticed this while looking at removing the "New Form" content for onboarding.

Before, empty forms display with the "Question Details" header and a horizontal line:
![screen shot 2017-01-10 at 10 55 57 am](https://cloud.githubusercontent.com/assets/1486591/21813182/68fdae26-d723-11e6-82cd-32b7d682181a.png)

After, those elements are gone:
![screen shot 2017-01-10 at 10 56 01 am](https://cloud.githubusercontent.com/assets/1486591/21813196/722b8d56-d723-11e6-9845-708e1070a92e.png)

A little nervous about removing this, but tests pass and I verified that both empty and non-empty forms load as expected (non-empty forms select the first question and display its question properties).

@millerdev / @emord 