### PR TITLE
Added 'script' to disallowed question IDs

### DIFF
--- a/src/mugs.js
+++ b/src/mugs.js
@@ -802,7 +802,7 @@ define([
         mug.p.conflictedNodeId = null;
     }
 
-    var RESERVED_NAMES = {"case": true, "registration": true};
+    var RESERVED_NAMES = {"case": true, "registration": true, "script": true};
     var baseSpecs = {
         databind: {
             // DATA ELEMENT


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-789

Strictly speaking this isn't necessary for vellum, it's an HQ bug...but this is a much easier fix. I'm guessing "case" is also illegal for HQ-based reasons.

The problem is that vellum's options include the form XML itself, which includes the string `<script>`, and those options are encoded as JSON for initial page data, we interpret that as an attempted script injection and [change it](https://github.com/dimagi/commcare-hq/blob/df912c4fa1179a79a76543269c358d7477119270/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py#L54) in a way that jQuery can no longer decode it as JSON.