### PR TITLE
Move question id into logic

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2199,7 +2199,6 @@ define([
         return [
             "label",
             "calculateAttr",
-            "nodeID",
             "requiredAttr",
             "readOnlyControl",
             "itemsetData",
@@ -2219,6 +2218,7 @@ define([
 
     fn.getLogicProperties = function () {
         return [
+            "nodeID",
             "relevantAttr",
             "constraintAttr",
             "repeat_count",

--- a/src/less-style/question-props.less
+++ b/src/less-style/question-props.less
@@ -100,10 +100,6 @@
                         margin: 10px;
                     }
                 }
-
-                .identifier {
-                    opacity: 0.5;
-                }
             }
 
             // "auto?" checkbox for custom itext IDs

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -795,7 +795,7 @@ define([
             nodeID: {
                 visibility: 'visible',
                 presence: 'required',
-                lstring: ' ',
+                lstring: 'Question ID',
                 setter: function (mug, attr, value) {
                     mug.form.moveMug(mug, "rename", value);
                 },
@@ -809,7 +809,6 @@ define([
                     mug.p.nodeID = value;
                 },
                 widget: widgets.identifier,
-                identifierString: 'Question ID',
                 validationFunc: function (mug) {
                     var caseWarning = {
                             key: "mug-nodeID-case-warning",
@@ -1439,11 +1438,10 @@ define([
         },
         spec: {
             nodeID: {
-                lstring: ' ',
+                lstring: 'Choice Value',
                 visibility: 'visible',
                 presence: 'required',
                 widget: widgets.identifier,
-                identifierString: 'Choice Value',
                 setter: null,
                 validationFunc: function (mug) {
                     if (/\s/.test(mug.p.nodeID)) {

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -325,12 +325,6 @@ define([
         var widget = text(mug, options),
             super_updateValue = widget.updateValue;
 
-        if (options.identifierString) {
-            widget.input = $("<div>").append(widget.input);
-            widget.input.addClass("input-group identifier");
-            widget.input.prepend('<div class="input-group-addon">' + options.identifierString + '</div>');
-        }
-
         widget.updateValue = function () {
             var val = widget.getValue();
 


### PR DESCRIPTION
As discussed in #vellum chat. I feel a little weird about not having the id visible for new users, but I think that's just resistance to change. Guessing that a heavy majority of users will have logic open most of the time, and that this'll just get the id out of the way for brand new people until they get more comfortable in the form builder.

fyi @biyeun 