### PR TITLE
fix truncated text issue with output refs

### DIFF
--- a/tests/xml.js
+++ b/tests/xml.js
@@ -270,6 +270,14 @@ define([
                 value = parsedXml.find("value");
             eq(value, REGEXP_CRASHING_DEBUG_ITEXT_PARSED, false);
         });
+
+        it("should not wrap trailing text in output refs", function () {
+            var value = "<value>&amp; <output value='/path' /> " +
+                "text-after *should* remain. ~&amp; not #disrupt the\nflow" +
+                "</value>";
+            eq($(value),"& <output value=\"/path\" /> text-after " +
+                "*should* remain. ~& not #disrupt the\nflow");
+        });
     });
 
     describe("The XML query", function () {
@@ -297,6 +305,18 @@ define([
 
         it("should round-trip newline", function () {
             eq(xml.query("\n").toString(), "\n");
+        });
+
+        it("should not insert text inside output refs", function () {
+            eq(xml.query(
+                "& <output value=\"/data/question1\" " +
+                "vellum:value=\"#form/question1\"> " +
+                "text-after *should* remain. ~& not #disrupt the\nflow</output>"
+            ).toString(),
+                "&amp; <output value=\"/data/question1\" " +
+                "vellum:value=\"#form/question1\" /> " +
+                "text-after *should* remain. ~&amp; not #disrupt the\nflow"
+            );
         });
     });
 });

--- a/tests/xml.js
+++ b/tests/xml.js
@@ -275,7 +275,7 @@ define([
             var value = "<value>&amp; <output value='/path' /> " +
                 "text-after *should* remain. ~&amp; not #disrupt the\nflow" +
                 "</value>";
-            eq($(value),"& <output value=\"/path\" /> text-after " +
+            eq($(value), "& <output value=\"/path\" /> text-after " +
                 "*should* remain. ~& not #disrupt the\nflow");
         });
     });
@@ -308,6 +308,9 @@ define([
         });
 
         it("should not insert text inside output refs", function () {
+            // this test is verifying a quirk of jQuery 3.5.0 that results in
+            // invalid XML transformations. It is not necessary to preserve
+            // the behavior if/when jQuery no longer mangles XML this way.
             eq(xml.query(
                 "& <output value=\"/data/question1\" " +
                 "vellum:value=\"#form/question1\"> " +


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11032

fixes an issue where if an ampersand and an output ref are present in an itext block, the text following the output ref gets truncated due to a strange behavior that this triggers in jquery's `parseXML`