### PR TITLE
set label itext

### DIFF
--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -511,8 +511,9 @@ define([
 
         it("itext changes do not bleed back after copy", function () {
             util.loadXML("");
-            var mug = util.addQuestion("Text", "question"),
-                dup = mug.form.duplicateMug(mug);
+            var mug = util.addQuestion("Text", "question");
+            mug.p.labelItext.set('question');
+            var dup = mug.form.duplicateMug(mug);
             dup.p.labelItext.set("q2");
 
             util.saveAndReload(function () {
@@ -523,8 +524,9 @@ define([
 
         it("itext changes do not bleed back from copy of copy", function () {
             util.loadXML("");
-            var mug = util.addQuestion("Text", "question"),
-                dup = mug.form.duplicateMug(mug),
+            var mug = util.addQuestion("Text", "question");
+            mug.p.labelItext.set('question');
+            var dup = mug.form.duplicateMug(mug),
                 cpy = mug.form.duplicateMug(dup);
             cpy.p.labelItext.set("copy");
 


### PR DESCRIPTION
Saw a test failing on local system which is actually passing on travis.
To be honest, i am not sure how these two tests are passing on travis.

I would expect `util.addQuestion("Text", "question")` to just add a question of type Text with id question. But the test then checks for its label and expected it to be same as id. passes on travis but fails on local. 
Checked on HQ otherwise and looks like the label is not populated by default.

Made this change to set label itext first and now test passes locally.
