### PR TITLE
i18n

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -15,5 +15,9 @@
     "nonew": true,
     "undef": true,
     "unused": "vars",
-    "globals": {"define": false}
+    "globals": {
+        "define": false,
+        "gettext": false,
+        "ngettext": false
+    }
 }

--- a/buildmain.py
+++ b/buildmain.py
@@ -62,6 +62,13 @@ requirejs.config({
 define('css/css', {});
 define('less/less', {});
 
+if (!window.gettext) {
+    window.gettext = function (arg) { return arg; };
+    window.ngettext = function (singular, plural, count) {
+        return count === 1 ? singular : plural;
+    };
+}
+
 define([
     'jquery',
     %(main_components)s

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <link href="node_modules/mocha/mocha.css" type="text/css" rel="stylesheet"></link>
     <script src="node_modules/mocha/mocha.js"></script>
 
+    <script src="tests/typoglycemia.js"></script>
     <script data-main="tests/main" src="bower_components/requirejs/require.js"></script>
     <script src="bower_components/xrayquire/xrayquire.js"></script>
     <script>mocha.setup('bdd');</script>

--- a/src/commtrack.js
+++ b/src/commtrack.js
@@ -64,8 +64,12 @@ define([
             ],
             help: {
                 title: gettext("Basic"),
-                text: gettext("<p>The <strong>Question ID</strong> is an internal identifier for a question. " +
-                    "It does not appear on the phone. It is the name of the question in data exports.</p>"),
+                text: "<p>" + util.format(
+                    gettext("The {questionid} is an internal identifier for " +
+                            "a question. It does not appear on the phone. It " +
+                            "is the name of the question in data exports."),
+                    {questionid: "<strong>" + gettext("Question ID") + "</strong>"}
+                ) + "</p>",
                 link: "https://help.commcarehq.org/display/commcarepublic/Transactions",
             },
         },

--- a/src/commtrack.js
+++ b/src/commtrack.js
@@ -52,7 +52,7 @@ define([
         },
         basicSection = {
             slug: "main",
-            displayName: "Basic",
+            displayName: gettext("Basic"),
             properties: [
                 "nodeID",
                 "src",
@@ -63,20 +63,20 @@ define([
                 "date",
             ],
             help: {
-                title: "Basic",
-                text: "<p>The <strong>Question ID</strong> is an internal identifier for a question. " +
-                    "It does not appear on the phone. It is the name of the question in data exports.</p>",
+                title: gettext("Basic"),
+                text: gettext("<p>The <strong>Question ID</strong> is an internal identifier for a question. " +
+                    "It does not appear on the phone. It is the name of the question in data exports.</p>"),
                 link: "https://help.commcarehq.org/display/commcarepublic/Transactions",
             },
         },
         logicSection = {
             slug: "logic",
-            displayName: "Logic",
+            displayName: gettext("Logic"),
             help: {
-                title: "Logic",
-                text: "Use logic to control when questions are asked and what answers are valid. " +
+                title: gettext("Logic"),
+                text: gettext("Use logic to control when questions are asked and what answers are valid. " +
                     "You can add logic to display a question based on a previous answer, to make " +
-                    "the question required or ensure the answer is in a valid range.",
+                    "the question required or ensure the answer is in a valid range."),
                 link: "https://confluence.dimagi.com/display/commcarepublic/Common+Logic+and+Calculations"
             },
             properties: [
@@ -137,42 +137,42 @@ define([
             isHashtaggable: false,
             spec: {
                 date: {
-                    lstring: 'Date',
+                    lstring: gettext('Date'),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.xPath,
                     xpathType: 'generic',
                     serialize: mugs.serializeXPath,
                     deserialize: mugs.deserializeXPath,
-                    help: 'The date and time of the action, e.g., now() or today()',
+                    help: gettext('The date and time of the action, e.g., now() or today()'),
                 },
                 sectionId: {
-                    lstring: 'Balance ID',
+                    lstring: gettext('Balance ID'),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.text,
-                    help: 'The name of the balance you are tracking. ' + 
-                         'This is an internal identifier which does not appear on the phone.',
+                    help: gettext('The name of the balance you are tracking. ' +
+                         'This is an internal identifier which does not appear on the phone.'),
                 },
                 entryId: {
-                    lstring: 'Product',
+                    lstring: gettext('Product'),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.xPath,
                     xpathType: "generic",
                     serialize: mugs.serializeXPath,
                     deserialize: mugs.deserializeXPath,
-                    help: 'A reference to a product ID, e.g., "/data/products/current_product"',
+                    help: gettext('A reference to a product ID, e.g., "/data/products/current_product"'),
                 },
                 quantity: {
-                    lstring: 'Quantity',
+                    lstring: gettext('Quantity'),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.xPath,
                     xpathType: "generic",
                     serialize: mugs.serializeXPath,
                     deserialize: mugs.deserializeXPath,
-                    help: 'A reference to an integer question in this form.',
+                    help: gettext('A reference to an integer question in this form.'),
                 },
                 relevantAttr: {
                     visibility: 'visible',
@@ -181,7 +181,7 @@ define([
                     xpathType: "bool",
                     serialize: mugs.serializeXPath,
                     deserialize: mugs.deserializeXPath,
-                    lstring: 'Display Condition'
+                    lstring: gettext('Display Condition')
                 },
             },
             getSetValues: function (mug) {
@@ -236,14 +236,14 @@ define([
                     serialize: serializeNodeId
                 },
                 entityId: {
-                    lstring: 'Case',
+                    lstring: gettext('Case'),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.xPath,
                     xpathType: "generic",
                     serialize: mugs.serializeXPath,
                     deserialize: mugs.deserializeXPath,
-                    help: 'XPath expression for the case ID associated with this balance.',
+                    help: gettext('XPath expression for the case ID associated with this balance.'),
                 },
                 requiredAttr: { presence: "notallowed" },
                 constraintAttr: { presence : "notallowed" },
@@ -253,8 +253,8 @@ define([
         transferMugValidation = function (mug) {
             var error = {key: "commtrack-transfer-src-dest-error", level: mug.ERROR};
             if (!mug.p.dest || !mug.p.src) {
-                error.message = 'Transfer must have both Source Case and ' +
-                                'Destination Case defined.';
+                error.message = gettext('Transfer must have both Source Case and ' +
+                                'Destination Case defined.');
             }
             mug.addMessages({src: [error], dest: [error]});
             return 'pass';
@@ -269,7 +269,7 @@ define([
                         isTransaction({__className: typeName})) {
                     return "";
                 }
-                return "Cannot change $1 to $2"
+                return gettext("Cannot change $1 to $2")
                         .replace("$1", mug.__className)
                         .replace("$2", typeName);
             },
@@ -313,25 +313,25 @@ define([
                     deserialize: function () {}
                 },
                 src: {
-                    lstring: 'Source Case',
+                    lstring: gettext('Source Case'),
                     visibility: 'visible',
                     presence: 'required',
                     widget: widgets.xPath,
                     xpathType: "generic",
                     serialize: mugs.serializeXPath,
                     deserialize: mugs.deserializeXPath,
-                    help: 'XPath expression for the case ID issuing the transaction.',
+                    help: gettext('XPath expression for the case ID issuing the transaction.'),
                     validationFunc: transferMugValidation,
                 },
                 dest: {
-                    lstring: 'Destination Case',
+                    lstring: gettext('Destination Case'),
                     visibility: 'visible',
                     presence: 'required',
                     widget: widgets.xPath,
                     xpathType: "generic",
                     serialize: mugs.serializeXPath,
                     deserialize: mugs.deserializeXPath,
-                    help: 'XPath expression for the case ID receiving the transaction.',
+                    help: gettext('XPath expression for the case ID receiving the transaction.'),
                     validationFunc: transferMugValidation,
                 },
                 requiredAttr: { presence: "notallowed" },
@@ -348,7 +348,7 @@ define([
                         if (mug.p.src) {
                             return 'pass';
                         }
-                        return 'Dispense must have a Source Case.';
+                        return gettext('Dispense must have a Source Case.');
                     },
                 },
                 dest: { presence: "notallowed" },
@@ -364,7 +364,7 @@ define([
                         if (mug.p.dest) {
                             return 'pass';
                         }
-                        return 'Receive must have a Destination Case.';
+                        return gettext('Receive must have a Destination Case.');
                     },
                 },
             }

--- a/src/copy-paste.js
+++ b/src/copy-paste.js
@@ -4,6 +4,7 @@ define([
     'tpl!vellum/templates/copy_paste_help',
     'vellum/mugs',
     'vellum/tsv',
+    'vellum/util',
     'vellum/analytics',
     'vellum/core'
 ], function (
@@ -12,6 +13,7 @@ define([
     copy_paste_help,
     mugs,
     tsv,
+    util,
     analytics
 ) {
     var PREAMBLE = ["Form Builder clip", "version 1"],
@@ -360,7 +362,10 @@ define([
                 copyPasteBox.removeClass("hide");
                 copyPasteArea.val(copy(true));
             }
-            var html = $(copy_paste_help({"metachar": (isMac ? "\u2318" : "Ctrl+")})),
+            var html = $(copy_paste_help({
+                    "metachar": (isMac ? "\u2318" : "Ctrl+"),
+                    "format": util.format,
+                })),
                 copyPasteHelp = html.find(".copy-paste-help"),
                 copyPasteBox = html.find(".copy-paste-box"),
                 copyPasteArea = copyPasteBox.find("textarea");

--- a/src/copy-paste.js
+++ b/src/copy-paste.js
@@ -167,10 +167,12 @@ define([
         if (!pos) {
             pos = {};
             if (!node.mug) {
-                pos.error = "Cannot insert " +
-                            nameOf(values.type) + " into tree root";
+                pos.error = util.format(
+                    gettext("Cannot insert {type} into tree root"),
+                    {type: nameOf(values.type)}
+                );
             } else {
-                pos.error = "Cannot insert $1 into or after $2"
+                pos.error = gettext("Cannot insert $1 into or after $2")
                         .replace("$1", nameOf(values.type))
                         .replace("$2", nameOf(node.mug.__className));
             }
@@ -179,7 +181,7 @@ define([
             while (node.mug !== pos.mug) {
                 if (!node.parent) {
                     // valid insertion point was outside of the paste root
-                    pos.error = "Cannot insert $1 into $2"
+                    pos.error = gettext("Cannot insert $1 into $2")
                         .replace("$1", nameOf(values.type))
                         .replace("$2", nameOf(node.mug.parentMug.__className));
                     return pos;
@@ -265,7 +267,7 @@ define([
         analytics.workflow("Paste questions in form builder");
         var next = tsv.makeRowParser(data);
         if (!_.isEqual(next().slice(0, 2), PREAMBLE)) {
-            return ["Unsupported paste format"];
+            return [gettext("Unsupported paste format")];
         }
         var types = vellum.data.core.mugTypes.allTypes,
             form = vellum.data.core.form,
@@ -292,11 +294,11 @@ define([
                     return valuify(str);
                 }));
             } catch (err) {
-                errors.add("Unsupported paste format: " + row.join(", "));
+                errors.add(gettext("Unsupported paste format:") + " " + row.join(", "));
                 continue;
             }
             if (!types.hasOwnProperty(values.type)) {
-                errors.add("Unknown question type: " + row.join(", "));
+                errors.add(gettext("Unknown question type:") + " " + row.join(", "));
                 continue;
             }
             pos = getInsertTargetAndPosition(node, values);

--- a/src/core.js
+++ b/src/core.js
@@ -99,17 +99,17 @@ define([
     var MESSAGE_TYPES = {
         "error": {
             cssClass: "alert-danger",
-            title: "Error",
+            title: gettext("Error"),
             icon: "fa fa-exclamation-circle",
         },
         "parse-warning": {
             cssClass: "",
-            title: "Warning",
+            title: gettext("Warning"),
             icon: "fa fa-warning",
         },
         "form-warning": {
             cssClass: "",
-            title: "Form Warning",
+            title: gettext("Form Warning"),
             icon: "fa fa-info-circle",
         }
     };
@@ -135,9 +135,9 @@ define([
             save: function(event) {
                 var forceFullSave = event && event.altKey;
                 if (forceFullSave &&
-                    !window.confirm("Holding the ALT key while clicking save " +
+                    !window.confirm(gettext("Holding the ALT key while clicking save " +
                             "invokes an inefficient save procedure. Do " +
-                            "this only if a normal save fails.")) {
+                            "this only if a normal save fails."))) {
                     return; // abort
                 }
                 _this.ensureCurrentMugIsSaved(function () {
@@ -145,29 +145,35 @@ define([
                     _this.validateAndSaveXForm(forceFullSave);
                 });
             },
-            unsavedMessage: 'Are you sure you want to exit? All unsaved changes will be lost!',
+            unsavedMessage: gettext('Are you sure you want to exit? All unsaved changes will be lost!'),
             csrftoken: _this.opts().csrftoken
         });
 
         var validateForSave = _.debounce(function () {
-            var form = _this.data.core.form;
+            var form = _this.data.core.form,
+                template = "<div class='alert alert-danger'>{error}<br/>{action}</div>",
+                icon = "<i class='fd-valid-alert-icon fa fa-warning'></i>",
+                action;
             if (form.hasBrokenReferences()) {
+                action = gettext("Look for questions marked with $1 and " +
+                    "check they don't reference deleted questions.");
                 return {
-                    title: "Errors in Form",
-                    content: "<div class='alert alert-danger'>Form has " +
-                        "reference errors.<br>Look for questions marked with " +
-                        "<i class='fd-valid-alert-icon fa fa-warning'></i> " +
-                        "and check they don't reference deleted questions.</div>",
+                    title: gettext("Errors in Form"),
+                    content: util.format(template, {
+                        error: gettext("Form has reference errors."),
+                        action: action.replace('$1', icon),
+                    }),
                 };
             } else if (!_this.isCurrentlySelectedMugValid()) {
+                action = gettext("Look for questions marked with $1 and fix the errors.");
                 // TODO make a more efficient way to check if any mug in the
                 // form is not valid and use that instead of only current mug.
                 return {
                     title: "Validation Failed",
-                    content: "<div class='alert alert-danger'>Form has " +
-                        "validation errors.<br>Look for questions marked with " +
-                        "<i class='fd-valid-alert-icon fa fa-warning'></i> " +
-                        "and fix the errors.</div>",
+                    content: util.format(template, {
+                        error: gettext("Form has validation errors."),
+                        action: action.replace('$1', icon),
+                    }),
                 };
             } else {
                 return {title: "", content: ""};
@@ -324,11 +330,11 @@ define([
                 questions: ["Text"],
             },
             {
-                group: ["Select", 'Multiple Choice'],
+                group: ["Select", gettext('Multiple Choice')],
                 questions: ["Select", "MSelect"],
             },
             {
-                group: ["Int", 'Number'],
+                group: ["Int", gettext('Number')],
                 questions: [
                     "Int",
                     "PhoneNumber",
@@ -336,7 +342,7 @@ define([
                 ]
             },
             {
-                group: ["Date", 'Date'],
+                group: ["Date", gettext('Date')],
                 questions: [
                     "Date",
                     "Time",
@@ -344,7 +350,7 @@ define([
                 ]
             },
             {
-                group: ["Group", 'Groups'],
+                group: ["Group", gettext('Groups')],
                 questions: [
                     "Group",
                     "Repeat",
@@ -352,7 +358,7 @@ define([
                 ]
             },
             {
-                group: ["Image", 'Multimedia Capture'],
+                group: ["Image", gettext('Multimedia Capture')],
                 questions: [
                     "Image",
                     "Audio",
@@ -365,13 +371,13 @@ define([
                 questions: ["Trigger"],
             },
             {
-                group: ["DataBindOnly", 'Hidden Value'],
+                group: ["DataBindOnly", gettext('Hidden Value')],
                 questions: [
                     "DataBindOnly"
                 ]
             },
             {
-                group: ["Geopoint", 'Advanced', ''],
+                group: ["Geopoint", gettext('Advanced'), ''],
                 textOnly: true,
                 questions: this.getAdvancedQuestions()
             }
@@ -438,17 +444,20 @@ define([
 
     fn.toggleFullScreen = function () {
         var _this = this,
+            expand = gettext("Expand Editor"),
+            shrink = gettext("Shrink Editor"),
+            expandOrShrink = new RegExp(RegExp.escape(expand) + "|" + RegExp.escape(shrink)),
             $fullScreenMenuItem = $(_.find(_this.$f.find('.fd-tools-menu').nextAll(), function(li) {
-                return $(li).find("a").text().match(/(expand|shrink) editor/i);
+                return $(li).find("a").text().match(expandOrShrink);
             })).find("a"),
             html = $fullScreenMenuItem.html();
         analytics.fbUsage("Full Screen Mode", _this.opts().core.formid);
         if (_this.data.windowManager.fullscreen) {
             _this.data.windowManager.fullscreen = false;
-            $fullScreenMenuItem.html(html.replace(/Shrink/, "Expand"));
+            $fullScreenMenuItem.html(html.replace(new RegExp(RegExp.escape(shrink)), expand));
         } else {
             _this.data.windowManager.fullscreen = true;
-            $fullScreenMenuItem.html(html.replace(/Expand/, "Shrink"));
+            $fullScreenMenuItem.html(html.replace(new RegExp(RegExp.escape(expand)), shrink));
         }
         $fullScreenMenuItem.find("i").toggleClass("fa-compress").toggleClass("fa-expand");
         _this.adjustToWindow();
@@ -462,35 +471,35 @@ define([
             shortcut = "<span class='hotkey'>" + HOTKEY_UNICODE.shift + HOTKEY_UNICODE.ctrl + "F</span>";
         return [
             {
-                name: 'Expand Editor' + shortcut,
+                name: gettext('Expand Editor') + shortcut,
                 icon: "fa fa-expand",
                 action: function (done) {
                     _this.toggleFullScreen();
                 }
             },
             {
-                name: "Export Form Contents",
+                name: gettext("Export Form Contents"),
                 icon: "fa fa-file-excel-o",
                 action: function (done) {
                     _this.showExportModal(done);
                 }
             },
             {
-                name: "Edit Source XML",
+                name: gettext("Edit Source XML"),
                 icon: "fa fa-edit",
                 action: function (done) {
                     _this.showSourceXMLModal(done);
                 }
             },
             {
-                name: "Form Properties",
+                name: gettext("Form Properties"),
                 icon: "fa fa-list-alt",
                 action: function (done) {
                     _this.showFormPropertiesModal(done);
                 }
             },
             {
-                name: "Find Usages",
+                name: gettext("Find Usages"),
                 icon: "fa fa-search",
                 action: function (done) {
                     _this.findUsages(done);
@@ -554,12 +563,12 @@ define([
             $modal, $updateForm, $textarea, codeMirror,
             warn = !this.data.core.form.isFormValid(validateMug) ?
                 " <i class='fd-valid-alert-icon fa fa-warning' /> " +
-                "Validation failed. Form may not perform correctly on your " +
-                "device!" : "";
+                gettext("Validation failed. Form may not perform correctly on your device!") :
+                "";
 
-        $modal = this.generateNewModal("Edit Form's Source XML" + warn, [
+        $modal = this.generateNewModal(gettext("Edit Form's Source XML") + warn, [
             {
-                title: "Update Source",
+                title: gettext("Update Source"),
                 cssClasses: "btn-primary",
                 action: function () {
                     codeMirror.save();
@@ -571,8 +580,9 @@ define([
             }
         ]);
         $updateForm = $(edit_source({
-            description: "This is the raw XML. You can edit or paste into this box to make changes " +
-                         "to your form. Press 'Update Source' to save changes, or 'Close' to cancel."
+            description: gettext("This is the raw XML. You can edit or paste " +
+                "into this box to make changes to your form. Press 'Update " +
+                "Source' to save changes, or 'Close' to cancel.")
         }));
 
         $modal.addClass('fd-full-screen-modal')
@@ -611,10 +621,11 @@ define([
         var $modal,
             $exportForm;
 
-        $modal = this.generateNewModal("Export Form Contents", []);
+        $modal = this.generateNewModal(gettext("Export Form Contents"), []);
         $exportForm = $(edit_source({
-            description: "Copy and paste this content into a spreadsheet program like Excel " +
-                         "to easily share your form with others."
+            description: gettext("Copy and paste this content into a " +
+                "spreadsheet program like Excel to easily share your " +
+                "form with others.")
         }));
         $modal.find('.modal-body').html($exportForm);
 
@@ -628,9 +639,9 @@ define([
     fn.showOverwriteWarning = function(send, formText, serverForm) {
         var $modal, $overwriteForm, _this = this;
 
-        $modal = _this.generateNewModal("Lost Work Warning", [
+        $modal = _this.generateNewModal(gettext("Lost Work Warning"), [
             {
-                title: "Overwrite their work",
+                title: gettext("Overwrite their work"),
                 cssClasses: "btn-primary",
                 defaultButton: true,
                 action: function () {
@@ -640,7 +651,7 @@ define([
                 }
             },
             {
-                title: "Show XML Differences",
+                title: gettext("Show XML Differences"),
                 cssClasses: "btn-info",
                 action: function () {
                     $('#form-differences').show();
@@ -654,14 +665,14 @@ define([
                     $modal.find('.btn-info').prop('disabled', true);
                 }
             }
-        ], "Cancel", "fa fa-warning");
+        ], gettext("Cancel"), "fa fa-warning");
 
         var diff = util.xmlDiff(formText, serverForm);
 
         $overwriteForm = $(confirm_overwrite({
-            description: "Looks like someone else has edited this form " +
+            description: gettext("Looks like someone else has edited this form " +
                          "since you loaded the page. Are you sure you want " +
-                         "to overwrite their work?",
+                         "to overwrite their work?"),
             xmldiff: util.escape(diff),
         }));
         $modal.find('.modal-body').html($overwriteForm);
@@ -674,11 +685,11 @@ define([
         // moved over just for display purposes, apparently the original
         // wasn't working perfectly, so this is a todo
         var _this = this,
-            $modal = this.generateNewModal("Edit Form Properties", []),
+            $modal = this.generateNewModal(gettext("Edit Form Properties"), []),
             $modalBody = $modal.find('.modal-body'),
             formProperties = [
                 {
-                    label: "Disable Text Formatting",
+                    label: gettext("Disable Text Formatting"),
                     slug: "noMarkdown",
                     type: "checkbox",
                     value: function(jq, val) {
@@ -689,7 +700,7 @@ define([
 
         if (this.opts().features.rich_text) {
             formProperties.push({
-                label: "Use Easy References",
+                label: gettext("Use Easy References"),
                 slug: "richText",
                 type: "checkbox",
                 value: function(jq, val) {
@@ -728,7 +739,7 @@ define([
 
     fn.findUsages = function () {
         var _this = this,
-            $modal = this.generateNewModal("Use of each question", []),
+            $modal = this.generateNewModal(gettext("Use of each question"), []),
             $modalBody = $modal.find('.modal-body'),
             form = _this.data.core.form,
             tableData = form.findUsages();
@@ -794,7 +805,7 @@ define([
     
     fn.generateNewModal = function (title, buttons, closeButtonTitle, headerIcon) {
         if (typeof closeButtonTitle === "undefined") {
-            closeButtonTitle = "Close";
+            closeButtonTitle = gettext("Close");
         }
         buttons.reverse();
         buttons = _.map(buttons, function (button) {
@@ -1183,9 +1194,9 @@ define([
 
         if (this.data.core.hasXPathEditorChanged) {
             this.alert(
-                "Unsaved Changes in Editor",
-                "You have UNSAVED changes in the Expression Editor. " +
-                "Please save changes before continuing.");
+                gettext("Unsaved Changes in Editor"),
+                gettext("You have UNSAVED changes in the Expression Editor. " +
+                        "Please save changes before continuing."));
             return false;
         } else {
             if (currentMug && !currentMug.p.nodeID) {
@@ -1247,12 +1258,13 @@ define([
                 // was a parse error
                 var msg = e.toString();
                 if (msg.indexOf("Invalid XML") === 0) {
-                    msg = "Parsing Error. Please check that your form is valid XML.";
+                    msg = gettext("Parsing Error. Please check that your form is valid XML.");
                 }
 
                 _this.hideQuestionProperties();
 
-                var $modal = _this.generateNewModal("Error", [], "OK", "fa fa-warning");
+                var $modal = _this.generateNewModal(
+                        gettext("Error"), [], gettext("OK"), "fa fa-warning");
                 $modal.find(".modal-body").text(msg);
                 $modal.modal('show');
 
@@ -1743,7 +1755,7 @@ define([
     };
 
     fn.displayXPathEditor = function(options) {
-        options.headerText = "Expression Editor";
+        options.headerText = gettext("Expression Editor");
         options.loadEditor = function($div, options) {
             require(['vellum/expressionEditor'], function (expressionEditor) {
                 expressionEditor.showXPathEditor($div, options);
@@ -1761,7 +1773,7 @@ define([
         var _this = this;
         this.data.core.isAlertVisible = true;
         if (!buttons.length) {
-            buttons.push({title: "OK", defaultButton: true});
+            buttons.push({title: gettext("OK"), defaultButton: true});
         }
 
         var $modal = this.generateNewModal(title, buttons, false, "fa fa-warning");
@@ -1962,7 +1974,7 @@ define([
             try {
                 _this.changeMugType(mug, $(this).data('qtype'));
             } catch (err) {
-                window.alert("Sorry, " + err);
+                window.alert(util.format(gettext("Sorry, {err}"), {err: err}));
             }
             e.preventDefault();
         });
@@ -1983,7 +1995,7 @@ define([
             tree.jstree(true).add_action(mug.ufid, {
                 "id": action_id,
                 "class": "fa fa-plus add_choice",
-                "text": " Add Choice",
+                "text": " " + gettext("Add Choice"),
                 "after": true,
                 "selector": "a",
                 "event": "click",
@@ -2013,15 +2025,15 @@ define([
                     errors: warnings,
                     displayLanguage: displayLanguage
                 }));
-            forAction = forAction ? " and " + forAction : "";
-            this.alert("There are errors in the form", message, [
+            forAction = forAction ? " " + gettext("and") + " " + forAction : "";
+            this.alert(gettext("There are errors in the form"), message, [
                 {
-                    title: "Fix Manually",
+                    title: gettext("Fix Manually"),
                     action: function () {
                         _this.data.core.$modal.modal('hide');
                     }
                 }, {
-                    title: "Fix Automatically" + forAction,
+                    title: gettext("Fix Automatically") + forAction,
                     cssClasses: 'btn-primary',
                     defaultButton: true,
                     action: function () {
@@ -2042,7 +2054,7 @@ define([
             _this.validateAndSaveXForm(forceFullSave);
         }
         var _this = this;
-        if (!this.canSerializeXForm("Save", retry)) {
+        if (!this.canSerializeXForm(gettext("Save"), retry)) {
             return; // validate/create XML failed
         }
         var formText = this.createXML();
@@ -2052,21 +2064,22 @@ define([
         } catch (err) {
             // something went wrong parsing, but maybe the user wants to save anyway
             // let's ask them with a scary message encouraging them not to.
-            var theScaryWarning = "It looks like your form is not valid XML. This can " +
+            var theScaryWarning = gettext(
+                "It looks like your form is not valid XML. This can " +
                 "often happen if you use a reserved character in one of your questions. " +
                 "Characters to look out for are <, >, and &. You can still save, but " +
                 "you CANNOT LOAD THIS FORM again until you fix the XML by hand. " +
-                "What would you like to do?";
-            var $modal = _this.generateNewModal("Form Validation Error", [
+                "What would you like to do?");
+            var $modal = _this.generateNewModal(gettext("Form Validation Error"), [
                 {
-                    title: 'Fix the problem (recommended)',
+                    title: gettext('Fix the problem (recommended)'),
                     cssClasses: "btn-primary",
                     action: function() {
                         _this.closeModal();
                     },
                 },
                 {
-                    title: 'Save anyway',
+                    title: gettext('Save anyway'),
                     cssClasses: "btn-default",
                     action: function() {
                         _this.closeModal();
@@ -2153,61 +2166,62 @@ define([
         return [
             {
                 slug: "main",
-                displayName: "Basic",
+                displayName: gettext("Basic"),
                 properties: this.getMainProperties(),
                 help: {
-                    title: "Basic",
-                    text: "<p>The <strong>Display Text</strong> appears in the application. " +
-                        "This text will not appear in data exports.</p> ",
+                    title: gettext("Basic"),
+                    text: "<p>" + gettext("The <strong>Display Text</strong> " +
+                        "appears in the application. This text will not " +
+                        "appear in data exports.") + "</p> ",
                     link: "https://confluence.dimagi.com/display/commcarepublic/Form+Builder"
                 }
             },
             {
                 slug: "data_source",
-                displayName: "Data Source",
+                displayName: gettext("Data Source"),
                 properties: this.getDataSourceProperties(),
                 isCollapsed: true,
                 help: {
-                    title: "Data Source",
-                    text: "You can configure an external data source like a " +
+                    title: gettext("Data Source"),
+                    text: gettext("You can configure an external data source like a " +
                         "case list or lookup table to use as the choices for " +
-                        "a multiple choice question."
+                        "a multiple choice question.")
                 }
             },
             {
                 slug: "logic",
-                displayName: "Logic",
+                displayName: gettext("Logic"),
                 properties: this.getLogicProperties(),
                 isCollapsed: true,
                 help: {
-                    title: "Logic",
-                    text: "Use logic to control when questions are asked and what answers are valid. " +
+                    title: gettext("Logic"),
+                    text: gettext("Use logic to control when questions are asked and what answers are valid. " +
                         "You can add logic to display a question based on a previous answer, to make " +
-                        "the question required or ensure the answer is in a valid range.",
+                        "the question required or ensure the answer is in a valid range."),
                     link: "https://confluence.dimagi.com/display/commcarepublic/Common+Logic+and+Calculations"
                 }
             },
             {
-                displayName: "Media",
+                displayName: gettext("Media"),
                 slug: "content",
                 properties: this.getMediaProperties(),
                 isCollapsed: true,
                 help: {
-                    title: "Media",
-                    text: "This will allow you to add images, audio or video media to a question, or other custom content.",
+                    title: gettext("Media"),
+                    text: gettext("This will allow you to add images, audio or video media to a question, or other custom content."),
                     link: "https://confluence.dimagi.com/display/commcarepublic/Multimedia+in+CommCare"
                 }
             },
             {
                 slug: "advanced",
                 type: "accordion",
-                displayName: "Advanced",
+                displayName: gettext("Advanced"),
                 properties: this.getAdvancedProperties(),
                 isCollapsed: true,
                 help: {
-                    title: "Advanced",
-                    text: "These are advanced settings and are not needed for most applications.  " +
-                        "Please only change these if you have a specific need!",
+                    title: gettext("Advanced"),
+                    text: gettext("These are advanced settings and are not needed for most applications.  " +
+                        "Please only change these if you have a specific need!"),
                     link: "https://confluence.dimagi.com/display/commcarepublic/Application+Building"
                 }
             }

--- a/src/core.js
+++ b/src/core.js
@@ -196,7 +196,8 @@ define([
         this.data.core.lastSavedXForm = this.opts().core.form;
 
         this.$f.addClass('formdesigner');
-        this.$f.empty().append(main_template(HOTKEY_UNICODE));
+        var mainVars = _.extend({format: util.format}, HOTKEY_UNICODE);
+        this.$f.empty().append(main_template(mainVars));
         $(document).on("keydown", function (e) {
             var ctrlKey = (isMac && e.metaKey) || (!isMac && e.ctrlKey),
                 metaKey = (isMac && e.ctrlKey) || (!isMac && e.metaKey),

--- a/src/core.js
+++ b/src/core.js
@@ -67,7 +67,6 @@ define([
     atwho,
     debug
 ) {
-    
     // Load these modules in the background after all runtime dependencies have
     // been resolved, since they're not needed initially.
     setTimeout(function () {

--- a/src/core.js
+++ b/src/core.js
@@ -2170,9 +2170,12 @@ define([
                 properties: this.getMainProperties(),
                 help: {
                     title: gettext("Basic"),
-                    text: "<p>" + gettext("The <strong>Display Text</strong> " +
-                        "appears in the application. This text will not " +
-                        "appear in data exports.") + "</p> ",
+                    text: "<p>" + util.format(
+                        gettext("The {displaytext} " +
+                            "appears in the application. This text will not " +
+                            "appear in data exports."),
+                        {displaytext: "<strong>" + gettext("Display Text") + "</strong>"}
+                    ) + "</p> ",
                     link: "https://confluence.dimagi.com/display/commcarepublic/Form+Builder"
                 }
             },

--- a/src/dataSourceWidgets.js
+++ b/src/dataSourceWidgets.js
@@ -136,7 +136,7 @@ define([
      *      setSource(source, mug) - Saves the source from the advanced editor
      */
     function fixtureWidget(mug, options, labelText) {
-        var CUSTOM_XML = "Lookup table was not found in the project",
+        var CUSTOM_XML = gettext("Lookup table was not found in the project"),
             EMPTY_VALUE = JSON.stringify({src: "", id: "", query: ""});
 
         function isEmptyValue(val) {
@@ -168,7 +168,7 @@ define([
             hasValue = false;
 
         widget.options.richText = false;
-        widget.addOption(EMPTY_VALUE, "Loading...");
+        widget.addOption(EMPTY_VALUE, gettext("Loading..."));
         var disconnect = mug.form.vellum.datasources.onChangeReady(function () {
             var data = mug.form.vellum.datasources.getDataSources(),
                 value;

--- a/src/datasources.js
+++ b/src/datasources.js
@@ -209,7 +209,7 @@ define([
                 id: "",
                 uri: "",
                 path: "",
-                name: "Not Found",
+                name: gettext("Not Found"),
                 structure: {}
             }]};
             that.loading = false;

--- a/src/dateformats.js
+++ b/src/dateformats.js
@@ -7,7 +7,7 @@ define([
 ){
     function showMenu(x, y, callback, hideOnLeave) {
         var formats = {
-                "": "No Formatting",
+                "": gettext("No Formatting"),
                 "%e/%n/%y": "d/m/yy e.g. 30/1/14",
                 "%a, %b %e, %Y": "ddd, mmm d, yyyy e.g. Thu, Jan 30, 2014"
             };

--- a/src/expressionEditor.js
+++ b/src/expressionEditor.js
@@ -42,8 +42,8 @@ define([
             validate = _.partial(validateXPath, form),
             saveButton;
         options = _.defaults(options, {
-            leftPlaceholder: "Drag question here",
-            rightPlaceholder: "Drag question here",
+            leftPlaceholder: gettext("Drag question here"),
+            rightPlaceholder: gettext("Drag question here"),
         });
 
         var handleChange = function () {
@@ -86,13 +86,13 @@ define([
             operationOpts.push([label, value]);
         }
 
-        addOp(BinOpHandler, expTypes.EQ, "is equal to");
-        addOp(BinOpHandler, expTypes.NEQ, "is not equal to");
-        addOp(BinOpHandler, expTypes.LT, "is less than");
-        addOp(BinOpHandler, expTypes.LTE, "is less than or equal to");
-        addOp(BinOpHandler, expTypes.GT, "is greater than");
-        addOp(BinOpHandler, expTypes.GTE, "is greater than or equal to");
-        addOp(FunctionHandler, "selected", "has selected value");
+        addOp(BinOpHandler, expTypes.EQ, gettext("is equal to"));
+        addOp(BinOpHandler, expTypes.NEQ, gettext("is not equal to"));
+        addOp(BinOpHandler, expTypes.LT, gettext("is less than"));
+        addOp(BinOpHandler, expTypes.LTE, gettext("is less than or equal to"));
+        addOp(BinOpHandler, expTypes.GT, gettext("is greater than"));
+        addOp(BinOpHandler, expTypes.GTE, gettext("is greater than or equal to"));
+        addOp(FunctionHandler, "selected", gettext("has selected value"));
 
         var getExpressionInput = function () {
             return $div.find(".fd-xpath-editor-text");
@@ -419,8 +419,8 @@ define([
 
             var $xpathUI = $(xpath_tpl({
                 topLevelJoinOpts: [
-                    ["True when ALL of the expressions are true.", expTypes.AND],
-                    ["True when ANY of the expressions are true.", expTypes.OR]
+                    [gettext("True when ALL of the expressions are true."), expTypes.AND],
+                    [gettext("True when ANY of the expressions are true."), expTypes.OR]
                 ],
                 tag: tag,
                 tagArgs: tagArgs,

--- a/src/form.js
+++ b/src/form.js
@@ -126,7 +126,7 @@ define([
         this.vellum = vellum;
         this.mugTypes = mugTypes;
 
-        this.formName = vellum.opts().core.formName || "New Form";
+        this.formName = vellum.opts().core.formName || gettext("New Form");
         this.noMarkdown = false;
         this.mugMap = {};
         this.instanceMetadata = [InstanceMetadata({})];

--- a/src/ignoreButRetain.js
+++ b/src/ignoreButRetain.js
@@ -274,10 +274,10 @@ define([
                     ],
                     isCollapsed: true,
                     help: {
-                        title: "Advanced",
-                        text: "This question represents advanced content " +
+                        title: gettext("Advanced"),
+                        text: gettext("This question represents advanced content " +
                           "that is not supported by the form builder. Please " +
-                          "only change it if you have a specific need!"
+                          "only change it if you have a specific need!")
                     }
                 }];
             }
@@ -312,7 +312,7 @@ define([
     });
 
     var IgnoredQuestion = {
-            typeName: "Ignored XML",
+            typeName: gettext("Ignored XML"),
             icon: 'fa fa-question-circle',
             isTypeChangeable: false,
             isRemoveable: false,

--- a/src/intentManager.js
+++ b/src/intentManager.js
@@ -210,7 +210,7 @@ define([
     }
 
     var AndroidIntent = util.extend(mugs.defaultOptions, {
-        typeName: 'Android App Callout',
+        typeName: gettext('Android App Callout'),
         dataType: 'intent',
         tagName: 'input',
         icon: 'fcc fcc-fd-android-intent',
@@ -220,11 +220,11 @@ define([
         },
         spec: {
             androidIntentAppId: {
-                lstring: 'External App',
+                lstring: gettext('External App'),
                 visibility: 'visible',
                 widget: intentAppIdWidget,
                 noCustom: true,
-                placeholder: 'Insert Android Application ID',
+                placeholder: gettext('Insert Android Application ID'),
                 deserialize: function (data, key, mug) {
                     if (data.intent) {
                         // support old format for now
@@ -255,19 +255,22 @@ define([
                     var opts = mug.form.vellum.opts(),
                         features = opts.features,
                         link = opts.core.externalLinks.changeSubscription,
-                        text = link ? "[change your subscription](" + link + ")" : "change your subscription";
+                        text = link ? "[" + gettext("change your subscription") +
+                            "](" + link + ")" : gettext("change your subscription");
                     if (noIntents(features)) {
-                        return "You no longer have access to built in or external integration in your application.\n\n" +
+                        return util.format(gettext(
+                            "You no longer have access to built in or external integration in your application.\n\n" +
                             "Built in integrations are available on the Pro plan and higher. " +
                             "External integrations are available on the Advanced plan and higher. " +
                             "Before you can make a new version of your application, " +
-                            "you must " + text + " or delete this question.";
+                            "you must {link} or delete this question."), {link: text});
                     } else if (onlyTemplatedIntents(features) &&
                                valueNotInIntentTemplates(mug.p.androidIntentAppId)) {
-                         return "Your subscription only has access to built-in integration.\n\n" +
-                             "External integrations are available on the Advanced plan and higher. " +
-                             "Before you can make a new version of your application, " +
-                             "you must " + text + " or delete this question.";
+                        return util.format(gettext(
+                            "Your subscription only has access to built-in integration.\n\n" +
+                            "External integrations are available on the Advanced plan and higher. " +
+                            "Before you can make a new version of your application, " +
+                            "you must {link} or delete this question."), {link: text});
                     }
 
                     // Validate that IDs are unique across app callouts
@@ -284,7 +287,7 @@ define([
                                 changed = i.messages.update("nodeID", {
                                     key: "intent-nodeID-duplicate",
                                     level: i.ERROR,
-                                    message: "Android app callouts of the same type must have different question ids.",
+                                    message: gettext("Android app callouts of the same type must have different question ids."),
                                 });
                             } else {
                                 changed = i.dropMessage("nodeID", "intent-nodeID-duplicate");
@@ -299,13 +302,13 @@ define([
                 },
             },
             androidIntentExtra: {
-                lstring: 'Extra',
+                lstring: gettext('Extra'),
                 visibility: 'visible',
                 widget: widgets.baseKeyValue,
                 serialize: serializeAttrs,
             },
             androidIntentResponse: {
-                lstring: 'Response',
+                lstring: gettext('Response'),
                 visibility: 'visible',
                 widget: widgets.baseKeyValue,
                 serialize: serializeAttrs,
@@ -318,7 +321,7 @@ define([
             intentXmlns: {
                 visibility: 'hidden',
                 presence: 'optional',
-                lstring: "Special Intent XMLNS attribute",
+                lstring: gettext("Special Intent XMLNS attribute"),
             }
         },
         // todo: move to spec system
@@ -328,7 +331,7 @@ define([
     });
 
     var PrintIntent = util.extend(AndroidIntent, {
-        typeName: 'Print',
+        typeName: gettext('Print'),
         icon: 'fa fa-print',
         init: function (mug, form) {
             AndroidIntent.init(mug, form);
@@ -336,7 +339,7 @@ define([
         },
         spec: {
             docTemplate: {
-                lstring: 'Document Template',
+                lstring: gettext('Document Template'),
                 visibility: 'visible',
                 widget: printTemplateWidget,
             },

--- a/src/intentManager.js
+++ b/src/intentManager.js
@@ -255,22 +255,22 @@ define([
                     var opts = mug.form.vellum.opts(),
                         features = opts.features,
                         link = opts.core.externalLinks.changeSubscription,
-                        text = link ? "[" + gettext("change your subscription") +
-                            "](" + link + ")" : gettext("change your subscription");
+                        changesub = gettext("change your subscription");
+                    link = link ? "[" + changesub + "](" + link + ")" : changesub;
                     if (noIntents(features)) {
                         return util.format(gettext(
                             "You no longer have access to built in or external integration in your application.\n\n" +
                             "Built in integrations are available on the Pro plan and higher. " +
                             "External integrations are available on the Advanced plan and higher. " +
                             "Before you can make a new version of your application, " +
-                            "you must {link} or delete this question."), {link: text});
+                            "you must {link} or delete this question."), {link: link});
                     } else if (onlyTemplatedIntents(features) &&
                                valueNotInIntentTemplates(mug.p.androidIntentAppId)) {
                         return util.format(gettext(
                             "Your subscription only has access to built-in integration.\n\n" +
                             "External integrations are available on the Advanced plan and higher. " +
                             "Before you can make a new version of your application, " +
-                            "you must {link} or delete this question."), {link: text});
+                            "you must {link} or delete this question."), {link: link});
                     }
 
                     // Validate that IDs are unique across app callouts

--- a/src/itemset.js
+++ b/src/itemset.js
@@ -40,7 +40,7 @@ define([
 
     Itemset = util.extend(mugs.defaultOptions, {
         isControlOnly: true,
-        typeName: 'Lookup Table Data',
+        typeName: gettext('Lookup Table Data'),
         tagName: 'itemset',
         icon: 'fa fa-th',
         isTypeChangeable: false,
@@ -91,7 +91,7 @@ define([
             otherItext: { presence: 'notallowed' },
             appearance: { presence: 'notallowed' },
             itemsetData: {
-                lstring: 'Lookup Table',
+                lstring: gettext('Lookup Table'),
                 visibility: 'visible_if_present',
                 presence: 'optional',
                 widget: itemsetWidget,
@@ -119,16 +119,21 @@ define([
                 },
                 validationFunc: function (mug) {
                     if (!mug.options.lookupTablesEnabled) {
-                        return _.template("You no longer have access to Lookup Tables in your application. " +
+                        return util.format(gettext(
+                            "You no longer have access to Lookup Tables in your application. " +
                             "Lookup Tables are available on the Standard plan and higher.\n" +
                             "Before you can make a new version of your application, " +
-                            "you must <%= link %> or delete this question")({
-                            link: changeSubscriptionLink ? "[change your subscription](" + changeSubscriptionLink + ")": "change your subscription"
+                            "you must {link} or delete this question"
+                        ), {
+                            link: changeSubscriptionLink ?
+                                "[" + gettext("change your subscription") +
+                                "](" + changeSubscriptionLink + ")" :
+                                gettext("change your subscription")
                         });
                     }
                     var itemsetData = mug.p.itemsetData;
                     if (!itemsetData.nodeset) {
-                        return "A data source must be selected.";
+                        return gettext("A data source must be selected.");
                     } else {
                         mug.form.updateLogicReferences(
                             mug, "itemsetData", itemsetData.nodeset);
@@ -150,7 +155,7 @@ define([
                 },
             },
             labelRef: {
-                lstring: 'Display Text Field',
+                lstring: gettext('Display Text Field'),
                 widget: refWidget,
                 visibility: 'visible',
                 presence: 'required',
@@ -162,7 +167,7 @@ define([
                 },
             },
             sortRef: {
-                lstring: 'Sort Field',
+                lstring: gettext('Sort Field'),
                 widget: refWidget,
                 visibility: 'visible',
                 presence: 'optional',
@@ -174,7 +179,7 @@ define([
                 },
             },
             filter: {
-                lstring: 'Filter',
+                lstring: gettext('Filter'),
                 presence: 'optional',
                 widget: widgets.xPath,
                 xpathType: 'bool',
@@ -187,8 +192,8 @@ define([
                         src = mug.p.itemsetData.instance.src;
                     return datasourceWidgets.autocompleteChoices(sources, src);
                 },
-                help: "This is an XPath expression that will filter the set " +
-                      "of choices from the lookup table",
+                help: gettext("This is an XPath expression that will filter the set " +
+                      "of choices from the lookup table"),
             }
         }
     });
@@ -249,7 +254,7 @@ define([
             var groups = this.__callOld();
             if (this.opts().features.lookup_tables) {
                groups.splice(groups.length - 1, 0, {
-                    group: ["SelectDynamic", 'Lookup Tables'],
+                    group: ["SelectDynamic", gettext('Lookup Tables')],
                     questions: ["SelectDynamic", "MSelectDynamic"],
                 });
             }
@@ -260,17 +265,18 @@ define([
             types.auxiliary.Itemset = Itemset;
             types.normal = $.extend(types.normal, {
                 "MSelectDynamic": util.extend(mugTypes.MSelect, {
-                    typeName: 'Checkbox Lookup Table',
+                    typeName: gettext('Checkbox Lookup Table'),
                     typeChangeError: function (mug, typeName) {
                         if (typeName.match(/^M?Select$/)) {
                             if (mug.form.getChildren(mug).length > 0) {
-                                return "Cannot change to Multiple/Single Choice " +
+                                return gettext("Cannot change to Multiple/Single Choice " +
                                       "question if it has Choices. " +
-                                      "Please remove all Choices and try again.";
+                                      "Please remove all Choices and try again.");
                             }
                             return '';
                         }
-                        return typeName === "SelectDynamic" ? "" : "Can only change to a Multiple Choice Lookup Table";
+                        return typeName === "SelectDynamic" ? "" :
+                            gettext("Can only change to a Multiple Choice Lookup Table");
                     },
                     validChildTypes: ["Itemset"],
                     maxChildren: 1,
@@ -285,17 +291,18 @@ define([
                     }
                 }),
                 "SelectDynamic": util.extend(mugTypes.Select, {
-                    typeName: 'Multiple Choice Lookup Table',
+                    typeName: gettext('Multiple Choice Lookup Table'),
                     typeChangeError: function (mug, typeName) {
                         if (typeName.match(/^M?Select$/)) {
                             if (mug.form.getChildren(mug).length > 0) {
-                                return "Cannot change to Multiple/Single Choice " +
+                                return gettext("Cannot change to Multiple/Single Choice " +
                                       "question if it has Choices. " +
-                                      "Please remove all Choices and try again.";
+                                      "Please remove all Choices and try again.");
                             }
                             return '';
                         }
-                        return typeName === "MSelectDynamic" ? "" : "Can only change to a Checkbox Lookup Table";
+                        return typeName === "MSelectDynamic" ? "" :
+                            gettext("Can only change to a Checkbox Lookup Table");
                     },
                     validChildTypes: ["Itemset"],
                     maxChildren: 1,
@@ -491,7 +498,7 @@ define([
             dataSources = [],
             optionsLoaded = false,
             canUpdateAutocomplete = false,
-            widget = datasourceWidgets.fixtureWidget(mug, options, "Lookup Table"),
+            widget = datasourceWidgets.fixtureWidget(mug, options, gettext("Lookup Table")),
             super_getValue = widget.getValue,
             super_setValue = widget.setValue,
             super_handleChange = widget.handleChange;
@@ -564,7 +571,10 @@ define([
                 strippedMugAttr = mugAttr.replace(filterRegex, "");
 
             if (notCustom && !_.contains(choices, strippedMugAttr)) {
-                return mugAttr + " was not found in the lookup table";
+                return util.format(
+                    gettext("{attr} was not found in the lookup table"),
+                    {attr: mugAttr}
+                );
             }
 
             return 'pass';

--- a/src/javaRosa/itext.js
+++ b/src/javaRosa/itext.js
@@ -230,7 +230,7 @@ define([
                 if (!data.hasOwnProperty(lang)) {
                     data[lang] = defaultValue;
                 }
-            })
+            });
         },
         getOutputRefExpressions: function () {
             if (this.outputExpressions === null) {
@@ -244,7 +244,7 @@ define([
                 if (expr) {
                     refs.push(expr);
                 }
-            })
+            });
             return refs;
         },
         /**
@@ -275,7 +275,7 @@ define([
                             value = output.attr(vkey) || output.attr(key),
                             result = fn(value);
                         if (result !== undefined && result !== value) {
-                            output.attr(key, result).removeAttr(vkey)
+                            output.attr(key, result).removeAttr(vkey);
                             shouldReset = true;
                         }
                     });

--- a/src/javaRosa/itextBlock.js
+++ b/src/javaRosa/itextBlock.js
@@ -165,16 +165,16 @@ define([
 
         block.getAddCustomItextButton = function () {
             var $customButton = $("<button />")
-                    .text("custom...")
+                    .text(gettext("custom..."))
                     .addClass('btn btn-default')
                     .attr('type', 'button'),
                 newItextBtnClass = 'fd-new-itext-button';
 
             $customButton.click(function () {
                 var $modal, $newItemForm, $newItemInput;
-                $modal = mug.form.vellum.generateNewModal("New Content Type", [
+                $modal = mug.form.vellum.generateNewModal(gettext("New Content Type"), [
                     {
-                        title: "Add",
+                        title: gettext("Add"),
                         cssClasses: newItextBtnClass + " disabled ",
                         attributes: {
                             disabled: "disabled"
@@ -183,7 +183,7 @@ define([
                 ]);
 
                 $newItemForm = $(control_group({
-                    label: "Content Type"
+                    label: gettext("Content Type")
                 }));
 
                 $newItemInput = $("<input />").attr("type", "text").addClass("form-control");

--- a/src/javaRosa/itextWidget.js
+++ b/src/javaRosa/itextWidget.js
@@ -452,7 +452,7 @@ define([
             widget.getBaseMediaPath = function () {
                 return "jr://file/commcare/" + form + url_type +
                        jrUtil.getDefaultItextRoot(widget.mug);
-            }
+            };
 
             widget.mug.form.vellum.initMediaUploaderWidget(widget);
 

--- a/src/javaRosa/plugin.js
+++ b/src/javaRosa/plugin.js
@@ -108,7 +108,7 @@ define([
             });
             fullLangs[fullLangs.length] = {
                 code: '_ids',
-                name: 'Question ID'
+                name: gettext('Question ID')
             };
 
             if (fullLangs.length < 2) {
@@ -226,13 +226,11 @@ define([
 
                 if (langs && langs.indexOf(lang) === -1) {
                     // todo: plugins!
-                    _this.data.core.parseWarnings.push(
+                    _this.data.core.parseWarnings.push(gettext(
                         "You have languages in your form that are not specified " +
                         "in the \"Languages\" page of the application builder. " +
                         "The following language will be deleted on save " +
-                        "unless you add it to the \"Languages\" page: " +
-                        lang + "."
-                    );
+                        "unless you add it to the \"Languages\" page:") + " " + lang);
                     return;
                 }
                 Itext.addLanguage(lang);
@@ -527,17 +525,29 @@ define([
                         hasItext = itext && itext.hasHumanReadableItext();
                     if (!hasItext && mug.getPresence(property) === 'required') {
                         if (itext.itextModel.languages.length === 1) {
-                            return name + " (or multimedia) is required.";
+                            return util.format(
+                                gettext("{name} (or multimedia) is required."),
+                                {name: name}
+                            );
                         } else {
-                            return name + " (or multimedia) is required for all languages.";
+                            return util.format(
+                                gettext("{name} (or multimedia) is required for all languages."),
+                                {name: name}
+                            );
                         }
                     }
                     if (itext && !itext.autoId && !itext.isEmpty()) {
                         // Itext ID validation
                         if (!itext.id) {
-                            return name + " Itext ID is required";
+                            return util.format(
+                                gettext("{name} Itext ID is required."),
+                                {name: name}
+                            );
                         } else if (!util.isValidAttributeValue(itext.id)) {
-                            return itext.id + " is not a valid ID";
+                            return util.format(
+                                gettext("{name} is not a valid ID."),
+                                {name: itext.id}
+                            );
                         }
                     }
                     return "pass";
@@ -624,8 +634,8 @@ define([
                                     mug.addMessage(name, {
                                         key: "missing-multimedia-warning",
                                         level: mug.WARNING,
-                                        message: "Multimedia was not copied; " +
-                                                 "it must be uploaded separately."
+                                        message: gettext("Multimedia was not copied; " +
+                                                 "it must be uploaded separately."),
                                     });
                                 }
                                 found = true;
@@ -650,13 +660,15 @@ define([
                         var msg = errors.get(null, WARNING_KEY);
                         if (msg) {
                             msg.langs = _.union(msg.langs, discardedLangs);
-                            msg.message = "Discarded languages: " + msg.langs.join(", ");
+                            msg.message = gettext("Discarded languages:") +
+                                " " + msg.langs.join(", ");
                         } else {
                             errors.update(null, {
                                 key: WARNING_KEY,
                                 level: mug.WARNING,
                                 langs: discardedLangs,
-                                message: "Discarded languages: " + discardedLangs.join(", ")
+                                message: gettext("Discarded languages:") +
+                                    " " + discardedLangs.join(", ")
                             });
                         }
                     }
@@ -668,8 +680,8 @@ define([
             function validateConstraintMsgAttr(mug) {
                 var itext = mug.p.constraintMsgItext;
                 if (!mug.p.constraintAttr && itext && !itext.isEmpty()) {
-                    return 'You cannot have a Validation Error Message ' +
-                           'with no Validation Condition!';
+                    return gettext('You cannot have a Validation Error ' +
+                           'Message with no Validation Condition!');
                 }
                 return 'pass';
             }
@@ -680,7 +692,7 @@ define([
                 presence: function (mug) {
                     return mug.options.isSpecialGroup ? 'notallowed' : 'optional';
                 },
-                lstring: 'Validation Message',
+                lstring: gettext('Validation Message'),
                 widget: function (mug, options) {
                     return itextBlock.label(mug, $.extend(options, {
                         itextType: "constraintMsg",
@@ -688,13 +700,13 @@ define([
                         getItextByMug: function (mug) {
                             return mug.p.constraintMsgItext;
                         },
-                        displayName: "Validation Message"
+                        displayName: gettext("Validation Message")
                     }));
                 },
                 validationFunc: function (mug) {
                     var itext = mug.p.constraintMsgItext;
                     if (!mug.p.constraintAttr && itext && itext.id && !itext.autoId) {
-                        return "Can't have a Validation Message Itext ID without a Validation Condition";
+                        return gettext("Can't have a Validation Message Itext ID without a Validation Condition");
                     }
                     var result = itextValidator("constraintMsgItext", "Validation Message")(mug);
                     if (result === "pass") {
@@ -709,7 +721,7 @@ define([
             databind.constraintMsgItextID = {
                 visibility: 'constraintMsgItext',
                 presence: 'optional',
-                lstring: "Validation Message Itext ID",
+                lstring: gettext("Validation Message Itext ID"),
                 widget: itextWidget.id,
                 widgetValuePath: "constraintMsgItext"
             };
@@ -719,10 +731,10 @@ define([
                         return mug.isVisible("constraintAttr");
                     },
                     presence: 'optional',
-                    lstring: 'Add Validation Media',
+                    lstring: gettext('Add Validation Media'),
                     widget: function (mug, options) {
                         return itextBlock.media(mug, $.extend(options, {
-                            displayName: "Add Validation Media",
+                            displayName: gettext("Add Validation Media"),
                             itextType: "constraintMsg",
                             getItextByMug: function (mug) {
                                 return mug.p.constraintMsgItext;
@@ -743,7 +755,7 @@ define([
             control.labelItext = addSerializer({
                 visibility: 'visible',
                 presence: 'optional',
-                lstring: "Display Text",
+                lstring: gettext("Display Text"),
                 widget: function (mug, options) {
                     return itextBlock.label(mug, $.extend(options, {
                         itextType: "label",
@@ -751,16 +763,16 @@ define([
                         getItextByMug: function (mug) {
                             return mug.p.labelItext;
                         },
-                        displayName: "Display Text"
+                        displayName: gettext("Display Text")
                     }));
                 },
-                validationFunc: itextValidator("labelItext", "Display Text")
+                validationFunc: itextValidator("labelItext", gettext("Display Text"))
             });
             // virtual property used to define a widget
             control.labelItextID = {
                 visibility: 'labelItext',
                 presence: 'optional',
-                lstring: "Display Text Itext ID",
+                lstring: gettext("Display Text Itext ID"),
                 widget: itextWidget.id,
                 widgetValuePath: "labelItext"
             };
@@ -770,7 +782,7 @@ define([
                 presence: function (mug) {
                     return mug.options.isSpecialGroup ? 'notallowed' : 'optional';
                 },
-                lstring: "Hint Message",
+                lstring: gettext("Hint Message"),
                 widget: function (mug, options) {
                     return itextBlock.label(mug, $.extend(options, {
                         itextType: "hint",
@@ -778,15 +790,15 @@ define([
                         getItextByMug: function (mug) {
                             return mug.p.hintItext;
                         },
-                        displayName: "Hint Message"
+                        displayName: gettext("Hint Message")
                     }));
                 },
-                validationFunc: itextValidator("hintItext", "Hint Message")
+                validationFunc: itextValidator("hintItext", gettext("Hint Message"))
             });
             // virtual property used to get a widget
             control.hintItextID = {
                 visibility: 'hintItext',
-                lstring: "Hint Itext ID",
+                lstring: gettext("Hint Itext ID"),
                 widget: itextWidget.id,
                 widgetValuePath: "hintItext"
             };
@@ -796,7 +808,7 @@ define([
                 presence: function (mug) {
                     return mug.options.isSpecialGroup ? 'notallowed' : 'optional';
                 },
-                lstring: "Help Message",
+                lstring: gettext("Help Message"),
                 widget: function (mug, options) {
                     var block = itextBlock.label(mug, $.extend(options, {
                             itextType: "help",
@@ -804,17 +816,17 @@ define([
                             getItextByMug: function (mug) {
                                 return mug.p.helpItext;
                             },
-                            displayName: "Help Message"
+                            displayName: gettext("Help Message")
                         }));
 
                     return block;
                 },
-                validationFunc: itextValidator("helpItext", "Help Message")
+                validationFunc: itextValidator("helpItext", gettext("Help Message"))
             });
             // virtual property used to get a widget
             control.helpItextID = {
                 visibility: 'helpItext',
-                lstring: "Help Itext ID",
+                lstring: gettext("Help Itext ID"),
                 widget: itextWidget.id,
                 widgetValuePath: "helpItext"
             };
@@ -824,10 +836,10 @@ define([
                 return mugOptions.isSpecialGroup ? undefined : {
                     visibility: 'labelItext',
                     presence: 'optional',
-                    lstring: "Add Other Content",
+                    lstring: gettext("Add Other Content"),
                     widget: function (mug, options) {
                         return itextBlock.configurable(mug, $.extend(options, {
-                            displayName: "Add Other Content",
+                            displayName: gettext("Add Other Content"),
                             itextType: "label",
                             getItextByMug: function (mug) {
                                 return mug.p.labelItext;
@@ -843,10 +855,10 @@ define([
                 return mugOptions.isSpecialGroup ? undefined : {
                     visibility: 'labelItext',
                     presence: 'optional',
-                    lstring: 'Add Multimedia',
+                    lstring: gettext('Add Multimedia'),
                     widget: function (mug, options) {
                         return itextBlock.media(mug, $.extend(options, {
-                            displayName: "Add Multimedia",
+                            displayName: gettext("Add Multimedia"),
                             itextType: "label",
                             pathPrefix: "",
                             getItextByMug: function (mug) {
@@ -863,10 +875,10 @@ define([
                 return mugOptions.isSpecialGroup ? undefined : {
                     visibility: 'helpItext',
                     presence: 'optional',
-                    lstring: 'Add Help Media',
+                    lstring: gettext('Add Help Media'),
                     widget: function (mug, options) {
                         return itextBlock.media(mug, $.extend(options, {
-                            displayName: "Add Help Media",
+                            displayName: gettext("Add Help Media"),
                             itextType: "help",
                             getItextByMug: function (mug) {
                                 return mug.p.helpItext;
@@ -916,7 +928,7 @@ define([
             var _this = this;
             return this.__callOld().concat([
                 {
-                    name: "Edit Bulk Translations",
+                    name: gettext("Edit Bulk Translations"),
                     icon: "fa fa-language",
                     action: function (done) {
                         _this.showItextModal(done);
@@ -930,9 +942,9 @@ define([
                 Itext = vellum.data.javaRosa.Itext,
                 form = vellum.data.core.form;
 
-            $modal = vellum.generateNewModal("Edit Bulk Translations", [
+            $modal = vellum.generateNewModal(gettext("Edit Bulk Translations"), [
                 {
-                    title: "Update Translations",
+                    title: gettext("Update Translations"),
                     cssClasses: "btn-primary",
                     action: function () {
                         jrUtil.parseXLSItext(form, $textarea.val(), Itext);
@@ -942,11 +954,12 @@ define([
                 }
             ]);
             $updateForm = $(edit_source({
-                description: "Copy these translations into a spreadsheet program " + 
+                description: gettext(
+                "Copy these translations into a spreadsheet program " +
                 "like Excel. You can edit them there and then paste them back " +
                 "here when you're done. These will update the translations used in " +
                 "your form. Press 'Update Translations' to save changes, or 'Close' " +
-                "to cancel."
+                "to cancel.")
             }));
             $modal.find('.modal-body').html($updateForm);
 

--- a/src/javaRosa/plugin.js
+++ b/src/javaRosa/plugin.js
@@ -284,8 +284,7 @@ define([
                     _.each(langs, function (lang) {
                         var text = itForm.getValue(lang);
                         if (!text) { return; }
-                        var div = $('<div>').append(text),
-                            changed = false;
+                        var div = $('<div>').append(text);
                         div.find('output').replaceWith(function() {
                             var output = $(this),
                                 key = output.is("[value]") ||
@@ -715,7 +714,6 @@ define([
                     return result;
                 }
             });
-            var super_constraintAttr_validate = databind.constraintAttr.validationFunc;
             databind.constraintAttr.validationFunc = validateConstraintMsgAttr;
             // virtual property used to define a widget
             databind.constraintMsgItextID = {

--- a/src/javaRosa/util.js
+++ b/src/javaRosa/util.js
@@ -219,9 +219,11 @@ define([
                 current.addMessage(null, {
                     key: "javaRosa-output-value-type-error",
                     level: mug.WARNING,
-                    message: typeName + " nodes cannot be used in an " +
-                        "output value. Please remove the output value for " +
-                        "'" + path + "' or your form will have errors."
+                    message: util.format(gettext(
+                        "{type} nodes cannot be used in an output value. " +
+                        "Please remove the output value for '{path}' or " +
+                        "your form will have errors."
+                    ), {type: typeName, path: path}),
                 });
             }
         }
@@ -242,10 +244,11 @@ define([
             mug.addMessage(propName, {
                 key: "core-circular-reference-warning",
                 level: mug.WARNING,
-                message: "The " + fieldName + " for a question " +
-                    "is not allowed to reference the question itself. " +
-                    "Please remove the " + refName + " from the " +
-                    fieldName +" or your form will have errors."
+                message: util.format(gettext(
+                    "The {field} for a question is not allowed to reference " +
+                    "the question itself. Please remove the {ref} from the " +
+                    "{field} or your form will have errors."
+                ), {field: fieldName, ref: refName}),
             });
         }
     };
@@ -259,7 +262,8 @@ define([
             util.insertTextAtCursor(target, output, true);
         }
         if (mug) {
-            warnOnCircularReference('label', mug, path, 'output value', target.attr('name'));
+            warnOnCircularReference(
+                'label', mug, path, gettext('output value'), target.attr('name'));
             warnOnNonOutputableValue(form, mug, path);
         }
     };

--- a/src/logic.js
+++ b/src/logic.js
@@ -248,10 +248,11 @@ define([
 
             expr.analyze();
             if (expr.referencesSelf && _.contains(NO_SELF_REFERENCES, property)) {
-                warning = "The " + propertyName + " for a question " +
+                warning = util.format(gettext("The {property} for a question " +
                     "is not allowed to reference the question itself. " +
-                    "Please remove the . from the " +
-                    propertyName +" or your form will have errors.";
+                    "Please remove the . from the {property} " +
+                    "or your form will have errors."),
+                    {property: propertyName});
             }
 
             messages.push({
@@ -322,9 +323,9 @@ define([
                     if (!unknowns.length) {
                         return "";
                     } else if (unknowns.length === 1) {
-                        return "Unknown question: " + unknowns[0];
+                        return gettext("Unknown question:") + " " + unknowns[0];
                     }
-                    return "Unknown questions:\n- " + unknowns.join("\n- ");
+                    return gettext("Unknown questions:") + "\n- " + unknowns.join("\n- ");
                 })()
             });
             return messages;

--- a/src/main.js
+++ b/src/main.js
@@ -158,6 +158,13 @@ if (window.jQuery) {
     });
 }
 
+if (!window.gettext) {
+    window.gettext = function (arg) { return arg; };
+    window.ngettext = function (singular, plural, count) {
+        return count === 1 ? singular : plural;
+    };
+}
+
 define([
     // begin buildmain.py delimiter
     'vellum/core',

--- a/src/modeliteration.js
+++ b/src/modeliteration.js
@@ -132,7 +132,7 @@ define([
                     }
                 }),
                 dataSource: {
-                    lstring: 'Data Source',
+                    lstring: gettext('Data Source'),
                     visibility: 'visible_if_present',
                     presence: 'optional',
                     widget: idsQueryDataSourceWidget,
@@ -314,7 +314,7 @@ define([
 
     function idsQueryDataSourceWidget(mug, options) {
         var widget = datasourceWidgets.advancedDataSourceWidget(
-                                    mug, options, "Model Iteration ID Query"),
+                                    mug, options, gettext("Model Iteration ID Query")),
             super_getValue = widget.getValue,
             super_setValue = widget.setValue;
 

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -1059,7 +1059,8 @@ define([
                         if(!dataParentMug &&
                            form.getBasePath().slice(0, -1) !== dataParent) {
                             return gettext("Must be valid path");
-                        } else if (dataParentMug && !dataParentMug.options.possibleDataParent) {
+                        } else if (dataParentMug && (dataParentMug === mug ||
+                                !dataParentMug.options.possibleDataParent)) {
                             return util.format(
                                 gettext("{path} is not a valid data parent"),
                                 {path: dataParentMug.hashtagPath}

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -147,16 +147,17 @@ define([
             // TODO use data.hasOwnProperty(attr) rather than !value?
             if (!value && presence === 'required') {
                 // can the user always fix this error?
-                message = label + ' is required.';
+                message = gettext('{question} is required.');
             } else if (value && presence === 'notallowed') {
                 // can the user always fix this error?
-                message = label + ' is not allowed.';
+                message = gettext('{question} is not allowed.');
             } else if (spec.validationFunc) {
                 try {
                     message = spec.validationFunc(mug);
                 } catch (err) {
                     // this should never happen
-                    message = label + " validation failed\n" + util.formatExc(err);
+                    message = gettext("{question} validation failed") +
+                        "\n" + util.formatExc(err);
                 }
                 if (message === "pass") {
                     message = "";
@@ -166,7 +167,7 @@ define([
             return this.messages.update(attr, {
                 key: "mug-" + attr + "-error",
                 level: this.ERROR,
-                message: message
+                message: util.format(message || "", {question: label})
             });
         },
         // message levels
@@ -378,10 +379,10 @@ define([
                 nodeID = this.p.conflictedNodeId || this.p.nodeID;
 
             if (this.__className === "ReadOnly") {
-                return "Unknown (read-only) question type";
+                return gettext("Unknown (read-only) question type");
             }
             if (this.__className === "Itemset") {
-                return "Lookup Table Data";
+                return gettext("Lookup Table Data");
             }
 
             if (!itextItem || lang === '_ids') {
@@ -390,7 +391,7 @@ define([
             lang = lang || defaultLang;
 
             if(!lang) {
-                return 'No Translation Data';
+                return gettext('No Translation Data');
             }
 
             defaultDisp = itextItem.get("default", defaultLang);
@@ -795,7 +796,7 @@ define([
             nodeID: {
                 visibility: 'visible',
                 presence: 'required',
-                lstring: 'Question ID',
+                lstring: gettext('Question ID'),
                 setter: function (mug, attr, value) {
                     mug.form.moveMug(mug, "rename", value);
                 },
@@ -815,17 +816,19 @@ define([
                             level: mug.WARNING,
                         };
                     if (mug.p.nodeID.toLowerCase() === "case") {
-                        caseWarning.message = "The ID 'case' may cause " +
-                            "problems with case management. It is " +
-                            "recommended to pick a different Question ID.";
+                        caseWarning.message = gettext("The ID 'case' may " +
+                            "cause problems with case management. It is " +
+                            "recommended to pick a different Question ID.");
                     }
                     mug.addMessage("nodeID", caseWarning);
                     if (!util.isValidElementName(mug.p.nodeID)) {
-                        return mug.p.nodeID + " is not a legal Question ID. " +
+                        return util.format(gettext(
+                            "{nodeID} is not a legal Question ID. " +
                             "It must start with a letter and contain only " +
-                            "letters, numbers, and '-' or '_' characters.";
+                            "letters, numbers, and '-' or '_' characters."),
+                            {nodeID: mug.p.nodeID});
                     } else if (mug.p.nodeID.toLowerCase() === "meta") {
-                        return "'meta' is not a valid Question ID.";
+                        return gettext("'meta' is not a valid Question ID.");
                     }
                     return "pass";
                 },
@@ -869,9 +872,9 @@ define([
                     var message = null;
                     if (value) {
                         mug.p.set(attr, value);
-                        message = "This question has the same " +
+                        message = gettext("This question has the same " +
                             "Question ID as another question in the same " +
-                            "group. Please choose a unique Question ID.";
+                            "group. Please choose a unique Question ID.");
                     } else {
                         mug.p.set(attr);
                     }
@@ -889,16 +892,16 @@ define([
             dataValue: {
                 visibility: 'visible_if_present',
                 presence: 'optional',
-                lstring: 'Default Data Value',
+                lstring: gettext('Default Data Value'),
             },
             xmlnsAttr: {
                 visibility: 'visible',
                 presence: 'notallowed',
-                lstring: "Special Hidden Value XMLNS attribute"
+                lstring: gettext("Special Hidden Value XMLNS attribute")
             },
             rawDataAttributes: {
                 presence: 'optional',
-                lstring: 'Extra Data Attributes',
+                lstring: gettext('Extra Data Attributes'),
             },
 
             // BIND ELEMENT
@@ -909,7 +912,7 @@ define([
                 xpathType: "bool",
                 serialize: serializeXPath,
                 deserialize: deserializeXPath,
-                lstring: 'Display Condition'
+                lstring: gettext('Display Condition')
             },
             calculateAttr: {
                 // only show calculate condition for non-data nodes if it already
@@ -922,7 +925,7 @@ define([
                 xpathType: "generic",
                 serialize: serializeXPath,
                 deserialize: deserializeXPath,
-                lstring: 'Calculate Condition'
+                lstring: gettext('Calculate Condition')
             },
             constraintAttr: {
                 visibility: 'visible',
@@ -934,7 +937,7 @@ define([
                 xpathType: "bool",
                 serialize: serializeXPath,
                 deserialize: deserializeXPath,
-                lstring: 'Validation Condition'
+                lstring: gettext('Validation Condition')
             },
             // non-itext constraint message
             constraintMsgAttr: {
@@ -942,17 +945,17 @@ define([
                 presence: 'optional',
                 validationFunc : function (mug) {
                     if (mug.p.constraintMsgAttr && !mug.p.constraintAttr) {
-                        return 'You cannot have a Validation Error Message with no Validation Condition!';
+                        return gettext('You cannot have a Validation Error Message with no Validation Condition!');
                     } else {
                         return 'pass';
                     }
                 },
-                lstring: 'Validation Error Message'
+                lstring: gettext('Validation Error Message')
             },
             requiredAttr: {
                 visibility: 'visible',
                 presence: 'optional',
-                lstring: "Required",
+                lstring: gettext("Required"),
                 widget: widgets.checkbox
             },
             nodeset: {
@@ -962,12 +965,12 @@ define([
             // could use a key-value widget for this in the future
             rawBindAttributes: {
                 presence: 'optional',
-                lstring: 'Extra Bind Attributes'
+                lstring: gettext('Extra Bind Attributes')
             },
             defaultValue: {
                 visibility: 'visible',
                 presence: 'optional',
-                lstring: 'Default Value',
+                lstring: gettext('Default Value'),
                 widget: widgets.xPath,
                 xpathType: 'generic',
                 serialize: serializeXPath,
@@ -978,15 +981,16 @@ define([
                         var paths = mug.form.getHashtagsInXPath(mug.p.defaultValue);
                         paths =  _.filter(paths, function(path) { return path.namespace === 'form'; });
                         if (paths.length) {
-                            return "You are referencing a node in this form. " +
-                                   "This can cause errors in the form";
+                            return gettext(
+                                "You are referencing a node in this form. " +
+                                "This can cause errors in the form");
                         }
                     }
                     return 'pass';
                 }
             },
             comment: {
-                lstring: 'Comment',
+                lstring: gettext('Comment'),
                 visibility: 'visible',
                 widget: widgets.multilineText,
             }
@@ -997,15 +1001,15 @@ define([
                 deleteOnCopy: true,
                 visibility: 'visible',
                 presence: 'optional',
-                lstring: 'Appearance Attribute'
+                lstring: gettext('Appearance Attribute')
             },
             label: {
                 visibility: 'visible',
                 presence: 'optional',
-                lstring: "Default Display Text",
+                lstring: gettext("Default Display Text"),
                 validationFunc: function (mug) {
                     if (!mug.p.label && mug.getPresence("label") === 'required') {
-                        return 'Default Display Text is required';
+                        return gettext('Default Display Text is required');
                     }
                     return 'pass';
                 }
@@ -1013,18 +1017,18 @@ define([
             hintLabel: {
                 visibility: 'visible',
                 presence: 'optional',
-                lstring: "Hint Display Text"
+                lstring: gettext("Hint Display Text")
             },
             rawControlAttributes: {
                 presence: 'optional',
-                lstring: "Extra Control Attributes",
+                lstring: gettext("Extra Control Attributes"),
             },
             rawControlXML: {
                 presence: 'optional',
-                lstring: 'Raw XML'
+                lstring: gettext('Raw XML')
             },
             dataParent: {
-                lstring: 'Data Parent',
+                lstring: gettext('Data Parent'),
                 visibility: function(mug) {
                     function recFunc(mug) {
                         if (!mug) {
@@ -1054,11 +1058,15 @@ define([
 
                         if(!dataParentMug &&
                            form.getBasePath().slice(0, -1) !== dataParent) {
-                            return "Must be valid path";
+                            return gettext("Must be valid path");
                         } else if (dataParentMug && !dataParentMug.options.possibleDataParent) {
-                            return dataParentMug.hashtagPath + " is not a valid data parent";
+                            return util.format(
+                                gettext("{path} is not a valid data parent"),
+                                {path: dataParentMug.hashtagPath}
+                            );
                         } else if (!mug.spec.dataParent.visibility(mug)) {
-                            return "Children of repeat groups cannot have a different data parent";
+                            return gettext("Children of repeat groups cannot " +
+                                "have a different data parent");
                         }
                     }
 
@@ -1215,7 +1223,7 @@ define([
 
     var DataBindOnly = util.extend(defaultOptions, {
         isDataOnly: true,
-        typeName: 'Hidden Value',
+        typeName: gettext('Hidden Value'),
         icon: 'fcc fcc-fd-variable',
         isTypeChangeable: false,
         spec: {
@@ -1240,7 +1248,7 @@ define([
     });
 
     var Text = util.extend(defaultOptions, {
-        typeName: "Text",
+        typeName: gettext("Text"),
         dataType: "xsd:string",
         icon: "fcc fcc-fd-text",
         init: function (mug, form) {
@@ -1248,7 +1256,7 @@ define([
     });
 
     var PhoneNumber = util.extend(Text, {
-        typeName: 'Phone Number or Numeric ID',
+        typeName: gettext('Phone Number or Numeric ID'),
         icon: 'fa fa-signal',
         init: function (mug, form) {
             Text.init(mug, form);
@@ -1260,7 +1268,7 @@ define([
     });
 
     var Secret = util.extend(defaultOptions, {
-        typeName: 'Password',
+        typeName: gettext('Password'),
         dataType: 'xsd:string',
         tagName: 'secret',
         icon: 'fa fa-key',
@@ -1270,7 +1278,7 @@ define([
     });
 
     var Int = util.extend(defaultOptions, {
-        typeName: 'Integer',
+        typeName: gettext('Integer'),
         dataType: 'xsd:int',
         icon: 'fcc fcc-fd-numeric',
         init: function (mug, form) {
@@ -1278,7 +1286,7 @@ define([
     });
 
     var Audio = util.extend(defaultOptions, {
-        typeName: 'Audio Capture',
+        typeName: gettext('Audio Capture'),
         dataType: 'binary',
         tagName: 'upload',
         icon: 'fcc fcc-fd-audio-capture',
@@ -1290,27 +1298,27 @@ define([
     });
 
     var Image = util.extend(Audio, {
-        typeName: 'Image Capture',
+        typeName: gettext('Image Capture'),
         icon: 'fa fa-camera',
         mediaType: "image/*", /* */
         spec: {
             imageSize: {
-                lstring: "Image Size",
+                lstring: gettext("Image Size"),
                 visibility: 'visible',
                 widget: widgets.dropdown,
                 enabled: function(mug) {
                     return mug.options.resize_enabled;
                 },
                 defaultOptions: [
-                    { text: "Small", value: "250" },
-                    { text: "Medium", value: "500" },
-                    { text: "Large", value: "1000" },
-                    { text: "Original", value: "" },
+                    { text: gettext("Small"), value: "250" },
+                    { text: gettext("Medium"), value: "500" },
+                    { text: gettext("Large"), value: "1000" },
+                    { text: gettext("Original"), value: "" },
                 ],
-                help: "This will resize the image before sending the form. " +
+                help: gettext("This will resize the image before sending the form. " +
                     "Use this option to send smaller images in areas of poor " +
                     "connectivity.<ul><li>Small - 0.1 megapixels</li><li>" +
-                    "Medium - 0.2 megapixels</li><li>Large - 0.5 megapixels</li></ul>",
+                    "Medium - 0.2 megapixels</li><li>Large - 0.5 megapixels</li></ul>"),
             }
         },
         writeCustomXML: function (xmlWriter, mug) {
@@ -1328,13 +1336,13 @@ define([
     });
 
     var Video = util.extend(Audio, {
-        typeName: 'Video Capture',
+        typeName: gettext('Video Capture'),
         icon: 'fa fa-video-camera',
         mediaType: "video/*", /* */
     });
 
     var Signature = util.extend(Image, {
-        typeName: 'Signature Capture',
+        typeName: gettext('Signature Capture'),
         icon: 'fcc fcc-fd-signature',
         spec: {
             imageSize: {
@@ -1351,7 +1359,7 @@ define([
     });
 
     var Geopoint = util.extend(defaultOptions, {
-        typeName: 'GPS',
+        typeName: gettext('GPS'),
         dataType: 'geopoint',
         icon: 'fa fa-map-marker',
         init: function (mug, form) {
@@ -1359,7 +1367,7 @@ define([
     });
 
     var Barcode = util.extend(defaultOptions, {
-        typeName: 'Barcode Scan',
+        typeName: gettext('Barcode Scan'),
         dataType: 'barcode',
         icon: 'fa fa-barcode',
         init: function (mug, form) {
@@ -1367,7 +1375,7 @@ define([
     });
 
     var Date = util.extend(defaultOptions, {
-        typeName: 'Date',
+        typeName: gettext('Date'),
         dataType: 'xsd:date',
         icon: 'fa fa-calendar',
         init: function (mug, form) {
@@ -1375,7 +1383,7 @@ define([
     });
 
     var DateTime = util.extend(defaultOptions, {
-        typeName: 'Date and Time',
+        typeName: gettext('Date and Time'),
         dataType: 'xsd:dateTime',
         icon: 'fcc fcc-fd-datetime',
         init: function (mug, form) {
@@ -1383,7 +1391,7 @@ define([
     });
 
     var Time = util.extend(defaultOptions, {
-        typeName: 'Time',
+        typeName: gettext('Time'),
         dataType: 'xsd:time',
         icon: 'fa fa-clock-o',
         init: function (mug, form) {
@@ -1393,7 +1401,7 @@ define([
     // Deprecated. Users may not add new longs to forms, 
     // but must be able to view forms already containing longs.
     var Long = util.extend(Int, {
-        typeName: 'Long',
+        typeName: gettext('Long'),
         dataType: 'xsd:long',
         icon: 'fcc fcc-fd-long',
         init: function (mug, form) {
@@ -1401,7 +1409,7 @@ define([
     });
 
     var Double = util.extend(Int, {
-        typeName: 'Decimal',
+        typeName: gettext('Decimal'),
         dataType: 'xsd:double',
         icon: 'fcc fcc-fd-decimal',
         init: function (mug, form) {
@@ -1410,7 +1418,7 @@ define([
 
     var Choice = util.extend(defaultOptions, {
         isControlOnly: true,
-        typeName: 'Choice',
+        typeName: gettext('Choice'),
         tagName: 'item',
         icon: 'fcc fcc-fd-single-circle',
         isTypeChangeable: false,
@@ -1438,14 +1446,14 @@ define([
         },
         spec: {
             nodeID: {
-                lstring: 'Choice Value',
+                lstring: gettext('Choice Value'),
                 visibility: 'visible',
                 presence: 'required',
                 widget: widgets.identifier,
                 setter: null,
                 validationFunc: function (mug) {
                     if (/\s/.test(mug.p.nodeID)) {
-                        return "Whitespace in values is not allowed.";
+                        return gettext("Whitespace in values is not allowed.");
                     }
                     if (mug.parentMug) {
                         var siblings = mug.form.getChildren(mug.parentMug),
@@ -1453,7 +1461,7 @@ define([
                                 return ele !== mug && ele.p.nodeID === mug.p.nodeID;
                             });
                         if (dup) {
-                            return "This choice value has been used in the same question";
+                            return gettext("This choice value has been used in the same question");
                         }
                     }
                     return "pass";
@@ -1476,7 +1484,7 @@ define([
     });
 
     var Trigger = util.extend(defaultOptions, {
-        typeName: 'Label',
+        typeName: gettext('Label'),
         tagName: 'trigger',
         icon: 'fa fa-tag',
         init: function (mug, form) {
@@ -1504,9 +1512,9 @@ define([
         },
         typeChangeError: function (mug, typeName) {
             if (mug.form.getChildren(mug).length > 0 && !typeName.match(/^M?Select$/)) {
-                return "Cannot change a Multiple/Single Choice " +
+                return gettext("Cannot change a Multiple/Single Choice " +
                       "question to a non-Choice question if it has Choices. " +
-                      "Please remove all Choices and try again.";
+                      "Please remove all Choices and try again.");
             }
             return '';
         },
@@ -1520,21 +1528,21 @@ define([
     });
 
     var MSelect = util.extend(BaseSelect, {
-        typeName: 'Checkbox',
+        typeName: gettext('Checkbox'),
         tagName: 'select',
         icon: 'fcc fcc-fd-multi-select',
         defaultOperator: "selected"
     });
 
     var Select = util.extend(BaseSelect, {
-        typeName: 'Multiple Choice',
+        typeName: gettext('Multiple Choice'),
         tagName: 'select1',
         icon: 'fcc fcc-fd-single-select',
         defaultOperator: null
     });
 
     var Group = util.extend(defaultOptions, {
-        typeName: 'Group',
+        typeName: gettext('Group'),
         tagName: 'group',
         icon: 'fa fa-folder-open',
         isSpecialGroup: true,
@@ -1564,7 +1572,7 @@ define([
     // of grouped questions.  It's a separate question type because it can't
     // nest other group types and it has a very different end-user functionality
     var FieldList = util.extend(Group, {
-        typeName: 'Question List',
+        typeName: gettext('Question List'),
         icon: 'fa fa-reorder',
         init: function (mug, form) {
             Group.init(mug, form);
@@ -1576,7 +1584,7 @@ define([
     });
 
     var Repeat = util.extend(Group, {
-        typeName: 'Repeat Group',
+        typeName: gettext('Repeat Group'),
         icon: 'fa fa-retweet',
         possibleDataParent: false,
         controlNodeChildren: function ($node) {
@@ -1621,7 +1629,7 @@ define([
         },
         spec: {
             repeat_count: {
-                lstring: 'Repeat Count',
+                lstring: gettext('Repeat Count'),
                 visibility: 'visible_if_present',
                 presence: 'optional',
                 widget: widgets.droppableText,
@@ -1639,7 +1647,7 @@ define([
                     }
 
                     if (!$.trim(mug.p.repeat_count) && insideFieldList(mug)) {
-                        return "Repeat Count is required.";
+                        return gettext("Repeat Count is required.");
                     }
 
                     return "pass";
@@ -1647,7 +1655,7 @@ define([
             },
             rawRepeatAttributes: {
                 presence: 'optional',
-                lstring: "Extra Repeat Attributes",
+                lstring: gettext("Extra Repeat Attributes"),
             }
         }
     });

--- a/src/parser.js
+++ b/src/parser.js
@@ -52,7 +52,7 @@ define([
             setValues = head.find('> model > setvalue');
 
         if($(xml).find('parsererror').length > 0) {
-            throw 'PARSE ERROR!:' + $(xml).find('parsererror').find('div').html();
+            throw gettext('PARSE ERROR!:') + $(xml).find('parsererror').find('div').html();
         }
 
         ignore = ignore ? ignore.split(" ") : [];
@@ -84,7 +84,7 @@ define([
         // TODO! adapt
         if(data.length === 0) {
             form.parseErrors.push(
-                'No Data block was found in the form.  Please check that your form is valid!');
+                gettext('No Data block was found in the form. Please check that your form is valid!'));
         }
        
         parseDataTree(form, data[0], title.length ? title.text() : "");
@@ -189,20 +189,21 @@ define([
         if (formName) {
             form.formName = formName;
         } else {
-            form.parseWarnings.push('Form does not have a Name! The default form name will be used');
+            form.parseWarnings.push(
+                gettext('Form does not have a Name! The default form name will be used'));
         }
 
         if (!form.formUuid || form.formUuid === "undefined") {
             form.formUuid = "http://openrosa.org/formdesigner/" + util.generate_xmlns_uuid();
         }
         if (!form.formJRM) {
-            form.parseWarnings.push('Form JRM namespace attribute was not found in data block. One will be added automatically');
+            form.parseWarnings.push(gettext('Form JRM namespace attribute was not found in data block. One will be added automatically'));
         }
         if (!form.formUIVersion) {
-            form.parseWarnings.push('Form does not have a UIVersion attribute, one will be generated automatically');
+            form.parseWarnings.push(gettext('Form does not have a UIVersion attribute, one will be generated automatically'));
         }
         if (!form.formVersion) {
-            form.parseWarnings.push('Form does not have a Version attribute (in the data block), one will be added automatically');
+            form.parseWarnings.push(gettext('Form does not have a Version attribute (in the data block), one will be added automatically'));
         }
     }
 
@@ -545,7 +546,7 @@ define([
             if (nodeId) {
                 pathToTry = processPath(nodeId, rootNodeName, form);
                 if (!form.getMugByPath(pathToTry)) {
-                    form.parseWarnings.push("Ambiguous bind: " + nodeId);
+                    form.parseWarnings.push(gettext("Ambiguous bind:") + " " + nodeId);
                 } else {
                     path = pathToTry;
                 }
@@ -663,9 +664,11 @@ define([
         var mug = form.getMugByPath(path);
 
         if(!mug){
-            form.parseWarnings.push(
-                "Bind Node [" + path + "] found but has no associated " +
-                "Data node. This bind node will be discarded!");
+            form.parseWarnings.push(util.format(
+                gettext("Bind Node [{path}] found but has no associated " +
+                        "Data node. This bind node will be discarded!"),
+                {path: path}
+            ));
             return;
         }
 

--- a/src/richText.js
+++ b/src/richText.js
@@ -779,7 +779,7 @@ define([
         // "%e/%n/%y"       -> "d/m/yy"
         // "%a, %b %e, %Y"  -> "ddd, mmm d, yyyy"
         if (!format) {
-            return "no formatting";
+            return gettext("no formatting");
         }
         return format.replace(/(%[YymnbdeHhMS3a])/g, function (match, fmt) {
             return DATE_FORMATS.hasOwnProperty(fmt[1]) ? DATE_FORMATS[fmt[1]] : fmt;

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -178,7 +178,7 @@ define([
             spec: {
                 xmlnsAttr: { presence: "optional" },
                 "date_modified": {
-                    lstring: "Date Modified",
+                    lstring: gettext("Date Modified"),
                     visibility: 'visible',
                     presence: 'required',
                     widget: widgets.xPath,
@@ -186,7 +186,7 @@ define([
                     deserialize: mugs.deserializeXPath,
                 },
                 "user_id": {
-                    lstring: "User ID",
+                    lstring: gettext("User ID"),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.xPath,
@@ -194,13 +194,13 @@ define([
                     deserialize: mugs.deserializeXPath,
                 },
                 "case_type": {
-                    lstring: "Case Type",
+                    lstring: gettext("Case Type"),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.text,
                 },
                 "case_id": {
-                    lstring: "Case ID",
+                    lstring: gettext("Case ID"),
                     visibility: 'visible',
                     presence: 'required',
                     widget: widgets.xPath,
@@ -208,13 +208,13 @@ define([
                     deserialize: mugs.deserializeXPath,
                 },
                 useCreate: {
-                    lstring: "Create Case",
+                    lstring: gettext("Create Case"),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.checkbox
                 },
                 createProperty: {
-                    lstring: "Properties To Create",
+                    lstring: gettext("Properties To Create"),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: saveCasePropWidget,
@@ -231,15 +231,18 @@ define([
                                 });
 
                             if (requiredProps.length !== required.length) {
-                                return "You must include " + 
-                                    required.join(", ") + 
-                                    " columns to create a case";
+                                return util.format(
+                                    gettext("You must include {columns} columns to create a case"),
+                                    {columns: required.join(", ")}
+                                );
                             } else if (illegalProps.length > 0) {
-                                return "You can only use the following properties: " +
-                                    legal.join(', ');
+                                return gettext("You can only use the following properties:") +
+                                    " " + legal.join(', ');
                             } else if (invalidProps.length > 0) {
-                                return invalidProps.join(", ") + 
-                                    " are invalid properties";
+                                return util.format(
+                                    gettext("{props} are invalid properties"),
+                                    {props: invalidProps.join(", ")}
+                                );
                             }
 
                         }
@@ -247,13 +250,13 @@ define([
                     }
                 },
                 useClose: {
-                    lstring: "Close Case",
+                    lstring: gettext("Close Case"),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.checkbox
                 },
                 closeCondition: {
-                    lstring: "Close Condition",
+                    lstring: gettext("Close Condition"),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.xPath,
@@ -261,13 +264,13 @@ define([
                     deserialize: mugs.deserializeXPath,
                 },
                 useUpdate: {
-                    lstring: "Update Case",
+                    lstring: gettext("Update Case"),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.checkbox
                 },
                 updateProperty: {
-                    lstring: "Properties To Update",
+                    lstring: gettext("Properties To Update"),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: saveCasePropWidget,
@@ -279,21 +282,23 @@ define([
                                 });
 
                             if (invalidProps.length > 0) {
-                                return invalidProps.join(", ") + 
-                                    " are invalid properties";
+                                return util.format(
+                                    gettext("{props} are invalid properties"),
+                                    {props: invalidProps.join(", ")}
+                                );
                             }
                         }
                         return 'pass';
                     }
                 },
                 useIndex: {
-                    lstring: "Use Index",
+                    lstring: gettext("Use Index"),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.checkbox
                 },
                 indexProperty: {
-                    lstring: "Index Properties",
+                    lstring: gettext("Index Properties"),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: indexCaseWidget,
@@ -311,23 +316,25 @@ define([
                                 });
 
                             if (invalidProps.length > 0) {
-                                return invalidProps.join(", ") + 
-                                    " are invalid properties";
+                                return util.format(
+                                    gettext("{props} are invalid properties"),
+                                    {props: invalidProps.join(", ")}
+                                );
                             } else if (invalidRelationships.length > 0) {
-                                return "Relationship must be child or extension";
+                                return gettext("Relationship must be child or extension");
                             }
                         }
                         return 'pass';
                     }
                 },
                 useAttachment: {
-                    lstring: "Use Attachments",
+                    lstring: gettext("Use Attachments"),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: widgets.checkbox
                 },
                 attachmentProperty: {
-                    lstring: "Attachment Properties",
+                    lstring: gettext("Attachment Properties"),
                     visibility: 'visible',
                     presence: 'optional',
                     widget: attachmentCaseWidget,
@@ -352,18 +359,20 @@ define([
                             });
 
                         if (invalidProps.length > 0) {
-                            return invalidProps.join(", ") + 
-                                " are invalid properties";
+                            return util.format(
+                                gettext("{props} are invalid properties"),
+                                {props: invalidProps.join(", ")}
+                            );
                         }
 
                         if (invalidFroms.length > 0) {
-                            return "The from attribute must be one of: " + 
-                                "local, remote, or inline";
+                            return gettext("The from attribute must be one of: " +
+                                "local, remote, or inline");
                         }
                         
                         if (invalidInlines.length > 0) {
-                            return "Inlined attachments must have an " +
-                                "attachment name";
+                            return gettext("Inlined attachments must have an " +
+                                "attachment name");
                         }
 
                         return "pass";
@@ -580,7 +589,7 @@ define([
             SaveToCase: [
                 {
                     slug: "main",
-                    displayName: "Basic",
+                    displayName: gettext("Basic"),
                     properties: [
                         "nodeID",
                         "date_modified",
@@ -591,7 +600,7 @@ define([
                 },
                 {
                     slug: "create",
-                    displayName: "Create",
+                    displayName: gettext("Create"),
                     properties: [
                         "useCreate",
                         "createProperty",
@@ -602,7 +611,7 @@ define([
                 },
                 {
                     slug: "update",
-                    displayName: "Update",
+                    displayName: gettext("Update"),
                     properties: [
                         "useUpdate",
                         "updateProperty",
@@ -613,7 +622,7 @@ define([
                 },
                 {
                     slug: "close",
-                    displayName: "Close",
+                    displayName: gettext("Close"),
                     properties: [
                         "useClose",
                         "closeCondition",
@@ -624,7 +633,7 @@ define([
                 },
                 {
                     slug: "index",
-                    displayName: "Index",
+                    displayName: gettext("Index"),
                     properties: [
                         "useIndex",
                         "indexProperty",
@@ -635,7 +644,7 @@ define([
                 },
                 {
                     slug: "attachment",
-                    displayName: "Attachments",
+                    displayName: gettext("Attachments"),
                     properties: [
                         "useAttachment",
                         "attachmentProperty",
@@ -742,9 +751,11 @@ define([
                             mug.p[attr.mugProp] = el.attr(attr.elAttr);
                             return;
                         }
-                        form.parseWarnings.push(
-                            "An error occurred when parsing bind node [" +
-                            path + "]. Please fix this.");
+                        form.parseWarnings.push(util.format(
+                            gettext("An error occurred when parsing bind " + 
+                                    "node [{path}]. Please fix this."),
+                            {path: path}
+                        ));
                         return;
                     }
                 }

--- a/src/templates/auto_box.html
+++ b/src/templates/auto_box.html
@@ -1,6 +1,6 @@
 <div class="fd-itextID-checkbox-container col-sm-1">
     <label class="checkbox">
         <!-- checkbox goes here -->
-        auto?
+        <%-gettext("auto?")%>
     </label>
 </div>

--- a/src/templates/copy_paste_help.html
+++ b/src/templates/copy_paste_help.html
@@ -1,5 +1,5 @@
 <div class="fd-copy-paste-help">
-    <h3>Copying and Pasting Questions</h3>
+    <h3><%-gettext("Copying and Pasting Questions")%></h3>
     <div class="copy-paste-help">
         <%-gettext("These actions are available via the browser's Edit menu, and you can also use:")%>
         <div class="row">

--- a/src/templates/copy_paste_help.html
+++ b/src/templates/copy_paste_help.html
@@ -1,11 +1,11 @@
 <div class="fd-copy-paste-help">
     <h3>Copying and Pasting Questions</h3>
     <div class="copy-paste-help">
-        These actions are available via the browser's Edit menu, and you can also use:
+        <%-gettext("These actions are available via the browser's Edit menu, and you can also use:")%>
         <div class="row">
             <div class="col-sm-3">
                 <h1><%=metachar%>C</h1>
-                <span>for copy</span>
+                <span><%-gettext("for copy")%></span>
             </div>
             <!--div class="col-sm-3">
                 <h1><%=metachar%>X</h1>
@@ -13,23 +13,22 @@
             </div-->
             <div class="col-sm-3">
                 <h1><%=metachar%>V</h1>
-                <span>for paste</span>
+                <span><%-gettext("for paste")%></span>
             </div>
         </div>
     </div>
     <div class="copy-paste-box hide">
-        <p>Copy from or Paste into this text box: <textarea></textarea></p>
-        <p><button class="btn btn-default insert-questions">Insert Questions</button></p>
+        <p><%-gettext("Copy from or Paste into this text box:")%> <textarea></textarea></p>
+        <p><button class="btn btn-default insert-questions"><%-gettext("Insert Questions")%></button></p>
     </div>
-    <h3>Selecting Multiple Questions</h3>
+    <h3><%-gettext("Selecting Multiple Questions")%></h3>
     <div class="row">
-        Hold <strong><%
-            if (metachar[metachar.length - 1] === "+") {
-                %><%=metachar.slice(0, -1)%><%
-            } else {
-                %><%=metachar%><%
-            } %></strong> and click on each question.
+        <%
+            var key = metachar.endsWith("+") ? metachar.slice(0, -1) : metachar;
+            key = "<strong>" + key + "</strong>";
+            print(format(gettext("Hold {key} and click on each question."), {key: key}));
+        %>
     </div>
-    <h3>Other Tips</h3>
-    <p>Questions can be copied between forms, and even to other apps.</p>
+    <h3><%-gettext("Other Tips")%></h3>
+    <p><%-gettext("Questions can be copied between forms, and even to other apps.")%></p>
 </div>

--- a/src/templates/data_source_editor.html
+++ b/src/templates/data_source_editor.html
@@ -2,11 +2,11 @@
 
     <fieldset class="data-source-advanced">
         <legend>
-            <i class="fa fa-cog"></i> Edit Data Source
+            <i class="fa fa-cog"></i> <%-gettext("Edit Data Source")%>
         </legend>
         <div class="form-group">
             <label class="control-label col-sm-2">
-                Query Expression
+                <%-gettext("Query Expression")%>
             </label>
             <div class="col-sm-10">
                 <textarea rows="5"
@@ -15,15 +15,15 @@
                 <p class="help-block">
                     <a target="_blank"
                        href="https://help.commcarehq.org/display/commcarepublic/Common+Logic+and+Calculations">
-                        <i class="fa fa-info-circle"></i> Guide to Common Logic and Calculations
+                        <i class="fa fa-info-circle"></i> <%-gettext("Guide to Common Logic and Calculations")%>
                     </a>
                 </p>
             </div>
         </div>
-        <legend>Optional Instance Properties</legend>
+        <legend><%-gettext("Optional Instance Properties")%></legend>
         <div class="form-group">
             <label class="control-label col-sm-2">
-                Instance ID
+                <%-gettext("Instance ID")%>
             </label>
             <div class="col-sm-10">
                 <input name="instance-id" type="text" class="form-control jstree-drop" />
@@ -31,7 +31,7 @@
         </div>
         <div class="form-group">
             <label class="control-label col-sm-2">
-                Instance URI
+                <%-gettext("Instance URI")%>
             </label>
             <div class="col-sm-10">
                 <input name="instance-src" type="text" class="form-control jstree-drop" />
@@ -42,8 +42,8 @@
     <div class="form-actions form-actions-condensed fd-data-source-actions">
         <div class="col-sm-2"></div>
         <div class="col-sm-10">
-            <button type="button" class="btn btn-primary fd-data-source-save-button">Save</button>
-            <button type="button" class="btn btn-default fd-data-source-cancel-button">Cancel</button>
+            <button type="button" class="btn btn-primary fd-data-source-save-button"><%-gettext("Save")%></button>
+            <button type="button" class="btn btn-default fd-data-source-cancel-button"><%-gettext("Cancel")%></button>
         </div>
     </div>
     </div>

--- a/src/templates/date_format_menu.html
+++ b/src/templates/date_format_menu.html
@@ -1,5 +1,5 @@
 <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu">
-    <li style="padding-left: 10px;"><strong>Date Format Options</strong></li>
+    <li style="padding-left: 10px;"><strong><%-gettext("Date Format Options")%></strong></li>
     <% _.each(formats, function (label, format) { %>
         <li><a tabindex="-1" href="#" data-format="<%= format %>"><%= label %></a></li>
     <% }); %>

--- a/src/templates/easy_reference_popover.html
+++ b/src/templates/easy_reference_popover.html
@@ -2,7 +2,7 @@
 <% if (ufid) { %>
     <p>
         <a href="#" class="jstree-hover" data-ufid="<%= ufid %>">
-            show in question list
+            <%-gettext("show in question list")%>
         </a>
     </p>
 <% } %>

--- a/src/templates/external_sources_tree.html
+++ b/src/templates/external_sources_tree.html
@@ -1,7 +1,7 @@
 <div class="fd-external-sources-container">
     <div class="fd-head fd-head-external-sources">
         <div class="fd-head-max-indicator"><i class="fa fa-arrow-circle-o-down"></i></div>
-        <h2>App Properties</h2>
+        <h2><%-gettext("App Properties")%></h2>
     </div>
     <div class="fd-scrollable">
         <div class="fd-external-resource-search">
@@ -11,7 +11,7 @@
                     <input type="text"
                         id="fdExternalSearch"
                         class="form-control search-query"
-                        placeholder="Search..."
+                        placeholder="<%-gettext("Search...")%>"
                         style="width: calc(100% - 42px);"
                         autocomplete="off" >
                 </div>

--- a/src/templates/find_usages.html
+++ b/src/templates/find_usages.html
@@ -1,8 +1,8 @@
 <table class="table table-hover">
   <thead>
-    <th>Question</th>
-    <th>Used By</th>
-    <th>In Property</th>
+    <th><%-gettext("Question")%></th>
+    <th><%-gettext("Used By")%></th>
+    <th><%-gettext("In Property")%></th>
   </thead>
   <% _.each(tableData, function(refs, question) { %>
      <tr>

--- a/src/templates/find_usages_search.html
+++ b/src/templates/find_usages_search.html
@@ -8,7 +8,7 @@
         <input type="text"
                class="form-control search-query"
                id="findUsagesSearch"
-               placeholder="Search..."
+               placeholder="<%-gettext("Search...")%>"
                style="width: calc(100% - 42px);"
                autocomplete="off"/>
       </div>

--- a/src/templates/language_selector.html
+++ b/src/templates/language_selector.html
@@ -1,5 +1,5 @@
 <li class="divider language-selector"></li>
-<li class="dropdown-header language-selector">Display</li>
+<li class="dropdown-header language-selector"><%-gettext("Display")%></li>
 <% _.each(languages, function(language) { %>
 <li><a tabindex="-1" href="#" class="fd-display-item language-selector" data-code="<%-language.code%>"><i class="fa fa-check"></i><%-language.name%><%
     if (language.name !== language.code && language.code !== '_ids') {

--- a/src/templates/main.html
+++ b/src/templates/main.html
@@ -4,7 +4,7 @@
             <div class="fd-head">
                 <h2>
                     <i class="fd-form-icon"></i>
-                    <span class="fd-head-text">Questions</span>
+                    <span class="fd-head-text"><%-gettext("Questions")%></span>
                 </h2>
                 <div class="fd-head-menu-container">
                     <div class="dropdown">
@@ -18,19 +18,19 @@
                             <li>
                                 <a class="fd-button-copy">
                                     <i class="fa fa-copy"></i>
-                                    Copy<span class="hotkey"><%-ctrl%>C</span>
+                                    <%-gettext("Copy")%><span class="hotkey"><%-ctrl%>C</span>
                                 </a>
                             </li>
                             <li>
                                 <a class="fd-expand-all">
                                     <i class="fa fa-angle-double-down"></i>
-                                    Expand All<span class="hotkey"><%-ctrl%><%-alt%>=</span>
+                                    <%-gettext("Expand All")%><span class="hotkey"><%-ctrl%><%-alt%>=</span>
                                 </a>
                             </li>
                             <li>
                                 <a class="fd-collapse-all">
                                     <i class="fa fa-angle-double-right"></i>
-                                    Collapse All<span class="hotkey"><%-ctrl%><%-alt%>&ndash;</span>
+                                    <%-gettext("Collapse All")%><span class="hotkey"><%-ctrl%><%-alt%>&ndash;</span>
                                 </a>
                             </li>
                             <li class="divider fd-tools-menu"></li>
@@ -41,7 +41,7 @@
             </div>
             <div class="dropdown fd-add-question-dropdown">
                 <a class="fd-add-question dropdown-toggle btn btn-purple" data-toggle="dropdown" href="#">
-                    <i class="fa fa-plus"></i> Add Question
+                    <i class="fa fa-plus"></i> <%-gettext("Add Question")%>
                     <i class="fa fa-caret-down"></i>
                 </a>
             </div>
@@ -51,7 +51,12 @@
                 <div class="hide fd-default-panel fd-default-qtree">
                   <div class="helpbubble helpbubble-purple helpbubble-top-left">
                     <p class="lead">
-                      Click <i class="fa fa-plus"></i> <strong>Add Question</strong> to start building your form.
+                    <%
+                        var msg = gettext("Click {btn} to start building your form."),
+                            add = gettext("Add Question"),
+                            btn = '<i class="fa fa-plus"></i> <strong>' + add + '</strong>';
+                        print(format(msg, {btn: btn}));
+                    %>
                     </p>
                     <p class="fd-default-helptext"></p>
                   </div>
@@ -67,14 +72,14 @@
             <div class="btn-group fd-save-button"></div>
         </div>
         <div class="fd-column fd-question-properties hide">
-            <div class="fd-head"><h2>Question Details</h2></div>
+            <div class="fd-head"><h2><%-gettext("Question Details")%></h2></div>
             <div class="fd-props-toolbar"></div>
             <div class="fd-scrollable fd-props-scrollable">
                 <form class="form form-horizontal fd-props-content"></form>
             </div>
         </div>
         <div class="fd-xpath-editor fd-column hide">
-            <div class="fd-head"><h2>Expression Editor</h2></div>
+            <div class="fd-head"><h2><%-gettext("Expression Editor")%></h2></div>
             <div class="fd-scrollable full">
                 <div class="fd-xpath-editor-content"></div>
             </div>

--- a/src/templates/markdown_help.html
+++ b/src/templates/markdown_help.html
@@ -3,9 +3,9 @@
       <a href="#" tabindex="-1"
         data-title="<%-title%>"
         data-placement="right"
-        data-content="Use text formatting to <strong>bold</strong> and <em>italicize</em> words, use bulleted lists, and <a target='_blank' href='https://help.commcarehq.org/display/commcarepublic/Text+Formatting'>more</a>"
+        data-content="<%-gettext("Use text formatting to <strong>bold</strong> and <em>italicize</em> words, use bulleted lists, and <a target='_blank' href='https://help.commcarehq.org/display/commcarepublic/Text+Formatting'>more</a>")%>"
       ></a>
     </div>
-    <a href="#" class="turn-markdown-off markdown-trigger clearfix">Turn Off Text Formatting</a>
-    <a href="#" class="turn-markdown-on markdown-trigger clearfix">Turn On Text Formatting</a>
+    <a href="#" class="turn-markdown-off markdown-trigger clearfix"><%-gettext("Turn Off Text Formatting")%></a>
+    <a href="#" class="turn-markdown-on markdown-trigger clearfix"><%-gettext("Turn On Text Formatting")%></a>
 </div>

--- a/src/templates/markdown_help.html
+++ b/src/templates/markdown_help.html
@@ -3,7 +3,7 @@
       <a href="#" tabindex="-1"
         data-title="<%-title%>"
         data-placement="right"
-        data-content="<%-gettext("Use text formatting to <strong>bold</strong> and <em>italicize</em> words, use bulleted lists, and <a target='_blank' href='https://help.commcarehq.org/display/commcarepublic/Text+Formatting'>more</a>")%>"
+        data-content="<%=gettext("Use text formatting to <strong>bold</strong> and <em>italicize</em> words, use bulleted lists, and <a target='_blank' href='https://help.commcarehq.org/display/commcarepublic/Text+Formatting'>more</a>")%>"
       ></a>
     </div>
     <a href="#" class="turn-markdown-off markdown-trigger clearfix"><%-gettext("Turn Off Text Formatting")%></a>

--- a/src/templates/multimedia_block.html
+++ b/src/templates/multimedia_block.html
@@ -2,14 +2,14 @@
     <div class="col-sm-12">
         <button type="button" class="btn btn-default fd-mm-path-show pull-right">
             <i class="fa fa-cog"></i>
-            Advanced: Show Path
+            <%-gettext("Advanced: Show Path")%>
         </button>
         <div class="fd-mm-upload-trigger"></div>
     </div>
 </div>
 <div class="control-row">
     <div class="fd-mm-path hide col-sm-12">
-        <button type="button" class="btn btn-default fd-mm-path-hide pull-right">Hide Path</button>
+        <button type="button" class="btn btn-default fd-mm-path-hide pull-right"><%-gettext("Hide Path")%></button>
         <div class="fd-mm-path-input"></div>
     </div>
 </div>

--- a/src/templates/multimedia_errors.html
+++ b/src/templates/multimedia_errors.html
@@ -1,9 +1,9 @@
 <% if (errors.length > 0) { %>
     <div class="alert alert-danger">
-        <h5>Errors found</h5>
+        <h5><%-gettext("Errors found")%></h5>
         <% for (var e = 0; e < errors.length; e++) {
             var error = errors[e]; %>
-            <p><%= error %></p>
+            <p><%- error %></p>
         <% } %>
     </div>
 <% } %>

--- a/src/templates/multimedia_existing_audio.html
+++ b/src/templates/multimedia_existing_audio.html
@@ -2,8 +2,8 @@
     <a href="<%= url %>"
        class="btn btn-default existing-media"
        target="_blank"
-       data-toggle="tooltip" data-title="Opens file in new tab.">Open Audio</a>
+       data-toggle="tooltip" data-title="<%-gettext("Opens file in new tab.")%>"><%-gettext("Open Audio")%></a>
 </p>
 <p class="text-success hqm-upload-completed hide">
-    <span class="label label-success">New Audio Uploaded Successfully</span>
+    <span class="label label-success"><%-gettext("New Audio Uploaded Successfully")%></span>
 </p>

--- a/src/templates/multimedia_existing_image.html
+++ b/src/templates/multimedia_existing_image.html
@@ -3,8 +3,8 @@
     <a href="<%= url %>"
        class="btn btn-default existing-media"
        target="_blank"
-       data-toggle="tooltip" data-title="Opens image in new tab.">View Full Size</a>
+       data-toggle="tooltip" data-title="<%-gettext("Opens image in new tab.")%>"><%-gettext("View Full Size")%></a>
 </p>
 <p class="text-success hqm-upload-completed hide">
-    <span class="label label-success">New Image Uploaded Successfully</span>
+    <span class="label label-success"><%-gettext("New Image Uploaded Successfully")%></span>
 </p>

--- a/src/templates/multimedia_existing_text.html
+++ b/src/templates/multimedia_existing_text.html
@@ -2,8 +2,8 @@
     <a href="<%= url %>"
        class="btn btn-default existing-media"
        target="_blank"
-       data-toggle="tooltip" data-title="Opens file in new tab.">Open HTML</a>
+       data-toggle="tooltip" data-title="<%-gettext("Opens file in new tab.")%>"><%-gettext("Open HTML")%></a>
 </p>
 <p class="text-success hqm-upload-completed hide">
-    <span class="label label-success">New HTML Document Uploaded Successfully</span>
+    <span class="label label-success"><%-gettext("New HTML Document Uploaded Successfully")%></span>
 </p>

--- a/src/templates/multimedia_existing_video.html
+++ b/src/templates/multimedia_existing_video.html
@@ -2,8 +2,8 @@
     <a href="<%= url %>"
        class="btn btn-default existing-media"
        target="_blank"
-       data-toggle="tooltip" data-title="Opens file in new tab.">Open Video</a>
+       data-toggle="tooltip" data-title="<%-gettext("Opens file in new tab.")%>"><%-gettext("Open Video")%></a>
 </p>
 <p class="text-success hqm-upload-completed hide">
-    <span class="label label-success">New Video Uploaded Successfully</span>
+    <span class="label label-success"><%-gettext("New Video Uploaded Successfully")%></span>
 </p>

--- a/src/templates/multimedia_modal.html
+++ b/src/templates/multimedia_modal.html
@@ -3,55 +3,55 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title">Upload <%= mediaType %></h4>
+                <h4 class="modal-title"><%-gettext("Upload")%> <%= mediaType %></h4>
             </div>
             <div class="modal-body form form-horizontal">
                 <div class="form-group">
                     <label class="col-sm-4 control-label">
-                        Select new <%= mediaType %>
+                        <%-gettext("Select new")%> <%= mediaType %>
                     </label>
                     <div class="col-sm-8">
                         <div class="hqm-select-files-container">
-                            <button class="hqm-select btn btn-primary" type="button">Select File</button>
+                            <button class="hqm-select btn btn-primary" type="button"><%-gettext("Select File")%></button>
                         </div>
                         <div class="hqm-queue"></div>
                     </div>
                 </div>
                 <div class="form-group hqm-existing hide">
                     <label class="col-sm-4 control-label">
-                        Current <%= mediaType %>
+                        <%-gettext("Current")%> <%= mediaType %>
                     </label>
                     <div class="col-sm-8 hqm-existing-controls">
                     </div>
                 </div>
                 <div class="hqm-upload-form">
                     <fieldset class="hqm-sharing hide">
-                        <legend>Multimedia Sharing Options</legend>
+                        <legend><%-gettext("Multimedia Sharing Options")%></legend>
                         <div class="form-group">
-                            <label class="control-label col-sm-4" for="fd-mm-<%= mediaType %>-license">License</label>
+                            <label class="control-label col-sm-4" for="fd-mm-<%= mediaType %>-license"><%-gettext("License")%></label>
                             <div class="col-sm-8">
                                 <select name="license" id="fd-mm-<%= mediaType %>-license">
-                                    <option value="cc-nc">Creative Commons Attribution, Non-Commercial</option>
-                                    <option value="cc-nd">Creative Commons Attribution, No Derivatives</option>
-                                    <option value="cc" selected="selected">Creative Commons Attribution</option>
-                                    <option value="cc-nc-sa">Creative Commons Attribution, Non-Commercial, and Share Alike</option>
-                                    <option value="cc-nc-nd">Creative Commons Attribution, Non-Commercial, and No Derivatives</option>
-                                    <option value="cc-sa">Creative Commons Attribution, Share Alike</option>
+                                    <option value="cc-nc"><%-gettext("Creative Commons Attribution, Non-Commercial")%></option>
+                                    <option value="cc-nd"><%-gettext("Creative Commons Attribution, No Derivatives")%></option>
+                                    <option value="cc" selected="selected"><%-gettext("Creative Commons Attribution")%></option>
+                                    <option value="cc-nc-sa"><%-gettext("Creative Commons Attribution, Non-Commercial, and Share Alike")%></option>
+                                    <option value="cc-nc-nd"><%-gettext("Creative Commons Attribution, Non-Commercial, and No Derivatives")%></option>
+                                    <option value="cc-sa"><%-gettext("Creative Commons Attribution, Share Alike")%></option>
                                 </select>
                             </div>
                         </div>
                         <div class="form-group">
-                            <label class="col-sm-4 control-label" for="fd-mm-<%= mediaType %>-author">Author</label>
+                            <label class="col-sm-4 control-label" for="fd-mm-<%= mediaType %>-author"><%-gettext("Author")%></label>
                             <div class="col-sm-8">
                                 <input type="text"
                                        name="author"
                                        id="fd-mm-<%= mediaType %>-author"
-                                       placeholder="Enter the name of the author." />
+                                       placeholder="<%-gettext("Enter the name of the author.")%>" />
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-4 control-label" for="fd-mm-<%= mediaType %>-attribution">
-                                Attribution Notes
+                                <%-gettext("Attribution Notes")%>
                             </label>
                             <div class="col-sm-8">
                                 <textarea name="attribution-notes"
@@ -63,9 +63,9 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <a href="#" class="btn btn-default" data-dismiss="modal">Close</a>
+                <a href="#" class="btn btn-default" data-dismiss="modal"><%-gettext("Close")%></a>
                 <a href="#" class="btn btn-default disabled hqm-upload hqm-upload-confirm">
-                    <i class="fa fa-cloud-upload"></i> Begin Upload
+                    <i class="fa fa-cloud-upload"></i> <%-gettext("Begin Upload")%>
                 </a>
             </div>
         </div>

--- a/src/templates/multimedia_nomedia.html
+++ b/src/templates/multimedia_nomedia.html
@@ -1,4 +1,4 @@
 <p class="fd-mm-no-ref">
     <i class="<%=iconClass%>"></i>
-    No Reference
+    <%-gettext("No Reference")%>
 </p>

--- a/src/templates/multimedia_queue.html
+++ b/src/templates/multimedia_queue.html
@@ -7,13 +7,17 @@
             <div class="progress-bar" style="width: 0%;"></div>
         </div>
         <p class="text-success hqm-begin">
-            Ready to upload. Click <strong>Begin Upload</strong> below to start.
+        <%
+            var msg = gettext("Ready to upload. Click {btn} below to start."),
+                btn = "<strong>" + gettext("Begin Upload") + "</strong>";
+            print(msg.replace(/\{btn\}/g, btn));
+        %>
         </p>
         <p class="text-danger hqm-error hide">
-            <span class="label label-danger">There were errors.</span>
+            <span class="label label-danger"><%-gettext("There were errors.")%></span>
         </p>
         <a href="#" class="btn btn-danger btn-xs pull-right hqm-cancel hide">
-            <i class="fa fa-remove"></i> Cancel Upload
+            <i class="fa fa-remove"></i> <%-gettext("Cancel Upload")%>
         </a>
     </div>
     <div class="hqm-status"></div>

--- a/src/templates/multimedia_upload_trigger.html
+++ b/src/templates/multimedia_upload_trigger.html
@@ -1,5 +1,5 @@
 <a href="#<%= uploaderId %>"
    class="btn btn-primary"
    data-toggle="modal">
-    <% if (multimediaExists) { %>Replace<% } else { %>Upload<% } %> <%=mediaType%>
+    <%- multimediaExists ? gettext("Replace") : gettext("Upload") %> <%=mediaType%>
 </a>

--- a/src/templates/question_toolbar.html
+++ b/src/templates/question_toolbar.html
@@ -3,7 +3,7 @@
     <div class="btn-toolbar pull-right">
         <% if (isDeleteable) { %>
             <button type="button" class="btn btn-danger fd-button-remove"  tabindex="-1">
-                <i class="fa fa-trash-o"></i> Delete
+                <i class="fa fa-trash-o"></i> <%-gettext("Delete")%>
             </button>
         <% } %>
         <% if (sections.length) { %>
@@ -13,7 +13,7 @@
                     <i class="fa fa-caret-down"></i>
                 </a>
                 <ul class="dropdown-menu dropdown-menu-right checklist">
-                    <li class="dropdown-header">Show</li>
+                    <li class="dropdown-header"><%-gettext("Show")%></li>
                     <% _.each(sections, function(section) { %>
                     <li>
                         <a href="#" data-slug="<%= section.slug %>" <% if (section.show) { %>class="selected"<% } %>>

--- a/src/templates/question_type_changer.html
+++ b/src/templates/question_type_changer.html
@@ -6,9 +6,9 @@
     </a>
     <ul class="dropdown-menu">
         <% if (questions.length === 0) { %>
-            <li class="dropdown-header">Cannot Change Question Type</li>
+            <li class="dropdown-header"><%-gettext("Cannot Change Question Type")%></li>
         <% } else { %>
-            <li class="dropdown-header">Change Question Type To</li>
+            <li class="dropdown-header"><%-gettext("Change Question Type To")%></li>
             <% _.each(questions, function(question) { %>
             <li>
                 <a href="#" class="change-question" data-qtype="<%=question.slug%>">

--- a/src/templates/undo_alert.html
+++ b/src/templates/undo_alert.html
@@ -1,9 +1,16 @@
 <div class="fd-undo-delete alert alert-<%= errors.length ? "danger" : "success" %> fade in">
   <button type="button" class="close">&times;</button>
-  You have deleted a question. <a href="#" class="fd-undo">Undo</a>
+  <%-gettext("You have deleted a question.")%> <a href="#" class="fd-undo"><%-gettext("Undo")%></a>
   <% if (errors.length) { %>
-    <p>Warning: <%= errors.join(", ") %>
-      <% errors.length > 1 ? "are" : "is" %>
-      still referenced by other questions.</p>
+    <p><%
+      print(format(
+        ngettext(
+          "Warning: {errs} is still referenced by other questions.",
+          "Warning: {errs} are still referenced by other questions.",
+          errors.length
+        ),
+        {errs: errors.join(", ")}
+      ))
+    %></p>
   <% } %>
 </div>

--- a/src/templates/widget_attachment_case.html
+++ b/src/templates/widget_attachment_case.html
@@ -5,7 +5,7 @@
     <div class="form-group">
       <div class="col-sm-11">
         <input class="fd-attachment-property-name form-control"
-               value="<%-k%>" type="text" placeholder="Node Name"/>
+               value="<%-k%>" type="text" placeholder="<%-gettext("Node Name")%>"/>
       </div>
       <div class="col-sm-1">
         <a href="#" class="btn fd-remove-property btn-sm btn-danger">
@@ -16,19 +16,19 @@
     <div class="form-group">
       <div class="col-sm-11">
         <input class="fd-attachment-property-source form-control"
-               value="<%-v['calculate']%>" type="text" placeholder="Source" />
+               value="<%-v['calculate']%>" type="text" placeholder="<%-gettext("Source")%>" />
       </div>
     </div>
     <div class="form-group">
       <div class="col-sm-11">
         <input class="fd-attachment-property-from form-control"
-               value="<%-v['from']%>" type="text" placeholder="From"/>
+               value="<%-v['from']%>" type="text" placeholder="<%-gettext("From")%>"/>
       </div>
     </div>
     <div class="form-group">
       <div class="col-sm-11">
         <input class="fd-attachment-name form-control"
-               value="<%-v['name']%>" type="text" placeholder="Attachment Name"/>
+               value="<%-v['name']%>" type="text" placeholder="<%-gettext("Attachment Name")%>"/>
       </div>
     </div>
   </div>

--- a/src/templates/widget_control_keyvalue.html
+++ b/src/templates/widget_control_keyvalue.html
@@ -14,5 +14,5 @@
             </div>
         </div>
     <% }); }); %>
-    <a href="#" class="btn btn-default fd-kv-add-pair hide"><i class="fa fa-plus"></i> <%-gettext("Add Key&rarr;Value Pair")%></a>
+    <a href="#" class="btn btn-default fd-kv-add-pair hide"><i class="fa fa-plus"></i> <%=gettext("Add Key&rarr;Value Pair")%></a>
 </div>

--- a/src/templates/widget_control_keyvalue.html
+++ b/src/templates/widget_control_keyvalue.html
@@ -3,10 +3,10 @@
     <% _.each(pairs, function (v, k) { _.each(_.isArray(v) ? v : [v], function (v) { %>
         <div class="fd-kv-pair form-group">
             <div class="col-sm-3">
-                <input class="fd-kv-key form-control" type="text" value="<%=k%>" placeholder="key" />
+                <input class="fd-kv-key form-control" type="text" value="<%=k%>" placeholder="<%-gettext("key")%>" />
             </div>
             <div class="col-sm-1 fd-kv-arrow"><i class="fa fa-arrow-right"></i></div>
-            <div class="col-sm-7"><input class="fd-kv-val form-control jstree-drop" type="text" value="<%=v%>" placeholder="value" /></div>
+            <div class="col-sm-7"><input class="fd-kv-val form-control jstree-drop" type="text" value="<%=v%>" placeholder="<%-gettext("value")%>" /></div>
             <div class="col-sm-1">
                 <a href="#" class="btn fd-kv-remove-pair btn-sm btn-danger<% if (k =='') { %> hide<% } %>">
                     <i class="fa fa-remove"></i>
@@ -14,5 +14,5 @@
             </div>
         </div>
     <% }); }); %>
-    <a href="#" class="btn btn-default fd-kv-add-pair hide"><i class="fa fa-plus"></i> Add Key&rarr;Value Pair</a>
+    <a href="#" class="btn btn-default fd-kv-add-pair hide"><i class="fa fa-plus"></i> <%-gettext("Add Key&rarr;Value Pair")%></a>
 </div>

--- a/src/templates/widget_index_case.html
+++ b/src/templates/widget_index_case.html
@@ -5,7 +5,7 @@
     <div class="form-group">
       <div class="col-sm-11">
         <input class="fd-index-property-name form-control"
-               value="<%-k%>" type="text" placeholder="Relationship Identifier (e.g. parent or host)"/>
+               value="<%-k%>" type="text" placeholder="<%-gettext("Relationship Identifier (e.g. parent or host)")%>"/>
       </div>
       <div class="col-sm-1">
         <a href="#" class="btn fd-remove-property btn-sm btn-danger">
@@ -16,19 +16,19 @@
     <div class="form-group">
       <div class="col-sm-11">
         <input class="fd-index-property-source form-control"
-               value="<%-v['calculate']%>" type="text" placeholder="Referenced Case ID" />
+               value="<%-v['calculate']%>" type="text" placeholder="<%-gettext("Referenced Case ID")%>" />
       </div>
     </div>
     <div class="form-group">
       <div class="col-sm-11">
         <input class="fd-index-property-case-type form-control"
-               value="<%-v['case_type']%>" type="text" placeholder="Referenced Case Type"/>
+               value="<%-v['case_type']%>" type="text" placeholder="<%-gettext("Referenced Case Type")%>"/>
       </div>
     </div>
     <div class="form-group">
       <div class="col-sm-11">
         <input class="fd-index-property-relationship form-control"
-               value="<%-v['relationship']%>" type="text" placeholder="Relationship (child or extension)"/>
+               value="<%-v['relationship']%>" type="text" placeholder="<%-gettext("Relationship (child or extension)")%>"/>
       </div>
     </div>
   </div>

--- a/src/templates/widget_save_to_case.html
+++ b/src/templates/widget_save_to_case.html
@@ -1,5 +1,5 @@
 <div class="well well-small">
   <%= internal_template({props: props}) %>
-  <a href="#" class="btn btn-default fd-add-property hide"><i class="fa fa-plus"></i> Add Property</a>
+  <a href="#" class="btn btn-default fd-add-property hide"><i class="fa fa-plus"></i> <%-gettext("Add Property")%></a>
 </div>
 <div class="messages" />

--- a/src/templates/widget_update_case.html
+++ b/src/templates/widget_update_case.html
@@ -5,7 +5,7 @@
     <div class="form-group">
       <div class="col-sm-11">
         <input class="fd-update-property-name form-control"
-               value="<%-k%>" type="text" placeholder="Property Name"/>
+               value="<%-k%>" type="text" placeholder="<%-gettext("Property Name")%>"/>
       </div>
       <div class="col-sm-1">
         <a href="#" class="btn fd-remove-property btn-sm btn-danger">
@@ -16,13 +16,13 @@
     <div class="form-group">
       <div class="col-sm-11">
         <input class="fd-update-property-source form-control"
-               value="<%-v['calculate']%>" type="text" placeholder="Calculation" />
+               value="<%-v['calculate']%>" type="text" placeholder="<%-gettext("Calculation")%>" />
       </div>
     </div>
     <div class="form-group">
       <div class="col-sm-11">
         <input class="fd-update-property-relevant form-control"
-               value="<%-v['relevant']%>" type="text" placeholder="Relevant"/>
+               value="<%-v['relevant']%>" type="text" placeholder="<%-gettext("Relevant")%>"/>
       </div>
     </div>
   </div>

--- a/src/templates/xpath.html
+++ b/src/templates/xpath.html
@@ -2,27 +2,27 @@
 
     <fieldset class="xpath-advanced hide">
         <legend> 
-            <i class="fa fa-cog"></i> Edit <span class='property-name'>Expression</span> (Advanced)
+            <i class="fa fa-cog"></i> <%-gettext("Edit <span class='property-name'>Expression</span> (Advanced)")%>
             <button type="button" class="btn btn-default fd-xpath-show-simple-button pull-right xpath-mode-toggle">
-                Show Simple Mode
+                <%-gettext("Show Simple Mode")%>
             </button>
         </legend>
         <div class="alert alert-info xpath-advanced-notice hide">
             <i class="fa fa-info-circle"></i>
-            You are currently in Advanced Mode because your logic is too complicated for Simple Mode.
+            <%-gettext("You are currently in Advanced Mode because your logic is too complicated for Simple Mode.")%>
         </div>
         <div class="form-group">
             <label class="control-label col-sm-2">
-                XPath Expression
+                <%-gettext("XPath Expression")%>
             </label>
             <div class="col-sm-10">
                 <<%= tag %> <%= tagArgs %>
                           class="fd-textarea form-control fd-xpath-editor-text jstree-drop"></<%= tag %>>
-                <p class="help-block">You can drag a question into the box.</p>
+                <p class="help-block"><%-gettext("You can drag a question into the box.")%></p>
                 <p class="help-block">
                     <a target="_blank"
                        href="https://help.commcarehq.org/display/commcarepublic/Common+Logic+and+Calculations">
-                        <i class="fa fa-info-circle"></i> Guide to Common Logic and Calculations
+                        <i class="fa fa-info-circle"></i> <%-gettext("Guide to Common Logic and Calculations")%>
                     </a>
                 </p>
             </div>
@@ -31,13 +31,13 @@
 
     <fieldset class="xpath-simple hide fieldset-condensed">
         <legend>
-            Edit <span class='property-name'>Expression</span>
+            <%-gettext("Edit <span class='property-name'>Expression</span>")%>
             <button type="button" class="btn btn-default pull-right xpath-mode-toggle fd-xpath-show-advanced-button">
-                <i class="fa fa-cog"></i> Show Advanced Mode
+                <i class="fa fa-cog"></i> <%-gettext("Show Advanced Mode")%>
             </button>
         </legend>
         <div class="form-group">
-            <label class="control-label col-sm-2">Result is</label>
+            <label class="control-label col-sm-2"><%-gettext("Result is")%></label>
             <div class="col-sm-10">
                 <select class="form-control top-level-join-select">
                     <% _.each(topLevelJoinOpts, function (opt) { %>
@@ -47,18 +47,18 @@
             </div>
         </div>
         <div class="form-group">
-            <label class="control-label col-sm-2">Expression</label>
+            <label class="control-label col-sm-2"><%-gettext("Expression")%></label>
             <div class="col-sm-10">
                 <div class="fd-xpath-editor-expressions well"></div>
                 <p class="help-block pull-right">
                     <a target="_blank"
                        href="https://help.commcarehq.org/display/commcarepublic/Common+Logic+and+Calculations">
-                        <i class="fa fa-info-circle"></i> Guide to Common Logic and Calculations
+                        <i class="fa fa-info-circle"></i> <%-gettext("Guide to Common Logic and Calculations")%>
                     </a>
                 </p>
                 <p>
                     <button type="button" class="btn btn-default fd-add-exp">
-                        <i class="fa fa-plus"></i> Add Expression
+                        <i class="fa fa-plus"></i> <%-gettext("Add Expression")%>
                     </button>
                 </p>
             </div>
@@ -70,8 +70,8 @@
     <div class="form-actions form-actions-condensed fd-xpath-actions">
         <div class="col-sm-2"></div>
         <div class="col-sm-10">
-            <button type="button" class="btn btn-default fd-xpath-save-button">Save</button>
-            <button type="button" class="btn btn-default fd-xpath-cancel-button">Cancel</button>
+            <button type="button" class="btn btn-default fd-xpath-save-button"><%-gettext("Save")%></button>
+            <button type="button" class="btn btn-default fd-xpath-cancel-button"><%-gettext("Cancel")%></button>
         </div>
     </div>
 </div>

--- a/src/templates/xpath.html
+++ b/src/templates/xpath.html
@@ -2,7 +2,7 @@
 
     <fieldset class="xpath-advanced hide">
         <legend> 
-            <i class="fa fa-cog"></i> <%-gettext("Edit <span class='property-name'>Expression</span> (Advanced)")%>
+            <i class="fa fa-cog"></i> <%=gettext("Edit <span class='property-name'>Expression</span> (Advanced)")%>
             <button type="button" class="btn btn-default fd-xpath-show-simple-button pull-right xpath-mode-toggle">
                 <%-gettext("Show Simple Mode")%>
             </button>
@@ -31,7 +31,7 @@
 
     <fieldset class="xpath-simple hide fieldset-condensed">
         <legend>
-            <%-gettext("Edit <span class='property-name'>Expression</span>")%>
+            <%=gettext("Edit <span class='property-name'>Expression</span>")%>
             <button type="button" class="btn btn-default pull-right xpath-mode-toggle fd-xpath-show-advanced-button">
                 <i class="fa fa-cog"></i> <%-gettext("Show Advanced Mode")%>
             </button>

--- a/src/templates/xpath_validation_errors.html
+++ b/src/templates/xpath_validation_errors.html
@@ -1,6 +1,6 @@
 <div class="alert alert-danger">
-    <h4><i class="fa fa-warning"></i> Validation Failed</h4>
-    <p>Please fix the error before leaving this page:</p>
+    <h4><i class="fa fa-warning"></i> <%-gettext("Validation Failed")%></h4>
+    <p><%-gettext("Please fix the error before leaving this page:")%></p>
     <pre>
       <%=errors%>
     </pre>

--- a/src/tree.js
+++ b/src/tree.js
@@ -153,7 +153,7 @@ define([
                 parentPath;
             if (dataParent) {
                 var dataParentMug = mug.form.getMugByPath(dataParent);
-                if (!dataParentMug) {
+                if (!dataParentMug || dataParentMug === mug) {
                     if (excludeRoot) {
                         parentPath = '';
                     } else {

--- a/src/undomanager.js
+++ b/src/undomanager.js
@@ -24,7 +24,10 @@ define([
         var refs = _.filter(_.map(mugs, function (mug) {
                 return mug.isReferencedByOtherMugs(mugs) ? mug.p.nodeID : "";
             }), _.identity);
-        $('.fd-undo-container').append(undo_alert({errors: refs}));
+        $('.fd-undo-container').append(undo_alert({
+            errors: refs,
+            format: util.format,
+        }));
     }
 
     function toggleAlert(undoStack) {

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -35,37 +35,37 @@ define([
     var SUPPORTED_EXTENSIONS = {
         image: [
             {
-                'description': 'Image',
+                'description': gettext('Image'),
                 'extensions': '*.jpg;*.png;*.gif'
             }
         ],
         audio: [
             {
-                'description': 'Audio',
+                'description': gettext('Audio'),
                 'extensions': '*.mp3;*.wav'
             }
         ],
         video: [
             {
-                'description': 'Video',
+                'description': gettext('Video'),
                 'extensions': '*.3gp;*.mp4'
             }
         ],
         'video-inline': [
             {
-                'description': 'Inline Video',
+                'description': gettext('Inline Video'),
                 'extensions': '*.3gp;*.mp4'
             }
         ],
         'expanded-audio': [
             {
-                'description': 'Audio with a Seekbar',
+                'description': gettext('Audio with a Seekbar'),
                 'extensions': '*.mp3;*.wav'
             }
         ],
         text: [
             {
-                'description': 'HTML',
+                'description': gettext('HTML'),
                 'extensions': '*.html'
             }
         ],

--- a/src/util.js
+++ b/src/util.js
@@ -372,5 +372,23 @@ define([
         return ref + " Reference";
     };
 
+    /**
+     * Simple string interpolation
+     *
+     * Usage: ``format("Across the {thing}", {thing: "Universe"})``
+     *
+     * Placeholder names must start with a letter and may contain
+     * letters, numbers and underscores. Unmatched placeholders are
+     * ignored.
+     */
+    that.format = function (string, map) {
+        return string.replace(/\{([a-z][\w_]*)\}/ig, function (match, key) {
+            if (map.hasOwnProperty(key)) {
+                return map[key];
+            }
+            return match;
+        });
+    };
+
     return that;
 });

--- a/src/util.js
+++ b/src/util.js
@@ -210,9 +210,9 @@ define([
     
     that.getOneOrFail = function (list, infoMsg) {
         if (list.length === 0) {
-            throw ("No match for " + infoMsg + " found!");
+            throw that.format(gettext("No match for {info} found!"), {info: infoMsg});
         } else if (list.length > 1) {
-            throw ("Multiple matches for " + infoMsg + " found!");
+            throw that.format(gettext("Multiple matches for {info} found!"), {info: infoMsg});
         }
         return list[0];
     };
@@ -282,9 +282,16 @@ define([
         }
         localForm = cleanForDiff(localForm);
         serverForm = cleanForDiff(serverForm);
-        var patch = jsdiff.createPatch("", serverForm, localForm, "Server Form", "Local Form");
+        var patch = jsdiff.createPatch(
+            "",
+            serverForm,
+            localForm,
+            gettext("Server Form"),
+            gettext("Local Form")
+        );
         patch = patch.replace(/^Index:/,
-                "XML " + (opts.not ? "should not be equivalent" : "mismatch"));
+            opts.not ? gettext("XML should not be equivalent") : gettext("XML mismatch")
+        );
         return patch;
     };
 

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -636,9 +636,9 @@ define([
         widget.addCustomIfNeeded = function (value) {
             var customOption = $('[name=property-androidIntentAppId]')
                 .find('option')
-                .filter(function () { return $(this).text() === "Custom"; });
+                .filter(function () { return $(this).text() === gettext("Custom"); });
             if (customOption.length === 0) {
-                widget.addOption(value, "Custom");
+                widget.addOption(value, gettext("Custom"));
             } else {
                 customOption.val(value);
             }
@@ -689,7 +689,7 @@ define([
 
         widget.dropdown.change(function () {
             var selectedOption = widget.dropdown.find(':selected');
-            widget.text.attr('readonly', selectedOption.text() !== "Custom");
+            widget.text.attr('readonly', selectedOption.text() !== gettext("Custom"));
             widget.text.val(selectedOption.val());
             super_handleChange();
         });

--- a/src/writer.js
+++ b/src/writer.js
@@ -89,7 +89,7 @@ define([
         xmlWriter.writeAttributeString("xmlns", uuid);
         xmlWriter.writeAttributeString("uiVersion", form.formUIVersion || "1");
         xmlWriter.writeAttributeString("version", form.formVersion || "1");
-        xmlWriter.writeAttributeString("name", form.formName || "New Form");
+        xmlWriter.writeAttributeString("name", form.formName || gettext("New Form"));
     };
 
     function write_html_tag_boilerplate (xmlWriter, form) {

--- a/test
+++ b/test
@@ -39,7 +39,7 @@ else
 fi
 
 if [[ "$run_jshint" == "true" ]]; then
-    jshint src/*.js \
-        && jshint --config tests/.jshintrc tests/*.js \
+    jshint src \
+        && jshint --config tests/.jshintrc tests \
         && echo "jshint passed"
 fi

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -17,6 +17,8 @@
     "unused": "vars",
     "globals": {
         "define": false,
+        "gettext": false,
+        "ngettext": false,
         "requirejs": false,
         /* MOCHA */
         "describe": false,

--- a/tests/diffDataParent.js
+++ b/tests/diffDataParent.js
@@ -207,5 +207,15 @@ define([
             );
             util.assertXmlEqual(call("createXML"), DATA_PARENT_MUG_IN_BETWEEN);
         });
+
+        it("should error on recursive data parent", function() {
+            util.loadXML("");
+            var mug = util.addQuestion("Text", 'mug');
+            assert.equal(mug.absolutePath, "/data/mug");
+            mug.p.dataParent = '#form/mug';
+            assert.deepEqual(mug.getErrors(),
+                [gettext("{path} is not a valid data parent")
+                    .replace("{path}", "#form/mug")]);
+        });
     });
 });

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -287,7 +287,7 @@ define([
                 text = errors.text();
             assert.equal(errors.length, 1, text);
             assert(text.indexOf("You have languages in your form that are not specified") > -1, text);
-            assert(text.indexOf("page: es.") > -1, text);
+            assert(text.indexOf("page: es") > -1, text);
         });
 
         it("should preserve itext values on load + save", function () {

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -120,7 +120,7 @@ define([
         it("should load and save the case type property", function () {
             util.loadXML(CASE_TYPE_PROPERTY_XML);
             var create = util.getMug("save_to_case");
-            window.console.log(create);
+            assert.isOk(create, "save_to_case mug should exist");
             util.assertXmlEqual(call("createXML"), CASE_TYPE_PROPERTY_XML);
         });
 

--- a/tests/typoglycemia.js
+++ b/tests/typoglycemia.js
@@ -1,0 +1,73 @@
+// Install word scrambling gettext functions if lang=eglinsh in URL
+(function () {
+    var placeholder = /^(\{.+?\}|\$\d)$/,
+        dictionary = {};
+
+    function typoglyceme(text) {
+        var words = text.split(" "),
+            info;
+        for (var i = words.length - 1; i >= 0; i--) {
+            if (!placeholder.test(words[i])) {
+                info = depunctuate(words[i]);
+                words[i] = scramble(info.word) + info.punctuation;
+            }
+        }
+        var result = words.join(" ");
+        if (result === text) {
+            result = "^" + result + "$";
+        }
+        return result;
+    }
+
+    function depunctuate(word) {
+        var match = /^(.*?)(\W*)$/.exec(word);
+        return {
+            original: word,
+            word: match[1],
+            punctuation: match[2],
+        };
+    }
+
+    function scramble(word) {
+        if (!dictionary.hasOwnProperty(word)) {
+            var letters = word.split("");
+            if (word.length === 2) {
+                letters = [word[1], word[0]];
+            } else if (word.length === 3 || word.length === 4) {
+                letters[1] = word[2];
+                letters[2] = word[1];
+            } else if (word.length > 4) {
+                var middle = shuffle(letters.slice(1, -1)).join("");
+                letters.splice(1, word.length - 2, middle);
+            }
+            dictionary[word] = letters.join("");
+        }
+        return dictionary[word];
+    }
+
+    // https://stackoverflow.com/a/2450976/10840
+    function shuffle(array) {
+        var currentIndex = array.length, temporaryValue, randomIndex;
+
+        // While there remain elements to shuffle...
+        while (0 !== currentIndex) {
+
+            // Pick a remaining element...
+            randomIndex = Math.floor(Math.random() * currentIndex);
+            currentIndex -= 1;
+
+            // And swap it with the current element.
+            temporaryValue = array[currentIndex];
+            array[currentIndex] = array[randomIndex];
+            array[randomIndex] = temporaryValue;
+        }
+        return array;
+    }
+
+    if (/[?&]typoglycemia(=true)?(&|#|$)/.test(window.location.href)) {
+        window.gettext = typoglyceme;
+        window.ngettext = function (singular, plural, count) {
+            return count === 1 ? typoglyceme(singular) : typoglyceme(plural);
+        };
+    }
+})();


### PR DESCRIPTION
I opted to use global `gettext` functions since it seemed like the simplest way to get this effort off the ground. It shouldn't be too hard to switch to a different i18n framework later if we decide that's better for whatever reason. However, this is not very nice for anyone who wants to use translated vellum outside of HQ. I don't know of anyone doing that, so not worrying about it for now. I suppose it would be possible to extract the translation from the HQ source if we wanted to package translations with vellum in the future.

I ran `vellum-to-hq` and then `./manage.py makemessages -d djangojs --all` and verified that it's picking up text from compiled vellum source files. One thing I am assuming is that the global `gettext` functions are installed before vellum is loaded in `form_designer.html` in HQ. If not, we'll have to do some finagling there.

Add `?typoglycemia` to the vellum stand-alone URL to verify that `gettext()` is getting called as expected inside vellum.

Best reviewed by commit 🐠 

@orangejenny @emord 