### PR TITLE
Maintain xpath referencess on copy/paste

### DIFF
--- a/src/copy-paste.js
+++ b/src/copy-paste.js
@@ -325,7 +325,17 @@ define([
         }
 
         function addMug(id, mug) {
+            mugs[id] = mug;
             self.length++;
+        }
+
+        function transform(hashtag) {
+            var path = hashtag.replace(/^#form/, "");
+            return mugs.hasOwnProperty(path) ? mugs[path].hashtagPath : hashtag;
+        }
+
+        function transformHashtags(value) {
+            return form.transformHashtags(value, transform);
         }
 
         function doLater(fn) {
@@ -337,11 +347,13 @@ define([
         }
 
         var errors = new mugsModule.MugMessages(),
+            mugs = {},
             later = [],
             context = {
                 addError: addError,
                 errors: errors,
                 later: doLater,
+                transformHashtags: transformHashtags,
             },
             self = {
                 length: 0,

--- a/src/form.js
+++ b/src/form.js
@@ -6,6 +6,7 @@ define([
     'vellum/logic',
     'vellum/richText',
     'vellum/xpath',
+    'vellum/escapedHashtags',
     'vellum/fuse',
     'vellum/undomanager',
     'vellum/util',
@@ -18,6 +19,7 @@ define([
     logic,
     richText,
     xpath,
+    escapedHashtags,
     Fuse,
     undomanager,
     util,
@@ -144,6 +146,7 @@ define([
         this.shouldInferHashtags = this.richText;
         vellum.datasources.on("change", this._updateHashtags.bind(this), null, null, this);
         this._updateHashtags();
+        this.transformHashtags = escapedHashtags.makeHashtagTransform(this);
 
         this.tree = new Tree('data', 'control');
         // initalize #form as /data

--- a/src/itemset.js
+++ b/src/itemset.js
@@ -238,13 +238,13 @@ define([
                     .value();
                 return !_.isEmpty(value) ? value : undefined;
             },
-            deserialize: function (data, key, mug) {
+            deserialize: function (data, key, mug, context) {
                 _.each(data[key], function (value, i) {
                     var children = mug.form.getChildren(mug),
                         itemset = children[i] || afterDynamicSelectInsert(mug.form, mug),
                         dat = _.clone(data);
                     dat[key] = value;
-                    itemset.p[key] = itemset.spec[key].deserialize(dat, key, itemset);
+                    itemset.p[key] = itemset.spec[key].deserialize(dat, key, itemset, context);
                 });
             }
         };

--- a/src/itemset.js
+++ b/src/itemset.js
@@ -100,14 +100,17 @@ define([
                     value.nodeset = mugs.serializeXPath(value.nodeset, key, mug, data);
                     return value;
                 },
-                deserialize: function (data, key, mug) {
-                    var value = mugs.deserializeXPath(data, key, mug);
+                deserialize: function (data, key, mug, context) {
+                    var value = data[key];
                     if (value) {
+                        mugs.updateInstances(data, mug);
                         if (value.instance && value.instance.id && value.instance.src) {
                             var instances = {};
                             instances[value.instance.id] = value.instance.src;
                             mug.form.updateKnownInstances(instances);
                         }
+                        var fakeMug = {form: mug.form, p: value};
+                        value.nodeset = mugs.deserializeXPath(value, "nodeset", fakeMug, context);
                         //support old copy/paste
                         if (value.valueRef) {
                             mug.p.valueRef = value.valueRef;

--- a/src/javaRosa/plugin.js
+++ b/src/javaRosa/plugin.js
@@ -554,7 +554,7 @@ define([
                         data[name + ':hasMarkdown'] = value.hasMarkdown;
                     }
                 };
-                options.deserialize = function (data, name, mug, errors) {
+                options.deserialize = function (data, name, mug, context) {
                     var item = mug.p[name],
                         found = false;
                     if (data[name]) {
@@ -638,13 +638,13 @@ define([
                             }
                         }), _.identity);
                     if (discardedLangs.length) {
-                        var msg = errors.get(null, WARNING_KEY);
+                        var msg = context.errors.get(null, WARNING_KEY);
                         if (msg) {
                             msg.langs = _.union(msg.langs, discardedLangs);
                             msg.message = gettext("Discarded languages:") +
                                 " " + msg.langs.join(", ");
                         } else {
-                            errors.update(null, {
+                            context.errors.update(null, {
                                 key: WARNING_KEY,
                                 level: mug.WARNING,
                                 langs: discardedLangs,

--- a/src/modeliteration.js
+++ b/src/modeliteration.js
@@ -149,7 +149,8 @@ define([
                         }
                     },
                     deserialize: function (data, key, mug, context) {
-                        var value = mugs.deserializeXPath(data, key, mug, context) || {};
+                        var value = data[key] || {};
+                        mugs.updateInstances(data, mug);
                         if (value && value.instance &&
                                      value.instance.id && value.instance.src) {
                             // legacy serialization format
@@ -157,7 +158,10 @@ define([
                             instances[value.instance.id] = value.instance.src;
                             mug.form.updateKnownInstances(instances);
                         }
-                        return {idsQuery: value.idsQuery};
+                        var src = {},
+                            fakeMug = {form: mug.form, p: src};
+                        src.idsQuery = mugs.deserializeXPath(value, "idsQuery", fakeMug, context);
+                        return src;
                     }
                 }
             },

--- a/src/modeliteration.js
+++ b/src/modeliteration.js
@@ -116,14 +116,14 @@ define([
             },
             spec: {
                 nodeID: {
-                    deserialize: function (data, key, mug) {
+                    deserialize: function (data, key, mug, context) {
                         var deserialize = mugs.baseSpecs.databind.nodeID.deserialize;
                         if (data.dataSource) {
                             var id = data.id.slice(0, data.id.lastIndexOf("/")) || data.id,
                                 copy = _.extend({}, data, {id: id});
-                            return deserialize(copy, key, mug);
+                            return deserialize(copy, key, mug, context);
                         }
-                        return deserialize(data, key, mug);
+                        return deserialize(data, key, mug, context);
                     }
                 },
                 repeat_count: _.extend({}, oldRepeat.spec.repeat_count, {
@@ -148,8 +148,8 @@ define([
                                 mugs.serializeXPath(value.idsQuery, key, mug, data)};
                         }
                     },
-                    deserialize: function (data, key, mug) {
-                        var value = mugs.deserializeXPath(data, key, mug) || {};
+                    deserialize: function (data, key, mug, context) {
+                        var value = mugs.deserializeXPath(data, key, mug, context) || {};
                         if (value && value.instance &&
                                      value.instance.id && value.instance.src) {
                             // legacy serialization format

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -443,31 +443,22 @@ define([
          * Deserialize mug property data
          *
          * @param data - An object containing mug property data.
-         * @param errors - A `MugMessages` object with a convenience
-         *      `add(message)` method for global errors.
-         * @returns - An array of `Later` objects to be executed as the
-         *      final step in deserializing a group of related mugs.
+         * @param context - Paste context.
          */
-        deserialize: function (data, errors) {
-            var mug = this,
-                later = [];
+        deserialize: function (data, context) {
+            var mug = this;
             _.each(mug.spec, function (spec, key) {
                 if (mug.getPresence(key) !== 'notallowed') {
                     if (spec.deserialize) {
-                        var value = spec.deserialize(data, key, mug, errors);
+                        var value = spec.deserialize(data, key, mug, context);
                         if (!_.isUndefined(value)) {
-                            if (value instanceof Later) {
-                                later.push(value);
-                            } else {
-                                mug.p[key] = value;
-                            }
+                            mug.p[key] = value;
                         }
                     } else if (data.hasOwnProperty(key)) {
                         mug.p[key] = data[key];
                     }
                 }
             });
-            return later;
         },
         teardownProperties: function () {
             this.fire({type: "teardown-mug-properties", mug: this});
@@ -552,10 +543,6 @@ define([
         });
 
         return spec;
-    }
-
-    function Later(execute) {
-        this.execute = execute;
     }
 
     function MugMessages() {
@@ -778,10 +765,8 @@ define([
         return value || undefined;
     }
 
-    function deserializeXPath(data, key, mug) {
-        if (data.hasOwnProperty("instances") && !_.isEmpty(data.instances)) {
-            mug.form.updateKnownInstances(data.instances);
-        }
+    function deserializeXPath(data, key, mug, context) {
+        updateInstances(data, mug);
         var value = data[key];
         try {
             if (value) {
@@ -795,6 +780,12 @@ define([
             }
         }
         return value;
+    }
+
+    function updateInstances(data, mug) {
+        if (data.hasOwnProperty("instances") && !_.isEmpty(data.instances)) {
+            mug.form.updateKnownInstances(data.instances);
+        }
     }
 
     function resolveConflictedNodeId(mug) {
@@ -869,17 +860,17 @@ define([
                 serialize: function (value, key, mug, data) {
                     data.id = mug.absolutePathNoRoot;
                 },
-                deserialize: function (data, key, mug) {
+                deserialize: function (data, key, mug, context) {
                     if (data.id && data.id !== mug.p.nodeID) {
                         mug.p.nodeID = data.id.slice(data.id.lastIndexOf("/") + 1) ||
                                        mug.form.generate_question_id(null, mug);
                         if (data.conflictedNodeId) {
                             // Obscure edge case: if mug.p.nodeID conflicts with
                             // an existing question then expressions will be
-                            // associated with that question and this Later
+                            // associated with that question and this later
                             // assignment will not restore those connections to
                             // this mug.
-                            return new Later(function () {
+                            return context.later(function () {
                                 // after all other properties are deserialized,
                                 // assign conflicted ID to convert expressions
                                 // or setup new conflict
@@ -887,7 +878,7 @@ define([
                             });
                         }
                     }
-                    return new Later(function () {
+                    return context.later(function () {
                         if (mug.p.conflictedNodeId) {
                             resolveConflictedNodeId(mug);
                         }

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -768,16 +768,19 @@ define([
     function deserializeXPath(data, key, mug, context) {
         updateInstances(data, mug);
         var value = data[key];
-        try {
-            if (value) {
-                value = mug.form.xpath.parse(value.toString()).toHashtag();
-            } else if (value === null) {
-                value = undefined;
+        if (value) {
+            try {
+                value = mug.form.xpath.parse(value).toHashtag();
+                context.later(function () {
+                    mug.p[key] = context.transformHashtags(value);
+                });
+            } catch (err) {
+                if (_.isString(value) && !value.startsWith('#invalid/')) {
+                    value = '#invalid/xpath ' + value;
+                }
             }
-        } catch (err) {
-            if (_.isString(value) && !value.startsWith('#invalid/')) {
-                value = '#invalid/xpath ' + value;
-            }
+        } else if (value === null) {
+            value = undefined;
         }
         return value;
     }
@@ -1852,5 +1855,6 @@ define([
         baseSpecs: baseSpecs,
         deserializeXPath: deserializeXPath,
         serializeXPath: serializeXPath,
+        updateInstances: updateInstances,
     };
 });

--- a/src/richText.js
+++ b/src/richText.js
@@ -603,10 +603,7 @@ define([
             text = text.slice(INVALID_PREFIX.length);
             transform = escapedHashtags.transform;
         } else {
-            if (form._richText_transform === undefined) {
-                form._richText_transform = escapedHashtags.makeHashtagTransform(form);
-            }
-            transform = form._richText_transform;
+            transform = form.transformHashtags;
         }
         function bubble(hashtag) {
             return makeBubble(form, hashtag).prop('outerHTML');

--- a/tests/copy-paste.js
+++ b/tests/copy-paste.js
@@ -1165,6 +1165,30 @@ define([
             ]);
         });
 
+        it("should maintain reference in output value", function() {
+            util.loadXML("");
+            paste([
+                ['id', 'type', 'labelItext:en-default', 'appearance'],
+                ["/name", "Text", "Name", "null"],
+                ['/label', 'Trigger', '<output value="#form/name" />', 'minimal'],
+                ["/sub", "Group", "null"],
+            ]);
+            paste([
+                ["id", "type", "labelItext:en-default", "appearance"],
+                ["/name", "Text", "Name", "null"],
+                ['/label', 'Trigger', '<output value="#form/name" />', 'minimal'],
+            ]);
+            util.selectAll();
+            eq(mod.copy(), [
+                ["id", "type", "labelItext:en-default", "labelItext:hin-default", "appearance"],
+                ["/name", "Text", "Name", "Name", "null"],
+                ['/label', 'Trigger', '<output value="#form/name" />', '<output value="#form/name" />', 'minimal'],
+                ["/sub", "Group", "null", "null", "null"],
+                ["/sub/name", "Text", "Name", "Name", "null"],
+                ['/sub/label', 'Trigger', '<output value="#form/sub/name" />', '<output value="#form/sub/name" />', 'minimal'],
+            ]);
+        });
+
         describe("with instances without src", function() {
             before(function (done) {
                 util.init({

--- a/tests/copy-paste.js
+++ b/tests/copy-paste.js
@@ -1059,6 +1059,112 @@ define([
             assert(!mug.isVisible("calculateAttr"), "calculateAttr should not be visible");
         });
 
+        it("should maintain reference to pasted question", function() {
+            util.loadXML("");
+            paste([
+                ["id", "type", "calculateAttr"],
+                ["/group", "Group", "null"],
+                ["/group/number", "Int", "null"],
+                ["/group/hidden", "DataBindOnly", "#form/group/number + 1"],
+                ["/text", "Text", "null"],
+            ]);
+            paste([
+                ["id", "type", "calculateAttr"],
+                ["/group", "Group", "null"],
+                ["/group/number", "Int", "null"],
+                ["/group/hidden", "DataBindOnly", "#form/group/number + 1"],
+            ]);
+            util.selectAll();
+            eq(mod.copy(), [
+                ["id", "type", "calculateAttr"],
+                ["/group", "Group", "null"],
+                ["/group/number", "Int", "null"],
+                ["/group/hidden", "DataBindOnly", "#form/group/number + 1"],
+                ["/text", "Text", "null"],
+                ["/copy-1-of-group", "Group", "null"],
+                ["/copy-1-of-group/number", "Int", "null"],
+                ["/copy-1-of-group/hidden", "DataBindOnly", "#form/copy-1-of-group/number + 1"],
+            ]);
+        });
+
+        it("should maintain reference to question pasted in group", function() {
+            util.loadXML("");
+            paste([
+                ["id", "type", "calculateAttr"],
+                ["/one", "Int", "null"],
+                ["/two", "Int", "null"],
+                ["/hidden", "DataBindOnly", "#form/one + #form/two + 1"],
+                ["/sub", "Group", "null"],
+            ]);
+            paste([
+                ["id", "type", "calculateAttr"],
+                ["/two", "Int", "null"],
+                ["/hidden", "DataBindOnly", "#form/one + #form/two + 1"],
+            ]);
+            util.selectAll();
+            eq(mod.copy(), [
+                ["id", "type", "calculateAttr"],
+                ["/one", "Int", "null"],
+                ["/two", "Int", "null"],
+                ["/hidden", "DataBindOnly", "#form/one + #form/two + 1"],
+                ["/sub", "Group", "null"],
+                ["/sub/two", "Int", "null"],
+                ["/sub/hidden", "DataBindOnly", "#form/one + #form/sub/two + 1"],
+            ]);
+        });
+
+        it("should maintain reference to question referenced by itemset", function() {
+            util.loadXML("");
+            paste([
+                ["id", "type", "labelItext:en-default", "itemsetData"],
+                ["/items", "DataBindOnly", "null", "null"],
+                ["/select", "SelectDynamic", "select",
+                 '[{"instance":null,"nodeset":"#form/items","labelRef":"@name","valueRef":"@id"}]'],
+                ["/sub", "Group", "null", "null"],
+            ]);
+            paste([
+                ["id", "type", "labelItext:en-default", "itemsetData"],
+                ["/items", "DataBindOnly", "null", "null"],
+                ["/select", "SelectDynamic", "select",
+                 '[{"instance":null,"nodeset":"#form/items","labelRef":"@name","valueRef":"@id"}]'],
+            ]);
+            util.selectAll();
+            eq(mod.copy(), [
+                ["id", "type", "labelItext:en-default", "labelItext:hin-default", "itemsetData"],
+                ["/items", "DataBindOnly", "null", "null", "null"],
+                ["/select", "SelectDynamic", "select", "select",
+                 '[{"instance":null,"nodeset":"#form/items","labelRef":"@name","valueRef":"@id"}]'],
+                ["/sub", "Group", "null", "null", "null"],
+                ["/sub/items", "DataBindOnly", "null", "null", "null"],
+                ["/sub/select", "SelectDynamic", "select", "select",
+                 '[{"instance":null,"nodeset":"#form/sub/items","labelRef":"@name","valueRef":"@id"}]'],
+            ]);
+        });
+
+        it("should maintain reference to question referenced by model iteration", function() {
+            util.loadXML("");
+            paste([
+                ['id', 'type', 'labelItext:en-default', 'labelItext:hin-default', 'dataSource'],
+                ['/ids', 'DataBindOnly', 'null', 'null', 'null'],
+                ['/repeat/item', 'Repeat', 'repeat', 'repeat', '{"idsQuery":"#form/ids"}'],
+                ['/sub', 'Group', 'null', 'null', 'null'],
+            ]);
+            paste([
+                ['id', 'type', 'labelItext:en-default', 'labelItext:hin-default', 'dataSource'],
+                ['/ids', 'DataBindOnly', 'null', 'null', 'null'],
+                ['/repeat/item', 'Repeat', 'repeat', 'repeat', '{"idsQuery":"#form/ids"}'],
+            ]);
+            util.selectAll();
+            eq(mod.copy(), [
+                ['id', 'type', 'labelItext:en-default', 'labelItext:hin-default', 'dataSource'],
+                ['/ids', 'DataBindOnly', 'null', 'null', 'null'],
+                ['/repeat/item', 'Repeat', 'repeat', 'repeat', '{"idsQuery":"#form/ids"}'],
+                ['/sub', 'Group', 'null', 'null', 'null'],
+                ['/sub/ids', 'DataBindOnly', 'null', 'null', 'null'],
+                ['/sub/repeat/item', 'Repeat', 'repeat', 'repeat', '{"idsQuery":"#form/sub/ids"}'],
+            ]);
+        });
+
         describe("with instances without src", function() {
             before(function (done) {
                 util.init({

--- a/tests/datasources.js
+++ b/tests/datasources.js
@@ -297,7 +297,7 @@ define([
                 callback([{
                     id: "bar",
                     uri: "jr://fixture/foo",
-                    path: "root",
+                    path: "/root",
                     name: "outer",
                     structure: {
                         "@id": {},
@@ -313,7 +313,7 @@ define([
                 clickQuestion('select/itemset');
                 var data = $('[name=property-itemsetData]');
                 assert.equal(data.val(),
-                    '{"id":"bar","src":"jr://fixture/foo","query":"instance(\'bar\')root"}');
+                    '{"id":"bar","src":"jr://fixture/foo","query":"instance(\'bar\')/root"}');
                 assert.equal(data.find("option:selected").text(), "outer");
                 assert.equal($('[name=property-valueRef]').val(), '@id');
                 assert.equal($('[name=property-labelRef]').val(), 'name');
@@ -325,14 +325,14 @@ define([
                     ["id", "type", "itemsetData"],
                     ["select", "SelectDynamic",
                      '[{"instance":{"id":"bar",' +
-                     '"src":"jr://fixture/foo","query":"instance(\'bar\')root/inner"},' +
-                     '"nodeset":"instance(\'bar\')root/inner","labelRef":"name","valueRef":"@id"}]'],
+                     '"src":"jr://fixture/foo","query":"instance(\'bar\')/root/inner"},' +
+                     '"nodeset":"instance(\'bar\')/root/inner","labelRef":"name","valueRef":"@id"}]'],
                 ]);
                 clickQuestion('select/itemset');
                 callback([{
                     id: "bar",
                     uri: "jr://fixture/foo",
-                    path: "root",
+                    path: "/root",
                     name: "outer",
                     structure: {
                         "@id": {},
@@ -347,7 +347,7 @@ define([
                 }]);
                 var data = $('[name=property-itemsetData]');
                 assert.equal(data.val(),
-                    '{"id":"bar","src":"jr://fixture/foo","query":"instance(\'bar\')root/inner"}');
+                    '{"id":"bar","src":"jr://fixture/foo","query":"instance(\'bar\')/root/inner"}');
                 assert.equal(data.find("option:selected").text(), "outer - inner");
             });
 


### PR DESCRIPTION
This fixes an unintuitive behavior when copying/pasting multiple questions that contain references to each other. I've wanted to fix this ever since [Jessica Long reported it almost two years ago](http://manage.dimagi.com/default.asp?265411), and finally decided to do it today.

🐡 Review by commit.

### Create form with question referencing another question
![image](https://user-images.githubusercontent.com/464726/62580766-0836bc00-b875-11e9-86a0-dc732b7667a5.png)


### Select and copy/paste `num` and `plus1` into group
![image](https://user-images.githubusercontent.com/464726/62580564-6911c480-b874-11e9-9d3c-0e564dd31959.png)


@dimagi/product this makes a subtle change in behavior, and I think it's more intuitive and therefore better than the previous behavior. We should announce it. Do we need to do anything else?