### PR TITLE
Commander: match "Date and Time" before "Date"

### DIFF
--- a/src/commander.js
+++ b/src/commander.js
@@ -132,9 +132,16 @@ define([
             if (!getArg) {
                 throw new Error("getArg parameter is required");
             }
-            var source = _.map(items, function (item) {
-                return RegExp.escape(item.name);
-            }).join("|");
+            var source = _.chain(items)
+                .map(function (item) {
+                    return RegExp.escape(item.name);
+                })
+                .sortBy(function (name) {
+                    // long items first -> greedy match (before shorter items)
+                    return -name.length;
+                })
+                .value()
+                .join("|");
             return {regexp: source, items: items, getArg: getArg};
         }
 

--- a/tests/commander.js
+++ b/tests/commander.js
@@ -156,6 +156,7 @@ define([
             ["choice ", ["...after", "...before", "...in", "...first in",
                 "Multiple Choice Lookup Table"]],
             ["choice i", ["...in", "...first in"]],
+            ["Date and Time ", ["...after", "...before", "...in", "...first in"]],
         ], function (args) {
             var cmd = args[0],
                 items = args[1];


### PR DESCRIPTION
Bug discovered by @nsclark 

also
- "Multiple Choice Lookup Table" before "Multiple Choice"
- "Checkbox Lookup Table" before "Checkbox"

This issue prevented add question position autocomplete from working for certain question types.

@orangejenny @emord 