### PR TITLE
v2: Make submenu arrows not invisible

### DIFF
--- a/src/less-style/dropdown.less
+++ b/src/less-style/dropdown.less
@@ -28,10 +28,9 @@
             float: right;
             width: 0;
             height: 0;
-            border-color: transparent;
+            border-color: transparent transparent transparent #ccc;
             border-style: solid;
             border-width: 5px 0 5px 5px;
-            border-left-color: #ccc;
             margin-top: 5px;
             margin-right: -10px;
         }


### PR DESCRIPTION
The submenu arrows on prod are currently invisible:
<img width="176" alt="screen shot 2017-03-14 at 2 13 52 pm" src="https://cloud.githubusercontent.com/assets/1486591/23916202/d45eda26-08c1-11e7-97b4-c5ea533d78cb.png">

Whereas they should look like:
<img width="167" alt="screen shot 2017-03-14 at 2 22 47 pm" src="https://cloud.githubusercontent.com/assets/1486591/23916205/dafce17a-08c1-11e7-915e-596e7a7d26b8.png">

Looks like an issue with the minifier, where `border-left-color: #ccc;` wasn't included in the minified file. Fixed by combining `border-color` and `border-left-color` into one rule.

cc @dannyroberts 