### PR TITLE
Sorted itemsets feature flag

### DIFF
--- a/src/itemset.js
+++ b/src/itemset.js
@@ -72,7 +72,8 @@ define([
             xmlWriter.writeStartElement('value');
             xmlWriter.writeAttributeString('ref', valueRef || '');
             xmlWriter.writeEndElement();
-            if (sortRef && sortRef.trim()) {
+            var features = mug.form.vellum.opts().features;
+            if (sortRef && sortRef.trim() && features.sorted_itemsets) {
                 xmlWriter.writeStartElement('sort');
                 xmlWriter.writeAttributeString('ref', sortRef);
                 xmlWriter.writeEndElement();
@@ -164,7 +165,9 @@ define([
             sortRef: {
                 lstring: 'Sort Field',
                 widget: refWidget,
-                visibility: 'visible',
+                visibility: function (mug) {
+                    return mug.form.vellum.opts().features.sorted_itemsets;
+                },
                 presence: 'optional',
                 validationFunc: validateRefWidget('sortRef'),
                 serialize: function (value, key, mug, data) {

--- a/src/itemset.js
+++ b/src/itemset.js
@@ -115,6 +115,9 @@ define([
                         if (value.labelRef) {
                             mug.p.labelRef = value.labelRef;
                         }
+                        if (value.sortRef) {
+                            mug.p.sortRef = value.sortRef;
+                        }
                     }
                     return value;
                 },

--- a/tests/itemset.js
+++ b/tests/itemset.js
@@ -200,6 +200,19 @@ define([
             );
         });
 
+        it("should update sortRef on paste dynamic select with sorted itemset", function () {
+            var data = [
+                ["id", "type", "labelItext:en-default", "instances", "itemsetData"],
+                ["/select", "SelectDynamic", "select",
+                 '{"foo":{"src":"jr://foo"}}',
+                 '[{"instance":{"id":"foo","src":"jr://foo"},' +
+                   '"nodeset":"instance(\'foo\')/foo/items","labelRef":"@name","valueRef":"@id","sortRef":"name"}]'],
+            ];
+            util.loadXML("");
+            util.paste(data);
+            assert.equal(util.getMug("select/itemset").p.sortRef, "name");
+        });
+
         describe("without access to lookup tables", function() {
             before(function (done) {
                 util.init({

--- a/tests/options.js
+++ b/tests/options.js
@@ -240,6 +240,7 @@ define(["underscore"], function (_) {
             'group_in_field_list': true,
             'rich_text': true,
             'advanced_itemsets': true,
+            'sorted_itemsets': true,
             'printing': true,
             'templated_intents': true,
             'custom_intents': true,


### PR DESCRIPTION
This is necessary because sorted itemsets are only supported on mobile 2.37+. HQ PR to follow.

Also fixed a bug when pasting sorted itemsets.

@emord @orangejenny 