### PR TITLE
Fix errors related to chai upgrade

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,7 +46,7 @@
     },
     "devDependencies": {
         "equivalent-xml-js": "mwhite/equivalent-xml-js#master",
-        "chai": ">4.0.0",
+        "chai": "^4.0.0",
         "xrayquire": "requirejs/xrayquire"
     }
 }

--- a/bower.json
+++ b/bower.json
@@ -46,7 +46,7 @@
     },
     "devDependencies": {
         "equivalent-xml-js": "mwhite/equivalent-xml-js#master",
-        "chai": ">=1.5.0",
+        "chai": ">4.0.0",
         "xrayquire": "requirejs/xrayquire"
     }
 }

--- a/tests/logic.js
+++ b/tests/logic.js
@@ -399,7 +399,7 @@ define([
 
             function compareHashtags(expr, expected) {
                 var tags = _.map(expr.getHashtags(), getHashtags);
-                assert.sameMembers(tags, expected.hashtags);
+                assert.includeMembers(tags, expected.hashtags);
             }
 
             _.each(hashtags, function(hashtag) {

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -233,7 +233,7 @@ define([
                     'case_name': 'name'
                 }
             });
-            assert.include(mug.options.getBindList(mug), {
+            assert.deepInclude(mug.options.getBindList(mug), {
                 nodeset: mug.absolutePath + "/case/@case_id",
                 calculate: 'uuid()'
             });


### PR DESCRIPTION
`assert.sameMembers(["#form/text2","#form/text1","#form/text2"], ["#form/text1","#form/text2"])`
-  Before (chai 3.5.0) -> pass
- After (chai 4.0.1)  -> fail
- Replace with `assert.includeMembers`

`assert.include([{a: 1}], {a: 1})`
- Before (chai 3.5.0) -> pass
- After (chai 4.0.1)  -> fail
- Replace with `assert.deepInclude` (new in Chai 4)

@orangejenny @emord 