### PR TITLE
Mk icds app trans hq 2

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -228,6 +228,7 @@ define([
             this.opts().core.dataSourcesEndpoint,
             this.opts().core.invalidCaseProperties
         );
+        this.data.core.showOnlyCurrentLang = this.opts().core.showOnlyCurrentLang;
     };
 
     fn.postInit = function () {

--- a/src/core.js
+++ b/src/core.js
@@ -228,7 +228,6 @@ define([
             this.opts().core.dataSourcesEndpoint,
             this.opts().core.invalidCaseProperties
         );
-        this.data.core.showOnlyCurrentLang = this.opts().core.showOnlyCurrentLang;
     };
 
     fn.postInit = function () {

--- a/src/javaRosa/itextBlock.js
+++ b/src/javaRosa/itextBlock.js
@@ -77,7 +77,7 @@ define([
             _.each(block.getForms(), function (form) {
                 var $formGroup = block.getFormGroupContainer(form);
                 var langs_to_show = block.languages
-                if(options.vellum.data.core.showOnlyCurrentLang) {
+                if(options.vellum.data.javaRosa.showOnlyCurrentLang) {
                     langs_to_show = _.uniq([
                     options.vellum.data.javaRosa.Itext.defaultLanguage,
                     options.vellum.data.core.currentItextDisplayLanguage])

--- a/src/javaRosa/itextBlock.js
+++ b/src/javaRosa/itextBlock.js
@@ -78,7 +78,9 @@ define([
                 var $formGroup = block.getFormGroupContainer(form);
                 var langs_to_show = block.languages
                 if(options.vellum.data.core.showOnlyCurrentLang) {
-                    langs_to_show = [options.vellum.data.core.currentItextDisplayLanguage]
+                    langs_to_show = _.uniq([
+                    options.vellum.data.javaRosa.Itext.defaultLanguage,
+                    options.vellum.data.core.currentItextDisplayLanguage])
                 }
                 _.each(langs_to_show, function(lang){
                     var itextWidget = block.itextWidget(block.mug, lang, form,

--- a/src/javaRosa/itextBlock.js
+++ b/src/javaRosa/itextBlock.js
@@ -76,7 +76,11 @@ define([
         block.getUIElement = function () {
             _.each(block.getForms(), function (form) {
                 var $formGroup = block.getFormGroupContainer(form);
-                _.each(block.languages, function (lang) {
+                var langs_to_show = block.languages
+                if(options.vellum.data.core.showOnlyCurrentLang) {
+                    langs_to_show = [options.vellum.data.core.currentItextDisplayLanguage]
+                }
+                _.each(langs_to_show, function(lang){
                     var itextWidget = block.itextWidget(block.mug, lang, form,
                                                         _.extend(options, {parent: $blockUI}));
                     itextWidget.init();

--- a/src/javaRosa/plugin.js
+++ b/src/javaRosa/plugin.js
@@ -63,6 +63,7 @@ define([
             this.data.javaRosa.ItextItem = itext.item;
             this.data.javaRosa.ItextForm = itext.form;
             this.data.javaRosa.ICONS = ICONS;
+            this.data.javaRosa.showOnlyCurrentLang = this.opts().javaRosa.showOnlyCurrentLang;
         },
         handleDropFinish: function (target, path, mug, event) {
             var inItext = target &&

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -1131,4 +1131,52 @@ define([
             assert.strictEqual($('.fd-questions-menu li:contains("Display")').length, 1);
         });
     });
+
+    describe("show only current language for translations", function () {
+        before(function (done) {
+            util.init({
+                features: {rich_text: false},
+                javaRosa: {langs: ['en', 'hin', 'tel'],
+                           showOnlyCurrentLang: true,
+                           displayLanguage: 'en'
+                           },
+                core: {onReady: function () { done(); }}
+            });
+        });
+
+        it("should change the property on javaRosa", function() {
+            assert.equal(util.call("getData").javaRosa.showOnlyCurrentLang, true)
+        });
+
+        describe("when current language same as default language", function() {
+            it("should just show translation for the current display language", function() {
+                assert.equal(util.call("getData").core.currentItextDisplayLanguage, "en")
+                assert.equal(util.call("getData").javaRosa.Itext.defaultLanguage, "en")
+                util.loadXML(TEST_XML_1);
+                util.clickQuestion("question1");
+                assert.equal($("[name='itext-en-label']").length, 1)
+                assert.equal($("[name='itext-hin-label']").length, 0)
+            });
+        });
+
+        describe("when current display language not same as default language", function() {
+            before(function (done) {
+                util.init({
+                    features: {rich_text: false},
+                    javaRosa: {langs: ['en', 'hin', 'tel'], showOnlyCurrentLang: true, displayLanguage: 'tel'},
+                    core: {onReady: function () { done(); }}
+                });
+            });
+
+            it("should show translation for both current and default language", function() {
+                assert.equal(util.call("getData").core.currentItextDisplayLanguage, "tel")
+                assert.equal(util.call("getData").javaRosa.Itext.defaultLanguage, "en")
+                util.loadXML(TEST_XML_1);
+                util.clickQuestion("question1");
+                assert.equal($("[name='itext-en-label']").length, 1)
+                assert.equal($("[name='itext-hin-label']").length, 0)
+                assert.equal($("[name='itext-tel-label']").length, 1)
+            });
+        });
+    });
 });

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -1145,17 +1145,17 @@ define([
         });
 
         it("should change the property on javaRosa", function() {
-            assert.equal(util.call("getData").javaRosa.showOnlyCurrentLang, true)
+            assert.equal(util.call("getData").javaRosa.showOnlyCurrentLang, true);
         });
 
         describe("when current language same as default language", function() {
             it("should just show translation for the current display language", function() {
-                assert.equal(util.call("getData").core.currentItextDisplayLanguage, "en")
-                assert.equal(util.call("getData").javaRosa.Itext.defaultLanguage, "en")
+                assert.equal(util.call("getData").core.currentItextDisplayLanguage, "en");
+                assert.equal(util.call("getData").javaRosa.Itext.defaultLanguage, "en");
                 util.loadXML(TEST_XML_1);
                 util.clickQuestion("question1");
-                assert.equal($("[name='itext-en-label']").length, 1)
-                assert.equal($("[name='itext-hin-label']").length, 0)
+                assert.equal($("[name='itext-en-label']").length, 1);
+                assert.equal($("[name='itext-hin-label']").length, 0);
             });
         });
 
@@ -1169,13 +1169,13 @@ define([
             });
 
             it("should show translation for both current and default language", function() {
-                assert.equal(util.call("getData").core.currentItextDisplayLanguage, "tel")
-                assert.equal(util.call("getData").javaRosa.Itext.defaultLanguage, "en")
+                assert.equal(util.call("getData").core.currentItextDisplayLanguage, "tel");
+                assert.equal(util.call("getData").javaRosa.Itext.defaultLanguage, "en");
                 util.loadXML(TEST_XML_1);
                 util.clickQuestion("question1");
-                assert.equal($("[name='itext-en-label']").length, 1)
-                assert.equal($("[name='itext-hin-label']").length, 0)
-                assert.equal($("[name='itext-tel-label']").length, 1)
+                assert.equal($("[name='itext-en-label']").length, 1);
+                assert.equal($("[name='itext-hin-label']").length, 0);
+                assert.equal($("[name='itext-tel-label']").length, 1);
             });
         });
     });


### PR DESCRIPTION
ICDS is considering stretching to 15+ languages and have run some tests for a bottleneck with form builder not able to support that many lanugages. While we are working on other possibilities, i believe the blocker is heavy HTML and this would help tackle that.
I did some test and this change should do the following:
render display text in form view for the current language and the default language. The reason for keeping both of them and not just the current language/default language is to avoid some issue i saw when adding questions with just current language display text available. But if default langugage is the current lang, it will just show one language.

One can still do translations by switching to the other language but i don't think the app builders use that in ICDS. Translations are handled by bulk app translations upload.

Derek is going to run some test again early next week so would like to deploy this before that if possible.
If you guys think this is worth a short, i would just add this [commit](https://github.com/dimagi/commcare-hq/commit/8cbfd76a474bd3f18d29ea3d31294e4dcceb896f) to HQ.

@esoergel 