### PR TITLE
Copy/paste hashtags in rich text fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /bower_components
 /node_modules
 /dist/*
+/lib/ckeditor/un-minified-ckeditor.js
 /_build
 vellum.tar.gz
 

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -467,6 +467,170 @@ define([
                 assert.equal(editor.getValue(), 'A');
             });
 
+            function assertCKCopy($editor, value) {
+                // WARNING this is heavily dependent on CKEditor internals
+                var domObject = new CKEDITOR.dom.domObject($editor[0]),
+                    realDataTransfer = CKEDITOR.plugins.clipboard.dataTransfer,
+                    data;
+                function testDataTransfer(nativeDataTransfer, editor) {
+                    realDataTransfer.call(this, nativeDataTransfer, editor);
+                    data = this._.data;
+                }
+                testDataTransfer.prototype = realDataTransfer.prototype;
+                CKEDITOR.plugins.clipboard.dataTransfer = testDataTransfer;
+                try {
+                    domObject.fire("copy", new CKEDITOR.dom.event({}));
+                } finally {
+                    CKEDITOR.plugins.clipboard.dataTransfer = realDataTransfer;
+                }
+                assert.equal(data.Text, value, 'text/plain');
+                assert.strictEqual(data["text/html"], undefined, 'text/html');
+            }
+
+            function ckPaste($editor, data, callback) {
+                // WARNING this is heavily dependent on CKEditor internals
+                function mockDataTransfer() {
+                    // borrowed from CKEditor tests
+                    return {
+                        types: [],
+                        files: CKEDITOR.env.ie && CKEDITOR.env.version < 10 ? undefined : [],
+                        _data: {},
+                        // Emulate browsers native behavior for getDeta/setData.
+                        setData: function( type, data ) {
+                            if ( CKEDITOR.env.ie && type !== 'Text' && type !== 'URL' )
+                                throw 'Unexpected call to method or property access.';
+
+                            if ( CKEDITOR.env.ie && CKEDITOR.env.version > 9 && type === 'URL' )
+                                return;
+
+                            if ( type === 'text/plain' || type === 'Text' ) {
+                                this._data[ 'text/plain' ] = data;
+                                this._data.Text = data;
+                            } else {
+                                this._data[ type ] = data;
+                            }
+
+                            this.types.push( type );
+                        },
+                        getData: function( type ) {
+                            if ( CKEDITOR.env.ie && type !== 'Text' && type !== 'URL' )
+                                throw 'Invalid argument.';
+
+                            if ( typeof this._data[ type ] === 'undefined' || this._data[ type ] === null )
+                                return '';
+
+                            return this._data[ type ];
+                        }
+                    };
+                }
+                function mockPasteEvent(_target, dataTransfer) {
+                    // borrowed from CKEditor tests
+                    var target = new CKEDITOR.dom.node(_target);
+                    return {
+                        $: {
+                            ctrlKey: true,
+                            clipboardData: CKEDITOR.env.ie ? undefined : dataTransfer
+                        },
+                        preventDefault: function() {
+                            // noop
+                        },
+                        getTarget: function() {
+                            return target;
+                        },
+                        setTarget: function( t ) {
+                            target = t;
+                        }
+                    };
+                }
+                var editor = $editor.ckeditor().editor,
+                    editable = editor.editable(),
+                    dataTransfer = mockDataTransfer(),
+                    evt = mockPasteEvent($editor[0], dataTransfer),
+                    types = {
+                        html: "text/html",
+                        text: "Text",
+                    };
+                if (_.isEmpty(data)) {
+                    throw new Error("bad paste: no data");
+                }
+                _.each(data, function (value, type) {
+                    if (!types.hasOwnProperty(type)) {
+                        throw new Error("bad paste type: " + type);
+                    }
+                    dataTransfer.setData(types[type], value);
+                });
+                editor.once("afterPaste", function () {
+                    callback(editor.getData());
+                }, null, null, 100);
+                editable.fire("paste", evt);
+            }
+
+            function escapeHTML(html) {
+                var reps = {'<': '&lt;', '>': '&gt;', '"': '&quot;', '\n': '<br />'};
+                return html.replace(/[<>"&\n]/g, function (match) {
+                    return reps[match];
+                });
+            }
+
+            var TEST_LABEL = 'Weight: <output value="#form/text" /> grams',
+                TEST_XPATH = "if(today() + (#case/dob - 3), #form/text, 0)";
+
+            it("should copy output tag from rich text editor", function () {
+                editor.setValue(TEST_LABEL, function () {
+                    editor.select(6, 3);
+                    assertCKCopy(input, ': <output value="#form/text" />');
+                });
+            });
+
+            it("should copy expression with hashtags from expression editor", function () {
+                exprEditor.setValue(TEST_XPATH, function () {
+                    exprEditor.select(11, 4);
+                    assertCKCopy(exprInput, "+ (#case/dob");
+                });
+            });
+
+            var OUTPUT = '<output value="#form/text" />',
+                START_LABEL = TEST_LABEL.replace(OUTPUT, 'XXXX'),
+                START_PATH = TEST_XPATH.replace('#case/dob', 'XXXX');
+            _.each([
+                [0, START_LABEL, 8, 4, {text: OUTPUT}],
+                [0, START_LABEL, 8, 4, {text: OUTPUT + " > 3"}],
+                [0, START_LABEL, 8, 4, {text: "4 pounds\n\nLines..."}],
+                [1, START_PATH, 14, 4, {text: "#case/dob"}],
+                [1, START_PATH, 11, 7, {text: "+ (#case/dob"}],
+                [1, START_PATH, 11, 7, {text: "< (#case/dob"}],
+                [1, START_PATH, 11, 7, {html: "<span>+ (#case/dob</span>"}],
+                [1, START_PATH, 11, 7, {html: "<meta charset='utf-8'>+ (#case/dob"}],
+            ], function (args) {
+                var inputFlag = args[0],
+                    initialExpr = args[1],
+                    selStart = args[2],
+                    selLength = args[3],
+                    pasteValue = args[4],
+                    pasteText = pasteValue.text ||
+                                pasteValue.html.replace(/<.*?>/g, ''),
+                    pasteRepr = JSON.stringify(pasteValue),
+                    type = inputFlag ? "expression" : "text",
+                    opts = {isExpression: true};
+                it("should paste " + type + ": " + pasteRepr, function (done) {
+                    var input_ = inputFlag ? exprInput : input,
+                        editor = richText.editor(input_),
+                        find = initialExpr.substring(selStart, selStart + selLength);
+                    editor.setValue(initialExpr, function () {
+                        editor.select(selStart, selLength);
+                        ckPaste(input_, pasteValue, function (text) {
+                            assert.equal(text, richText
+                                .toRichText(initialExpr, form, opts)
+                                .replace(find, escapeHTML(pasteText)));
+                            assert.equal(editor.getValue(),
+                                initialExpr.substring(0, selStart) + pasteText +
+                                initialExpr.substring(selStart + selLength));
+                            done();
+                        });
+                    });
+                });
+            });
+
             function applyArgs(func) {
                 return function (args) {
                     return func.apply(this, args);


### PR DESCRIPTION
![cut copy paste logic expressions](https://cloud.githubusercontent.com/assets/464726/26007103/21636570-370d-11e7-973b-30ed26aa1d6c.gif)
*You have to imagine where I'm pressing CTRL+C and CTRL+V

This uncovered more edge cases than I had hoped. CKEditor has a lot of rough edges that make the editing experience annoying, and our integration is getting more tightly coupled with its internals as we try to address issues like this.

Tested in Chrome and Firefox.

@emord @orangejenny 