### PR TITLE
Blank placeholder to appease ckeditor/firefox

### DIFF
--- a/src/richText.js
+++ b/src/richText.js
@@ -168,6 +168,7 @@ define([
             editor = input.ckeditor({
                 contentsLangDirection: options.rtl ? 'rtl' : 'ltr',
                 disableNativeSpellChecker: options.disableNativeSpellChecker,
+                placeholder: ' ',
             }).editor;
         wrapper = {
             getValue: function (callback) {


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?250396

Not proud of this. The extra line is caused by [this code](https://github.com/dimagi/Vellum/blob/master/src/richText.js#L263-L268) which is needed for atwho/bubbles to insert correctly.

@emord 
cc @esoergel 