### PR TITLE
Expose messages publicly

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1856,7 +1856,6 @@ define([
 
     fn._resetMessages = function (errors) {
         var error, messages_div = this.$f.find('.fd-messages');
-        messages_div.empty();
 
         function asArray(value) {
             // TODO: I don't like this array business, should be refactored away
@@ -1875,12 +1874,18 @@ define([
             // default with a clickable indicator to show them?
 
             error = errors[errors.length - 1];
-            messages_div
-                .html(alert_global({
+            var showMessage = function() {
+                messages_div.html(alert_global({
                     messageType: MESSAGE_TYPES[error.level],
                     messages: asArray(error.message)
                 }))
-                .find('.alert').removeClass('hide').addClass('in');
+                .fadeIn(500);
+            };
+            if (messages_div.is(":visible")) {
+                messages_div.fadeOut(500, showMessage);
+            } else {
+                showMessage();
+            }
         }
     };
 

--- a/src/core.js
+++ b/src/core.js
@@ -102,15 +102,20 @@ define([
             icon: "fa fa-exclamation-circle",
         },
         "parse-warning": {
-            cssClass: "",
+            cssClass: "alert-warning",
             title: gettext("Warning"),
             icon: "fa fa-warning",
         },
         "form-warning": {
-            cssClass: "",
+            cssClass: "alert-warning",
             title: gettext("Form Warning"),
             icon: "fa fa-info-circle",
-        }
+        },
+        "info": {
+            cssClass: "alert-info",
+            title: gettext("Notification"),
+            icon: "fa fa-info-circle",
+        },
     };
 
     var fn = {};
@@ -1827,17 +1832,11 @@ define([
             });
     };
 
-    fn.alertUser = function(message, emphasis, append) {
-        var $container = this.$f.find("#alert-user"),
-            $content = $container.children("span");
-        if (emphasis) {
-            $container.addClass("alert-" + emphasis);
-        }
-        if (!append) {
-            $content.html('');
-        }
-        $content.append(message + "<br>");
-        $container.removeClass("hide");
+    fn.alertUser = function(message) {
+        this._resetMessages([{
+            level: 'info',
+            message: message,
+        }]);
     };
 
     fn.setTreeValidationIcon = function (mug) {

--- a/src/core.js
+++ b/src/core.js
@@ -1827,6 +1827,19 @@ define([
             });
     };
 
+    fn.alertUser = function(message, emphasis, append) {
+        var $container = this.$f.find("#alert-user"),
+            $content = $container.children("span");
+        if (emphasis) {
+            $container.addClass("alert-" + emphasis);
+        }
+        if (!append) {
+            $content.html('');
+        }
+        $content.append(message + "<br>");
+        $container.removeClass("hide");
+    };
+
     fn.setTreeValidationIcon = function (mug) {
         var node = mug.ufid && this.jstree("get_node", mug.ufid);
         if (node) {

--- a/src/less-style/structure.less
+++ b/src/less-style/structure.less
@@ -68,6 +68,16 @@ body.vellum-full-screen {
                 .fd-form-actions {
                     background-color: @cc-brand-mid !important; // lazy
                     padding: 5px 8px 8px;
+
+                    #alert-user {
+                        margin-left: 10px;
+                        margin-bottom: 0;
+                        padding: 7px 15px;
+
+                        .close {
+                            margin-left: 5px;
+                        }
+                    }
                 }
             }
 

--- a/src/less-style/structure.less
+++ b/src/less-style/structure.less
@@ -66,7 +66,7 @@ body.vellum-full-screen {
 
                 // Bar with save button
                 .fd-form-actions {
-                    background: @navbarBackground;
+                    background-color: @cc-brand-mid !important; // lazy
                     padding: 5px 8px 8px;
                 }
             }
@@ -155,7 +155,7 @@ body.vellum-full-screen {
         // Draggable separators between .fd-content blocks
         .fd-content-vertical-divider {
             width: 5px;
-            background: @navbarBackground;
+            background: @cc-brand-mid;
         }
 
         .fd-content-horizontal-divider {
@@ -193,16 +193,6 @@ body.vellum-full-screen {
 
             // Prevent scrollbars underneath the modal from bleeding through on OSX
             transform: translate3d(0, 0, 0);
-        }
-    }
-
-    &.app-manager-v2 {
-        .fd-form-actions {
-            background-color: @cc-brand-mid !important; // lazy because this is temporary code
-        }
-
-        .fd-content-vertical-divider {
-            background: @cc-brand-mid;
         }
     }
 }

--- a/src/less-style/structure.less
+++ b/src/less-style/structure.less
@@ -68,16 +68,6 @@ body.vellum-full-screen {
                 .fd-form-actions {
                     background-color: @cc-brand-mid !important; // lazy
                     padding: 5px 8px 8px;
-
-                    #alert-user {
-                        margin-left: 10px;
-                        margin-bottom: 0;
-                        padding: 7px 15px;
-
-                        .close {
-                            margin-left: 5px;
-                        }
-                    }
                 }
             }
 

--- a/src/less-style/structure.less
+++ b/src/less-style/structure.less
@@ -179,7 +179,7 @@ body.vellum-full-screen {
                 .box-shadow(0px 0px 10px rgba(0, 0, 0, 0.4));
                 margin: @gridGutterWidth;
                 height: auto;
-                overflow: scroll;
+                overflow: auto;
                 max-height: 200px;
             }
         }

--- a/src/templates/alert_global.html
+++ b/src/templates/alert_global.html
@@ -1,4 +1,4 @@
-<div class="alert alert-block <%=messageType.cssClass%> fade hide">
+<div class="alert alert-block <%=messageType.cssClass%>">
     <button type="button" class="close" data-dismiss="alert">&times;</button>
     <h4><% if (messageType.icon) { %><i class="<%=messageType.icon%>"></i> <% } %><%=messageType.title%></h4>
     <ul>

--- a/src/templates/alert_global.html
+++ b/src/templates/alert_global.html
@@ -1,4 +1,4 @@
-<div class="alert alert-warning alert-block <%=messageType.cssClass%> fade hide">
+<div class="alert alert-block <%=messageType.cssClass%> fade hide">
     <button type="button" class="close" data-dismiss="alert">&times;</button>
     <h4><% if (messageType.icon) { %><i class="<%=messageType.icon%>"></i> <% } %><%=messageType.title%></h4>
     <ul>

--- a/src/templates/main.html
+++ b/src/templates/main.html
@@ -70,6 +70,10 @@
     <div class="fd-content fd-content-right">
         <div class="fd-form-actions btn-toolbar">
             <div class="btn-group fd-save-button"></div>
+            <div id="alert-user" class="pull-left alert hide">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <span></span>
+            </div>
         </div>
         <div class="fd-column fd-question-properties hide">
             <div class="fd-head"><h2><%-gettext("Question Details")%></h2></div>

--- a/src/templates/main.html
+++ b/src/templates/main.html
@@ -70,10 +70,6 @@
     <div class="fd-content fd-content-right">
         <div class="fd-form-actions btn-toolbar">
             <div class="btn-group fd-save-button"></div>
-            <div id="alert-user" class="pull-left alert hide">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <span></span>
-            </div>
         </div>
         <div class="fd-column fd-question-properties hide">
             <div class="fd-head"><h2><%-gettext("Question Details")%></h2></div>

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -211,6 +211,13 @@ define([
     function init(opts) {
         opts = opts || {};
         var vellum_options = $.extend(true, {}, options.options, opts);
+
+        // Turn off animations for testing
+        var oldAnimate = $.fn.animate;
+        $.fn.animate = function(prop, speed, easing, callback) {
+            oldAnimate.apply(this, [prop, 0, easing, callback]);
+        };
+
         // $.extend merges arrays :(
         if (opts.javaRosa && opts.javaRosa.langs) {
             vellum_options.javaRosa.langs = opts.javaRosa.langs;


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?260647

Originally did this as discussed on slack, with messages showing next to the save button, then remembered that we already have an area for messages.

![screen shot 2017-09-25 at 5 52 31 pm](https://user-images.githubusercontent.com/1486591/30834293-7b8c7266-a220-11e7-9da7-12617c38c204.png)

On additional messages, the message bar will quickly fade out and then fade back in, to stick to vellum's "one message at a time" stance while still catching the user's eye if an additional person has opened the form.

@emord / @millerdev 
cc @nickpell 