### PR TITLE
don't let people change the form name

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -673,10 +673,6 @@ define([
             $modalBody = $modal.find('.modal-body'),
             formProperties = [
                 {
-                    label: "Form Name",
-                    slug: "formName"
-                },
-                {
                     label: "Disable Text Formatting",
                     slug: "noMarkdown",
                     type: "checkbox",


### PR DESCRIPTION
@orangejenny @millerdev This came from field dev/stack exchange post. We shouldn't have this box because it isn't reflected in HQ, but it would change it on mobile leading to very confusing behavior. Changing on the form page in HQ should be the only way to change this

@benrudolph @gcapalbo 