### PR TITLE
Disable F2 to rename tree node

### DIFF
--- a/src/jstree-plugins.js
+++ b/src/jstree-plugins.js
@@ -45,5 +45,8 @@ define([
                 base = {inst: this, parent: parent};
             return this.settings.conditionalevents.redraw_node.apply(base, args);
         };
+        this.edit = function () {
+            // do nothing: disable F2 -> rename node
+        };
     };
 });


### PR DESCRIPTION
F2 to edit node name was referenced in https://manage.dimagi.com/default.asp?249819 I didn't even know about this feature, but it does nothing so just disabling it.

@emord @benrudolph 