### PR TITLE
Wait to attach drag events until first drag

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -995,32 +995,38 @@ define([
      *
      * NOTE this is done once when Vellum is loaded. These handlers must work
      * for multiple Vellum instances on the same page.
+     *
+     * These handlers need to be executed AFTER jstree's own dnd_move and
+     * dnd_stop handlers, so wait to attach them until the first time a
+     * drag begins.
      */
-    $(document).on("dnd_move.vakata.jstree", function (e, data) {
-        var source = $(data.data.obj),
-            target = $(data.event.target),
-            inst = $.jstree.reference(target);
-        if (!inst && target.vellum("get") === source.vellum("get")) {
-            // only when not dragging inside the tree
-            if (target.closest('.jstree-drop').length) {
-                data.helper.find('.jstree-icon').removeClass('jstree-er').addClass('jstree-ok');
-            } else {
-                data.helper.find('.jstree-icon').removeClass('jstree-ok').addClass('jstree-er');
-            }
-        }
-    }).on("dnd_stop.vakata.jstree", function (e, data) {
-        var vellum = $(data.data.obj).vellum("get"),
-            target = $(data.event.target),
-            inst = $.jstree.reference(target);
-
-        if (!inst && (target.closest('.jstree-drop').length) && vellum === target.vellum("get")) {
-            if (data.data.origin) {
-                var node = data.data.origin.get_node(data.data.nodes[0]);
-                if (node.data && node.data.handleDrop) {
-                    node.data.handleDrop(target.closest('.jstree-drop'));
+    $(document).one("dnd_move.vakata.jstree", function (e, data) {
+        $(document).on("dnd_move.vakata.jstree", function (e, data) {
+            var source = $(data.data.obj),
+                target = $(data.event.target),
+                inst = $.jstree.reference(target);
+            if (!inst && target.vellum("get") === source.vellum("get")) {
+                // only when not dragging inside the tree
+                if (target.closest('.jstree-drop').length) {
+                    data.helper.find('.jstree-icon').removeClass('jstree-er').addClass('jstree-ok');
+                } else {
+                    data.helper.find('.jstree-icon').removeClass('jstree-ok').addClass('jstree-er');
                 }
             }
-        }
+        }).on("dnd_stop.vakata.jstree", function (e, data) {
+            var vellum = $(data.data.obj).vellum("get"),
+                target = $(data.event.target),
+                inst = $.jstree.reference(target);
+
+            if (!inst && (target.closest('.jstree-drop').length) && vellum === target.vellum("get")) {
+                if (data.data.origin) {
+                    var node = data.data.origin.get_node(data.data.nodes[0]);
+                    if (node.data && node.data.handleDrop) {
+                        node.data.handleDrop(target.closest('.jstree-drop'));
+                    }
+                }
+            }
+        });
     });
 
     /**


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?244447

This is a timing issue. When you drag a bubble over an input in question properties, jstree doesn't recognize it as a legal place to drop (I think because you're not in the tree...didn't delve deeply into the jstree logic) and [shows the red X](https://github.com/vakata/jstree/blob/master/dist/jstree.js#L6709). But vellum does recognize that this is a legal place to drop and [shows the green checkmark](https://github.com/dimagi/Vellum/blob/master/src/core.js#L1006).

Both of these pieces of code are inside `dnd_move` handlers, and whichever one runs last effectively "wins." Event handlers are run in the order they're registered, which in this case isn't reliable: the jstree handler is attached on document ready, the vellum handler on vellum initialization.

Fixing by waiting to attach the vellum code until the first time someone attempts to drag, at which point the jstree handlers will have been attached.

`?w=1`

cc @czue 