### PR TITLE
Updated languages menu to scroll vertically

### DIFF
--- a/src/less-style/structure.less
+++ b/src/less-style/structure.less
@@ -186,10 +186,13 @@ body.vellum-full-screen {
 
         // Let major content blocks scroll independently (i.e., tree versus expression editor)
         .fd-scrollable {
-            width: 100%;
             overflow-x: hidden;
             overflow-y: auto;
-            height: @containerHeight;
+            max-height: @containerHeight;
+
+            &:not(.dropdown-menu) {     // Protect scrolling dropdowns from also scrolling horizontally
+                width: 100%;
+            }
 
             // Prevent scrollbars underneath the modal from bleeding through on OSX
             transform: translate3d(0, 0, 0);

--- a/src/templates/main.html
+++ b/src/templates/main.html
@@ -13,7 +13,7 @@
                             <i class="fa fa-reorder"></i>
                             <i class="fa fa-caret-down"></i>
                         </a>
-                        <ul class="dropdown-menu checklist fd-questions-menu" role="menu">
+                        <ul class="dropdown-menu checklist fd-questions-menu fd-scrollable" role="menu">
                             <li>
                                 <a class="fd-button-copy">
                                     <i class="fa fa-copy"></i>

--- a/src/window.js
+++ b/src/window.js
@@ -108,18 +108,18 @@ define([
                 treeHeight -= 2 + accessoryHeight +
                     this.$f.find('.fd-content-left-divider').outerHeight(true);
                 accessoryPane.find(".fd-scrollable")
-                             .css('height', accessoryScrollableHeight + 'px');
+                             .css('max-height', accessoryScrollableHeight + 'px');
                 accessoryPane.show();
                 this.$f.find(".fd-content-left-divider").show();
             } else {
                 accessoryPane.hide();
                 this.$f.find(".fd-content-left-divider").hide();
             }
-            $tree.find('.fd-scrollable').css('height', treeHeight + 'px');
+            $tree.find('.fd-scrollable').css('max-height', treeHeight + 'px');
 
             $fdc.find('.fd-content-right')
                 .css('width', availableHorizSpace - this.getLeftWidth() + 'px')
-                .find('.fd-scrollable.full').css('height', columnHeight + 'px');
+                .find('.fd-scrollable.full').css('max-height', columnHeight + 'px');
 
             $fdc.find('.fd-props-scrollable')
                 .css('height', columnHeight -


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-813

Most of the changes are `height` => `max-height` so that scrolling content isn't forced to be as tall as the window.

Tested out on a form with a lot of languages and a form with a few languages. Tested out full screen mode.