### PR TITLE
Updated invalid XML error to be friendlier

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1284,7 +1284,7 @@ define([
                 // hack: don't display the whole invalid XML block if it
                 // was a parse error
                 var msg = e.toString();
-                if (msg.indexOf("Invalid XML") === 0) {
+                if (msg.indexOf("Invalid XML") !== -1) {
                     msg = gettext("Parsing Error. Please check that your form is valid XML.");
                 }
 


### PR DESCRIPTION
Noticed while working on https://github.com/dimagi/commcare-hq/pull/25531

The code is checking for an "Invalid XML" prefix but the message starts with "Error: Invalid XML" instead.

before
<img width="1445" alt="Screen Shot 2019-10-02 at 10 05 44 PM" src="https://user-images.githubusercontent.com/1486591/66094168-0d587480-e561-11e9-9fa6-3e54e71bc203.png">

after
<img width="1445" alt="Screen Shot 2019-10-02 at 10 04 45 PM" src="https://user-images.githubusercontent.com/1486591/66094176-134e5580-e561-11e9-9d40-27a1f0eaebfc.png">
