### PR TITLE
Fix overwrite conflicting form without prompt

### DIFF
--- a/tests/utils.js
+++ b/tests/utils.js
@@ -235,7 +235,7 @@ define([
         vellum_options.core.saveUrl = function (data) {
             savedForm = data.xform;
             saveCount++;
-            originalSaveUrl(data);
+            return originalSaveUrl(data);
         };
         var vellum = $("#vellum"),
             old = vellum.vellum("get");


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?266075

Do not overwrite conflicting form on switching from patch to full form save. The switch from patch to full save happens if the patch content is bigger than the new form being saved.

This change will have no effect until https://github.com/dimagi/commcare-hq/pull/19586 is also deployed.

@emord @orangejenny cc @snopoke @esoergel 