### PR TITLE
default user_id to value from session

### DIFF
--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -173,6 +173,7 @@ define([
             icon: 'fa fa-save',
             init: function (mug, form) {
                 mug.p.date_modified = mug.p.date_modified || '/data/meta/timeEnd';
+                mug.p.user_id = mug.p.user_id || "instance('commcaresession')/session/context/userid";
             },
             spec: {
                 xmlnsAttr: { presence: "optional" },


### PR DESCRIPTION
I don't think I've ever used any other value for this.

note that `/data/meta/userID` would be another equivalent option if we prefer that. this has the benefit of working with nonstandard `meta` blocks though that's not really a thing that we care about.