### PR TITLE
Mk fix id display

### DIFF
--- a/src/javaRosa/itextBlock.js
+++ b/src/javaRosa/itextBlock.js
@@ -78,13 +78,13 @@ define([
                 var $formGroup = block.getFormGroupContainer(form);
                 var langs_to_show = block.languages;
                 if(options.vellum.data.javaRosa.showOnlyCurrentLang) {
-                    if(!_.contains(langs_to_show, options.vellum.data.core.currentItextDisplayLanguage)) {
-                        langs_to_show = [options.vellum.data.javaRosa.Itext.defaultLanguage];
-                    } else {
-                        langs_to_show = _.uniq([
-                        options.vellum.data.javaRosa.Itext.defaultLanguage,
-                        options.vellum.data.core.currentItextDisplayLanguage]);
-                    }
+                    // show default and current display language and
+                    // ensure they are in app languages
+                    langs_to_show = _.intersection(
+                        [options.vellum.data.javaRosa.Itext.defaultLanguage],
+                        [options.vellum.data.core.currentItextDisplayLanguage],
+                        block.languages
+                    )
                 }
                 _.each(langs_to_show, function(lang){
                     var itextWidget = block.itextWidget(block.mug, lang, form,

--- a/src/javaRosa/itextBlock.js
+++ b/src/javaRosa/itextBlock.js
@@ -76,11 +76,15 @@ define([
         block.getUIElement = function () {
             _.each(block.getForms(), function (form) {
                 var $formGroup = block.getFormGroupContainer(form);
-                var langs_to_show = block.languages
+                var langs_to_show = block.languages;
                 if(options.vellum.data.javaRosa.showOnlyCurrentLang) {
-                    langs_to_show = _.uniq([
-                    options.vellum.data.javaRosa.Itext.defaultLanguage,
-                    options.vellum.data.core.currentItextDisplayLanguage])
+                    if(!_.contains(langs_to_show, options.vellum.data.core.currentItextDisplayLanguage)) {
+                        langs_to_show = [options.vellum.data.javaRosa.Itext.defaultLanguage];
+                    } else {
+                        langs_to_show = _.uniq([
+                        options.vellum.data.javaRosa.Itext.defaultLanguage,
+                        options.vellum.data.core.currentItextDisplayLanguage]);
+                    }
                 }
                 _.each(langs_to_show, function(lang){
                     var itextWidget = block.itextWidget(block.mug, lang, form,

--- a/src/javaRosa/itextBlock.js
+++ b/src/javaRosa/itextBlock.js
@@ -78,13 +78,13 @@ define([
                 var $formGroup = block.getFormGroupContainer(form);
                 var langs_to_show = block.languages;
                 if(options.vellum.data.javaRosa.showOnlyCurrentLang) {
-                    // show default and current display language and
+                    // show default and/or current display language and
                     // ensure they are in app languages
                     langs_to_show = _.intersection(
-                        [options.vellum.data.javaRosa.Itext.defaultLanguage],
-                        [options.vellum.data.core.currentItextDisplayLanguage],
+                        [options.vellum.data.javaRosa.Itext.defaultLanguage,
+                         options.vellum.data.core.currentItextDisplayLanguage],
                         block.languages
-                    )
+                    );
                 }
                 _.each(langs_to_show, function(lang){
                     var itextWidget = block.itextWidget(block.mug, lang, form,

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -1160,22 +1160,44 @@ define([
         });
 
         describe("when current display language not same as default language", function() {
-            before(function (done) {
-                util.init({
-                    features: {rich_text: false},
-                    javaRosa: {langs: ['en', 'hin', 'tel'], showOnlyCurrentLang: true, displayLanguage: 'tel'},
-                    core: {onReady: function () { done(); }}
+            describe("when current display language is one of the app langs", function() {
+                before(function (done) {
+                    util.init({
+                        features: {rich_text: false},
+                        javaRosa: {langs: ['en', 'hin', 'tel'], showOnlyCurrentLang: true, displayLanguage: 'tel'},
+                        core: {onReady: function () { done(); }}
+                    });
+                });
+
+                it("should show translation for both current and default language", function() {
+                    assert.equal(util.call("getData").core.currentItextDisplayLanguage, "tel");
+                    assert.equal(util.call("getData").javaRosa.Itext.defaultLanguage, "en");
+                    util.loadXML(TEST_XML_1);
+                    util.clickQuestion("question1");
+                    assert.equal($("[name='itext-en-label']").length, 1);
+                    assert.equal($("[name='itext-hin-label']").length, 0);
+                    assert.equal($("[name='itext-tel-label']").length, 1);
                 });
             });
 
-            it("should show translation for both current and default language", function() {
-                assert.equal(util.call("getData").core.currentItextDisplayLanguage, "tel");
-                assert.equal(util.call("getData").javaRosa.Itext.defaultLanguage, "en");
-                util.loadXML(TEST_XML_1);
-                util.clickQuestion("question1");
-                assert.equal($("[name='itext-en-label']").length, 1);
-                assert.equal($("[name='itext-hin-label']").length, 0);
-                assert.equal($("[name='itext-tel-label']").length, 1);
+            describe("when current display language is not one of the app langs", function() {
+                before(function (done) {
+                    util.init({
+                        features: {rich_text: false},
+                        javaRosa: {langs: ['en', 'hin', 'tel'], showOnlyCurrentLang: true, displayLanguage: '_ids'},
+                        core: {onReady: function () { done(); }}
+                    });
+                });
+
+                it("should just show translation for the default language", function() {
+                    assert.equal(util.call("getData").core.currentItextDisplayLanguage, "_ids");
+                    assert.equal(util.call("getData").javaRosa.Itext.defaultLanguage, "en");
+                    util.loadXML(TEST_XML_1);
+                    util.clickQuestion("question1");
+                    assert.equal($("[name='itext-en-label']").length, 1);
+                    assert.equal($("[name='itext-hin-label']").length, 0);
+                    assert.equal($("[name='itext-tel-label']").length, 0);
+                });
             });
         });
     });


### PR DESCRIPTION
introduced in #941.
When Question ID is used for display instead of one of the available languages a text box with label `Display Text (_ids)` is added.
<img width="1122" alt="screen shot 2018-06-06 at 1 04 11 am" src="https://user-images.githubusercontent.com/3864163/40998606-f64e504c-6925-11e8-8ceb-073eb05eb4d3.png">


This PR adds a check to ensure that display language is one of the app languages.