### PR TITLE
Allow choices to start off without label or id

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -932,10 +932,17 @@ define([
                 mug.p.nodeID = this.generate_question_id();
             }
             if (mug.__className === "Choice") {
-                var parent = refMug.__className === "Choice" ? refMug.parentMug : refMug;
-                mug.p.nodeID = this.generate_item_label(parent);
+                mug.p.nodeID = "";
             }
             this.insertQuestion(mug, refMug, position, isInternal);
+
+            // Choice require a nodeID and a label, but give user
+            // a chance to enter them before displaying an error
+            if (mug.__className === "Choice") {
+                mug.dropMessage("labelItext", "mug-labelItext-error");
+                mug.dropMessage("nodeID", "mug-nodeID-error");
+            }
+
             // should we fix broken references when nodeID is auto-generated?
             //if (!mug.options.isControlOnly && !this.isLoadingXForm) {
             //    this.fixBrokenReferences();
@@ -1139,7 +1146,7 @@ define([
                     new_id = "copy-" + i + "-of-" + question_id;
                 }
             } else {
-                return this._make_label('question', mug);
+                return this._make_label(mug && mug.__className === "Choice" ? 'choice' : 'question', mug);
             }
         },
         generate_item_label: function (parentMug, name, i) {

--- a/tests/questionTypes.js
+++ b/tests/questionTypes.js
@@ -605,7 +605,7 @@ define([
 
         it("adds and removes the add choice action when type changes", function() {
             util.loadXML("");
-            util.addQuestion("Text", "question1");
+            var mug = util.addQuestion("Text", "question1");
             var changerSelector = ".fd-question-changer";
 
             $(changerSelector + " > a").click();
@@ -614,6 +614,8 @@ define([
 
             assert.strictEqual($(".add_choice").length, 1);
             $(".add_choice").click();
+            mug.form.vellum.ensureCurrentMugIsSaved();  // force id to generate
+            clickQuestion("question1/choice1");
 
             util.assertJSTreeState(
                 "question1",
@@ -630,10 +632,12 @@ define([
 
         it("gives select questions an add choice action", function() {
             util.loadXML("");
-            util.addQuestion("Select", "question1");
+            var mug = util.addQuestion("Select", "question1");
 
             assert.strictEqual($(".add_choice").length, 1);
             $(".add_choice").click();
+            mug.form.vellum.ensureCurrentMugIsSaved();  // force id to generate
+            clickQuestion("question1/choice1");
 
             util.assertJSTreeState(
                 "question1",

--- a/tests/questionTypes.js
+++ b/tests/questionTypes.js
@@ -616,8 +616,9 @@ define([
             $(".add_choice").click();
 
             var choice = call("getCurrentlySelectedMug");
-            assert(!choice.p.nodeID);
-            assert(!choice.p.labelItext.get());
+            assert(!choice.messages.get().length, "New mug should have no errors");
+            assert(!choice.p.nodeID, "New mug shouldn't have an id");
+            assert(!choice.p.labelItext.get(), "New mug shouldn't have a label");
             choice.form.vellum.ensureCurrentMugIsSaved();  // force id to generate
             clickQuestion("question1/choice1");
 

--- a/tests/questionTypes.js
+++ b/tests/questionTypes.js
@@ -605,7 +605,7 @@ define([
 
         it("adds and removes the add choice action when type changes", function() {
             util.loadXML("");
-            var mug = util.addQuestion("Text", "question1");
+            util.addQuestion("Text", "question1");
             var changerSelector = ".fd-question-changer";
 
             $(changerSelector + " > a").click();
@@ -614,7 +614,11 @@ define([
 
             assert.strictEqual($(".add_choice").length, 1);
             $(".add_choice").click();
-            mug.form.vellum.ensureCurrentMugIsSaved();  // force id to generate
+
+            var choice = call("getCurrentlySelectedMug");
+            assert(!choice.p.nodeID);
+            assert(!choice.p.labelItext.get());
+            choice.form.vellum.ensureCurrentMugIsSaved();  // force id to generate
             clickQuestion("question1/choice1");
 
             util.assertJSTreeState(


### PR DESCRIPTION
Deal with some issues Derek raised about the workflow of adding choices to a select question.

Previously, when you added a choice, the label and id would default to `choiceN`, which the user would inevitably need to overwrite. Now I'm letting the id and label default to blank, which is a better workflow, but because this causes a validation error, I'm letting the validation run, assuming it's going to error on `nodeID` and the label, and then removing those errors, which is a bit sketchy.

@emord 
cc @esoergel 