### PR TITLE
adding popovers with descriptions to databrowser

### DIFF
--- a/src/databrowser.js
+++ b/src/databrowser.js
@@ -81,6 +81,12 @@ define([
             $search = $container.find(".fd-external-resource-search input"),
             $tree = $container.find(".fd-external-sources-tree");
         vellum.data.core.databrowser.errorContainer = $container;
+        $tree.on('after_open.jstree', function () {
+            $('.jstree-anchor').popover();
+        });
+        $tree.on('redraw.jstree', function () {
+            $('.jstree-anchor').popover();
+        });
         $tree.jstree({
             core: {
                 data: function (node, callback) {
@@ -133,6 +139,11 @@ define([
                 data: {
                     handleDrop: _.partial(handleDrop, node, node.sourceInfo),
                     getNodes: node.recursive ? getNodes : null,
+                },
+                a_attr: {
+                    'data-content': node.description,
+                    'data-container': 'body',
+                    'data-trigger': 'hover',
                 }
             };
         }


### PR DESCRIPTION
@emord @millerdev @orangejenny cc: @czue 
this adds popovers to the data browser, the are correctly rendered after searches or opening of the tree. tested with 300+ case properties for load issues and there didnt seem to be a problem. When there is no description, there is no popover not an empty one
<img width="1440" alt="screen shot 2017-03-01 at 5 03 59 pm" src="https://cloud.githubusercontent.com/assets/6844721/23483490/2607e802-fea1-11e6-92e2-eaddfc292498.png">
