### PR TITLE
Move question id back into basic

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2218,6 +2218,7 @@ define([
         return [
             "label",
             "calculateAttr",
+            "nodeID",
             "requiredAttr",
             "readOnlyControl",
             "itemsetData",
@@ -2237,7 +2238,6 @@ define([
 
     fn.getLogicProperties = function () {
         return [
-            "nodeID",
             "relevantAttr",
             "constraintAttr",
             "repeat_count",


### PR DESCRIPTION
Experimenting with this for the next few user tests.

My hope is that now that the id's placeholder updates itself as you type into the label, the id will look "filled out" and people won't be so compelled to type in it.

@millerdev / @biyeun / @emord 