### PR TITLE
Tiptoeing around media uploader minefield

### DIFF
--- a/src/uploader.js
+++ b/src/uploader.js
@@ -126,6 +126,7 @@ define([
             uploadController.updateMediaPath = function () {
                 var params = uploadController.uploadParams;
                 params.path = widget.getRandomizedMediaPath(params.path);
+                widget.updateReference(params.path);
             };
             uploadController.uploadParams = {
                 path: ref.path,
@@ -236,8 +237,8 @@ define([
             widget.updateReference();
         };
 
-        widget.updateReference = function () {
-            var currentPath = getValue();
+        widget.updateReference = function (path) {
+            var currentPath = path || getValue();
             $uiElem.attr('data-hqmediapath', currentPath);
             widget.mediaRef.updateRef(currentPath);
         };


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?248873 voodoo magic

Since #810, the Print question type does not initialize its template path until a template is uploaded. I couldn't find any changes since then that would have caused this bug, but I can also hardly imagine that we did not test this workflow before releasing that change (it passed QA).

Since the template path is initially blank, the [`mediaUploadComplete` handler](https://github.com/dimagi/Vellum/blob/03750224202048d01e682c3028e139a484ea3f2d/src/uploader.js#L206-L207) was not called because the [selector (constructed with said blank path) used to trigger the event](https://github.com/dimagi/MediaUploader/blob/d8e910547683e63a38fdf82e3195be0a2b83edc0/hqmedia.upload_controller.js#L551) matched nothing. This change ensures that the path is properly initialized. I tested it locally and it works both for print template and JavaRosa media uploads. I couldn't think of a way to write an automated test that would not be too fragile to be worth writing.

This PR was very carefully devised to not touch any code in the media uploader submodule. The logic in the media uploader is confounding. That thing should be rewritten.

@orangejenny @emord 