### PR TITLE
Show error message when app properties fail

### DIFF
--- a/src/databrowser.js
+++ b/src/databrowser.js
@@ -65,7 +65,7 @@ define([
                 if (container && event.xhr.responseText) {
                     container.find(".fd-external-sources-error")
                         .removeClass("hide")
-                        .text(event.xhr.responseText);
+                        .text(gettext("Could not load app properties. If this error persists, please report an issue."));
                 }
             });
             var toggle = _.partial(toggleExternalDataTree, vellum);


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?272806

Looked into doing more clever behavior specific to the error code but found that unreliable - redirects (can show up if you get logged out) show up as 200s, and faking an error [like this](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/domain/views.py#L2861-L2863) with an explicit status code just came through as a 500. So I went the route of just putting up a vague error.

@millerdev / @emord 