### PR TITLE
Add choice with addQuestion, not form.createQuestion

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1989,9 +1989,7 @@ define([
                 "selector": "a",
                 "event": "click",
                 "callback": function (node_id, node, action_id, action_el) {
-                    var newMug = _this.data.core.form.createQuestion(mug, 'into', "Choice", true);
-                    _this.ensureCurrentMugIsSaved();
-                    _this.setCurrentMug(newMug);
+                    _this.addQuestion("Choice");
                 }
             });
         } else {


### PR DESCRIPTION
Reason for doing this is that using `createQuestion` means that when a choice is added, the parent select question ends up selected. This change makes it so that the new choice question ends up selected.

@millerdev / @emord 
cc @NoahCarnahan 