### PR TITLE
inform user changing a saved question ID that old data is unaffected

### DIFF
--- a/src/mugs.js
+++ b/src/mugs.js
@@ -849,7 +849,7 @@ define([
                             {nodeID: mug.p.nodeID});
                     } else if (mug.p.nodeID.toLowerCase() === "meta") {
                         return_value = gettext("'meta' is not a valid Question ID.");
-                    } else if (mug.__originalNodeID && mug.p.nodeID.toLowerCase() !== mug.__originalNodeID) {
+                    } else if (mug.__originalNodeID && mug.p.nodeID !== mug.__originalNodeID) {
                         changedQuestionIDWarning.message = gettext(
                             "Changing a Question ID will create a new Question ID (and a new data column). " +
                             "It will NOT update the existing or previously submitted data.");

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -246,22 +246,15 @@ define([
             return changed;
         },
         /**
-         * Get a list of error message strings
-         *
-         * Currently there are only two message levels: "warning" and
-         * "error", and this function returns both. If a lower level
-         * message type such as "info" is added we may want to change
-         * this to drop "info" messages.
+         * Get a list of error and warning message strings
          */
         getErrors: function () {
             var errors = [];
-            var messagesList = this.messages.messages.nodeID || [];
-            for (var i = 0; i < messagesList.length; i++) {
-                var messageObj = messagesList[i];
-                if (messageObj.level === 'error' || messageObj.level === 'warning') {
-                    errors.push(messageObj.message);
+            this.messages.each(function(msg) {
+                if (msg.level !== "info") {
+                    errors.push(msg.message);
                 }
-            }
+            });
             return _.uniq(errors);
         },
         hasErrors: function () {

--- a/src/parser.js
+++ b/src/parser.js
@@ -224,6 +224,8 @@ define([
 
         var mug = form.mugTypes.make(role, form);
         mug.p.nodeID = nodeID;
+        mug.__originalNodeID = nodeID;
+
         mug.p.dataValue = nodeVal || undefined;
 
         if (extraXMLNS && (extraXMLNS !== form.formUuid)) {

--- a/tests/form.js
+++ b/tests/form.js
@@ -397,6 +397,19 @@ define([
             assert(!util.isTreeNodeValid(q1), "q1 should not be valid");
         });
 
+        it("should warn about changing question ID", function () {
+            util.loadXML(SELECT_QUESTIONS);
+            var mug = util.getMug('question1');
+            assert.equal(util.getMessages(mug), "");
+
+            mug.p.nodeID = "question";
+            assert(mug.messages.get("nodeID", "mug-nodeID-changed-warning"),
+                "mug-nodeID-changed-warning was expected");
+
+            mug.p.nodeID = "question1";
+            assert.equal(util.getMessages(mug), "");
+        });
+
         describe("with async data sources", function() {
             var vellum, callback;
             before(function (done) {


### PR DESCRIPTION
Product Note: When a user updates the question ID in formbuilder, remind them that previously submitted data is unaffected.

https://trello.com/c/peoYQUMn/77-crs-items-for-q4

<img width="451" alt="screen shot 2018-11-12 at 5 51 18 pm" src="https://user-images.githubusercontent.com/1757035/48379870-980f5700-e6a3-11e8-886f-604425fb6696.png">