### PR TITLE
jquery 3.2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     ],
     "dependencies": {
         "underscore": "~1.8.3",
-        "jquery": "~3.1.1",
+        "jquery": "~3.2.1",
         "requirejs": "~2.3.1",
         "requirejs-text": "~2.0.12",
         "require-less": "~0.1.2",


### PR DESCRIPTION
@orangejenny I think the only things that use the deprecated functions are at.js and jstree

https://blog.jquery.com/2017/03/16/jquery-3-2-0-is-out/

> This release includes some bug fixes, improvements, and some deprecations. There should be no compatibility issues if upgrading from jQuery 3.0+.