### PR TITLE
Fix saved after overwrite warning

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2186,8 +2186,11 @@ define([
             success: function (data) {
                 if (saveType === 'patch') {
                     if (data.status === 'conflict') {
-                        if (_.isUndefined(data.xform)) {
+                        var force_full = _this.opts()
+                            .features.full_save_on_missing_conflict_xform;
+                        if (_.isUndefined(data.xform) && force_full) {
                             // unconditionally overwrite if no xform to compare
+                            // this codepath should never execute in production
                             _this.send(formText, 'full');
                         } else {
                             hidePageSpinner();

--- a/src/core.js
+++ b/src/core.js
@@ -668,7 +668,7 @@ define([
             }
         ], gettext("Cancel"), "fa fa-warning");
 
-        var diff = util.xmlDiff(formText, serverForm);
+        var diff = util.xmlDiff(formText, serverForm || "");
 
         $overwriteForm = $(confirm_overwrite({
             description: gettext("Looks like someone else has edited this form " +
@@ -2186,11 +2186,13 @@ define([
             success: function (data) {
                 if (saveType === 'patch') {
                     if (data.status === 'conflict') {
+                        // reset save button to unsaved state
+                        _this.data.core.saveButton.fire("change");
                         var force_full = _this.opts()
                             .features.full_save_on_missing_conflict_xform;
                         if (_.isUndefined(data.xform) && force_full) {
                             // unconditionally overwrite if no xform to compare
-                            // this codepath should never execute in production
+                            // this codepath is for standalone/test mode only
                             _this.send(formText, 'full');
                         } else {
                             hidePageSpinner();

--- a/tests/options.js
+++ b/tests/options.js
@@ -236,6 +236,7 @@ define(["underscore"], function (_) {
         ],
         features: {
             // 'remove_popvers': false, // disabled for most tests
+            'full_save_on_missing_conflict_xform': true,
             'lookup_tables': true,
             'group_in_field_list': true,
             'rich_text': true,


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?266075

This fixes the issue where the save button is disabled after canceled overwrite warning. I am unable to reproduce (or even understand how it would happen) the second part where the person with a conflicted form overwrites the other users work without a warning.

🐠 Review by commit

@orangejenny @emord 