### PR TITLE
Reload fuse data on enable easy references

### DIFF
--- a/src/fuse.js
+++ b/src/fuse.js
@@ -20,6 +20,7 @@ define([
 
         form.vellum.datasources.on("change", function() {
             _this.dataset = generateNewFuseData(form);
+            _this.fusejs.set(_this.dataset);
         }, null, null, form);  // context=form for form.disconnectDataSources()
 
         if (!this.dataset) {

--- a/src/fuse.js
+++ b/src/fuse.js
@@ -23,6 +23,13 @@ define([
             _this.fusejs.set(_this.dataset);
         }, null, null, form);  // context=form for form.disconnectDataSources()
 
+        form.on("change", function(event) {
+            if (event.mug === undefined) {
+                _this.dataset = generateNewFuseData(form);
+                _this.fusejs.set(_this.dataset);
+            }
+        });
+
         if (!this.dataset) {
             this.dataset = generateNewFuseData(form);
         }

--- a/tests/form.js
+++ b/tests/form.js
@@ -429,6 +429,14 @@ define([
                 assert(form.isValidHashtag("#case/dob"), "not valid: #case/dob");
                 assert(form.isValidHashtag("#form/text"), "not valid: #form/text");
             });
+
+            it("should update fuse on enabling rich text", function () {
+                var form = util.loadXML("");
+                form.fire("form-load-finished");
+                assert.deepEqual(form.fuse.list(), []);
+                form.setAttr("richText", true);
+                assert.notDeepEqual(form.fuse.list(), []);
+            });
         });
 
         describe("naming logic", function () {

--- a/tests/form.js
+++ b/tests/form.js
@@ -402,6 +402,14 @@ define([
                 callback(util.options.dataSources);
                 assert.isOk(form.hasCaseHashtags);
             });
+
+            it("should update fuse when data sources are loaded", function () {
+                var form = util.loadXML("");
+                form.fire("form-load-finished");
+                assert.deepEqual(form.fuse.list(), []);
+                callback(util.options.dataSources);
+                assert.notDeepEqual(form.fuse.list(), []);
+            });
         });
 
         describe("with rich text disabled", function() {

--- a/tests/main.js
+++ b/tests/main.js
@@ -172,6 +172,12 @@ requirejs(['jquery', 'jquery.vellum'], function ($) {
         if (mocha.env) {
             // ensure the first instance is fully loaded before running tests
             load("", function () { mocha.run(); });
+        } else if (/[?&]load=saved(&|#|$)/.test(window.location.href)) {
+            // Use Chrome dev tools to preset form XML
+            // (Application > Storage > Session Storage > http://localhost...
+            //  > vellum.tests.main.lastSavedForm value)
+            // and then add ?load=saved to query string and reload.
+            load(session.getItem("vellum.tests.main.lastSavedForm") || "");
         } else {
             load(""); // load empty form on initial page load
         }


### PR DESCRIPTION
Earlier today while editing a form loaded with easy references disabled I noticed that I could not auto-complete case references after turning on easy references.

@emord @orangejenny 