### PR TITLE
"Question ID changed" warning updates

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1406,8 +1406,8 @@ define([
      * after parsing XML before tree population.
      */
     fn.onXFormLoaded = function (form) {
-        form.submission_url = this.opts().core.hasSubmissionsUrl;
-        util.check_for_form_submissions(form);
+        form.submissionUrl = this.opts().core.hasSubmissionsUrl;
+        util.checkForFormSubmissions(form);
     };
 
     fn.refreshMugName = function (mug) {

--- a/src/core.js
+++ b/src/core.js
@@ -1404,8 +1404,8 @@ define([
      * after parsing XML before tree population.
      */
     fn.onXFormLoaded = function (form) {
+        form.warnWhenChanged = this.opts().core.hasSubmissions;
         form.submissionUrl = this.opts().core.hasSubmissionsUrl;
-        util.checkForFormSubmissions(form);
     };
 
     fn.refreshMugName = function (mug) {
@@ -2438,6 +2438,7 @@ define([
         form: null,
         loadDelay: 500,
         patchUrl: false,
+        hasSubmissions: false,
         hasSubmissionsUrl: false,
         saveUrl: false,
         saveType: 'full',

--- a/src/core.js
+++ b/src/core.js
@@ -1406,6 +1406,8 @@ define([
      * after parsing XML before tree population.
      */
     fn.onXFormLoaded = function (form) {
+        form.submission_url = this.opts().core.hasSubmissionsUrl;
+        util.check_for_form_submissions(form);
     };
 
     fn.refreshMugName = function (mug) {
@@ -2438,6 +2440,7 @@ define([
         form: null,
         loadDelay: 500,
         patchUrl: false,
+        hasSubmissionsUrl: false,
         saveUrl: false,
         saveType: 'full',
         staticPrefix: "",

--- a/src/core.js
+++ b/src/core.js
@@ -148,12 +148,10 @@ define([
                     analytics.workflow("Clicked Save in the form builder");
                     _this.validateAndSaveXForm(forceFullSave);
                 });
-                var mugMap = _this.data.core.form.mugMap;
-                for (var mugId in mugMap) {
-                    var mug = mugMap[mugId];
+                _this.data.core.form.walkMugs(function (mug) {
                     mug.__originalNodeID = mug.p.nodeID;
-                    mug.validate();
-                }
+                    mug.dropMessage("nodeID", "mug-nodeID-changed-warning");
+                });
             },
             unsavedMessage: gettext('Are you sure you want to exit? All unsaved changes will be lost!'),
             csrftoken: _this.opts().csrftoken

--- a/src/core.js
+++ b/src/core.js
@@ -148,6 +148,12 @@ define([
                     analytics.workflow("Clicked Save in the form builder");
                     _this.validateAndSaveXForm(forceFullSave);
                 });
+                var mugMap = _this.data.core.form.mugMap;
+                for (var mugId in mugMap) {
+                    var mug = mugMap[mugId];
+                    mug.__originalNodeID = mug.p.nodeID;
+                    mug.validate();
+                }
             },
             unsavedMessage: gettext('Are you sure you want to exit? All unsaved changes will be lost!'),
             csrftoken: _this.opts().csrftoken

--- a/src/form.js
+++ b/src/form.js
@@ -695,7 +695,7 @@ define([
          * Move a mug from its current place to
          * the position specified by the arguments.
          *
-         * NOTE the cannonical way to rename a mug is to set its
+         * NOTE the canonical way to rename a mug is to set its
          * `nodeID` property: `mug.p.nodeID = "name"`
          *
          * @param mug - The mug to be moved.

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -855,8 +855,7 @@ define([
                     } else if (mug.form.warn_when_changed && !mug.skip_changed_msg &&
                         mug.__originalNodeID && mug.p.nodeID !== mug.__originalNodeID) {
                         changedQuestionIDWarning.message = gettext(
-                            "Changing a Question ID will create a new Question ID (and a new data column). " +
-                            "It will NOT update the existing or previously submitted data.");
+                            "Making this change will create a new Question ID (and a new column in exports).");
                     }
                     mug.addMessage("nodeID", changedQuestionIDWarning);
                     return return_value;

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -124,6 +124,9 @@ define([
          */
         validate: function (attr) {
             var mug = this;
+
+            util.check_for_form_submissions(mug.form);
+
             return this._withMessages(function () {
                 var changed = false;
                 mug.form.updateLogicReferences(mug, attr);
@@ -849,7 +852,8 @@ define([
                             {nodeID: mug.p.nodeID});
                     } else if (mug.p.nodeID.toLowerCase() === "meta") {
                         return_value = gettext("'meta' is not a valid Question ID.");
-                    } else if (mug.__originalNodeID && mug.p.nodeID !== mug.__originalNodeID && !mug.skip_changed_msg) {
+                    } else if (mug.form.warn_when_changed && !mug.skip_changed_msg &&
+                        mug.__originalNodeID && mug.p.nodeID !== mug.__originalNodeID) {
                         changedQuestionIDWarning.message = gettext(
                             "Changing a Question ID will create a new Question ID (and a new data column). " +
                             "It will NOT update the existing or previously submitted data.");

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -849,7 +849,7 @@ define([
                             {nodeID: mug.p.nodeID});
                     } else if (mug.p.nodeID.toLowerCase() === "meta") {
                         return_value = gettext("'meta' is not a valid Question ID.");
-                    } else if (mug.__originalNodeID && mug.p.nodeID !== mug.__originalNodeID) {
+                    } else if (mug.__originalNodeID && mug.p.nodeID !== mug.__originalNodeID && !mug.skip_changed_msg) {
                         changedQuestionIDWarning.message = gettext(
                             "Changing a Question ID will create a new Question ID (and a new data column). " +
                             "It will NOT update the existing or previously submitted data.");

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -85,6 +85,7 @@ define([
             this.logicReferenceAttrs = [];
             this.options = util.extend(defaultOptions, options);
             this.__className = this.options.__className;
+            this.showChangedMsg = true;
             this.spec = copyAndProcessSpec(this._baseSpec, this.options.spec, this.options);
 
             // Reset any properties that are part of the question type
@@ -852,7 +853,7 @@ define([
                             {nodeID: mug.p.nodeID});
                     } else if (mug.p.nodeID.toLowerCase() === "meta") {
                         return_value = gettext("'meta' is not a valid Question ID.");
-                    } else if (mug.form.warnWhenChanged && !mug.skip_changed_msg &&
+                    } else if (mug.form.warnWhenChanged && mug.showChangedMsg &&
                         mug.__originalNodeID && mug.p.nodeID !== mug.__originalNodeID) {
                         changedQuestionIDWarning.message = gettext(
                             "Making this change will create a new Question ID (and a new column in exports).");

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -125,7 +125,7 @@ define([
         validate: function (attr) {
             var mug = this;
 
-            util.check_for_form_submissions(mug.form);
+            util.checkForFormSubmissions(mug.form);
 
             return this._withMessages(function () {
                 var changed = false;
@@ -852,7 +852,7 @@ define([
                             {nodeID: mug.p.nodeID});
                     } else if (mug.p.nodeID.toLowerCase() === "meta") {
                         return_value = gettext("'meta' is not a valid Question ID.");
-                    } else if (mug.form.warn_when_changed && !mug.skip_changed_msg &&
+                    } else if (mug.form.warnWhenChanged && !mug.skip_changed_msg &&
                         mug.__originalNodeID && mug.p.nodeID !== mug.__originalNodeID) {
                         changedQuestionIDWarning.message = gettext(
                             "Making this change will create a new Question ID (and a new column in exports).");

--- a/src/util.js
+++ b/src/util.js
@@ -451,10 +451,9 @@ define([
                 success: function(data) {
                     if(data.form_has_submissions) {
                         form.warnWhenChanged = true;
-                        var mugMap = form.mugMap;
-                        for (var mugId in mugMap) {
-                            mugMap[mugId].validate();
-                        }
+                        form.walkMugs(function (mug) {
+                            mug.validate();
+                        });
                     }
                 }
             });

--- a/src/util.js
+++ b/src/util.js
@@ -442,7 +442,7 @@ define([
         });
     };
 
-    that.checkForFormSubmissions = function (form) {
+    that.checkForFormSubmissions = _.throttle(function (form) {
         if (!form.warnWhenChanged && !form.isCurrentlyCheckingForSubmissions) {
             form.isCurrentlyCheckingForSubmissions = true;
             $.ajax({
@@ -462,7 +462,7 @@ define([
                 }
             });
         }
-    };
+    }, 10000);
 
     return that;
 });

--- a/src/util.js
+++ b/src/util.js
@@ -442,15 +442,15 @@ define([
         });
     };
 
-    that.check_for_form_submissions = function (form) {
-        if (!form.warn_when_changed) {
+    that.checkForFormSubmissions = function (form) {
+        if (!form.warnWhenChanged) {
             $.ajax({
-                url: form.submission_url,
+                url: form.submissionUrl,
                 type: 'GET',
                 dataType: 'json',
                 success: function(data) {
                     if(data.form_has_submissions) {
-                        form.warn_when_changed = true;
+                        form.warnWhenChanged = true;
                         var mugMap = form.mugMap;
                         for (var mugId in mugMap) {
                             mugMap[mugId].validate();

--- a/src/util.js
+++ b/src/util.js
@@ -443,7 +443,8 @@ define([
     };
 
     that.checkForFormSubmissions = function (form) {
-        if (!form.warnWhenChanged) {
+        if (!form.warnWhenChanged && !form.isCurrentlyCheckingForSubmissions) {
+            form.isCurrentlyCheckingForSubmissions = true;
             $.ajax({
                 url: form.submissionUrl,
                 type: 'GET',
@@ -455,6 +456,9 @@ define([
                             mug.validate();
                         });
                     }
+                },
+                complete: function() {
+                    form.isCurrentlyCheckingForSubmissions = false;
                 }
             });
         }

--- a/src/util.js
+++ b/src/util.js
@@ -442,5 +442,24 @@ define([
         });
     };
 
+    that.check_for_form_submissions = function (form) {
+        if (!form.warn_when_changed) {
+            $.ajax({
+                url: form.submission_url,
+                type: 'GET',
+                dataType: 'json',
+                success: function(data) {
+                    if(data.form_has_submissions) {
+                        form.warn_when_changed = true;
+                        var mugMap = form.mugMap;
+                        for (var mugId in mugMap) {
+                            mugMap[mugId].validate();
+                        }
+                    }
+                }
+            });
+        }
+    };
+
     return that;
 });

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -77,7 +77,7 @@ define([
 
         widget.handleChange = function () {
             widget.updateValue();
-            mug.skip_changed_msg = false;
+            mug.showChangedMsg = true;
             // TODO make all widgets that inherit from base set path
             if (widget.path) {
                 // Widget change events, in addition to mug property
@@ -806,7 +806,7 @@ define([
             html.find("button.close").click(function () {
                 mug.dropMessage(path, msg.key);
                 if (msg.key === "mug-nodeID-changed-warning") {
-                    mug.skip_changed_msg = true;
+                    mug.showChangedMsg = false;
                 }
             });
             $messages = $messages.add(html);

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -77,6 +77,7 @@ define([
 
         widget.handleChange = function () {
             widget.updateValue();
+            mug.skip_changed_msg = false;
             // TODO make all widgets that inherit from base set path
             if (widget.path) {
                 // Widget change events, in addition to mug property
@@ -804,6 +805,9 @@ define([
                 }));
             html.find("button.close").click(function () {
                 mug.dropMessage(path, msg.key);
+                if (msg.key === "mug-nodeID-changed-warning") {
+                    mug.skip_changed_msg = true;
+                }
             });
             $messages = $messages.add(html);
         });

--- a/tests/form.js
+++ b/tests/form.js
@@ -432,7 +432,7 @@ define([
             assert(mug.messages.get("nodeID", "mug-nodeID-changed-warning"),
                 "mug-nodeID-changed-warning was expected");
 
-            mug.skip_changed_msg = true;
+            mug.showChangedMsg = false;
             assert(mug.messages.get("nodeID", ""),
                 "mug-nodeID-changed-warning was not expected");
         });

--- a/tests/form.js
+++ b/tests/form.js
@@ -399,7 +399,7 @@ define([
 
         it("should warn about changing question ID", function () {
             var form = util.loadXML(SELECT_QUESTIONS);
-            form.warn_when_changed = true;
+            form.warnWhenChanged = true;
             var mug = util.getMug("question1");
             assert.equal(util.getMessages(mug), "");
 
@@ -413,7 +413,7 @@ define([
 
         it("should not warn about changing question ID", function () {
             var form = util.loadXML(SELECT_QUESTIONS);
-            form.warn_when_changed = false;
+            form.warnWhenChanged = false;
             var mug = util.getMug("question1");
             assert.equal(util.getMessages(mug), "");
 
@@ -424,7 +424,7 @@ define([
 
         it("should skip warning about changing question ID", function () {
             var form = util.loadXML(SELECT_QUESTIONS);
-            form.warn_when_changed = true;
+            form.warnWhenChanged = true;
             var mug = util.getMug("question1");
             assert.equal(util.getMessages(mug), "");
 

--- a/tests/form.js
+++ b/tests/form.js
@@ -398,16 +398,43 @@ define([
         });
 
         it("should warn about changing question ID", function () {
-            util.loadXML(SELECT_QUESTIONS);
-            var mug = util.getMug('question1');
+            var form = util.loadXML(SELECT_QUESTIONS);
+            form.warn_when_changed = true;
+            var mug = util.getMug("question1");
             assert.equal(util.getMessages(mug), "");
 
-            mug.p.nodeID = "question";
+            mug.p.nodeID = "new-question-id";
             assert(mug.messages.get("nodeID", "mug-nodeID-changed-warning"),
                 "mug-nodeID-changed-warning was expected");
 
             mug.p.nodeID = "question1";
             assert.equal(util.getMessages(mug), "");
+        });
+
+        it("should not warn about changing question ID", function () {
+            var form = util.loadXML(SELECT_QUESTIONS);
+            form.warn_when_changed = false;
+            var mug = util.getMug("question1");
+            assert.equal(util.getMessages(mug), "");
+
+            mug.p.nodeID = "new-question-id";
+            assert(mug.messages.get("nodeID", ""),
+                "mug-nodeID-changed-warning was not expected");
+        });
+
+        it("should skip warning about changing question ID", function () {
+            var form = util.loadXML(SELECT_QUESTIONS);
+            form.warn_when_changed = true;
+            var mug = util.getMug("question1");
+            assert.equal(util.getMessages(mug), "");
+
+            mug.p.nodeID = "new-question-id";
+            assert(mug.messages.get("nodeID", "mug-nodeID-changed-warning"),
+                "mug-nodeID-changed-warning was expected");
+
+            mug.skip_changed_msg = true;
+            assert(mug.messages.get("nodeID", ""),
+                "mug-nodeID-changed-warning was not expected");
         });
 
         describe("with async data sources", function() {


### PR DESCRIPTION
https://trello.com/c/peoYQUMn/77-crs-items-for-q4-alert-ux-changes

This implements the following changes:
1) Don't re-open closed question ID warning after navigating to a different question. https://github.com/dimagi/Vellum/commit/6f515fa28c0ad6619e019cab15db3bb875762cc3
2) Remove all existing warnings after saving a form. https://github.com/dimagi/Vellum/commit/348f4d0cda763e20a14ce1fd4ec2c659794f3491
3) Only show warning after at least one form has been submitted. https://github.com/dimagi/Vellum/commit/822242722df4638f61cccf2a9a6645128724af74
4) Updates warning text. https://github.com/dimagi/Vellum/commit/b17352633dc467e2c817dedc2011377e41880269

🐡 