### PR TITLE
updated regex to support different markdown table format

### DIFF
--- a/src/javaRosa/util.js
+++ b/src/javaRosa/util.js
@@ -55,12 +55,12 @@ define([
          * headings
          * italics/bold/bold italics
          * links
-         * tables (regex written after ||)
+         * tables (hasTable regex) 
          */
         var hasMarkdown = /^\d+[\.\)] |^\* |~~.+~~|# |\*{1,3}\S.*\*{1,3}|\[.+\]\(\S+\)/m.test(val),
             hasTable = false;
         if (supportTables) {
-            hasTable = /^(\|[^\n]+\|\r?\n)((?:\|:?[-]+:?)+\|)(\n(?:\|[^\n]+\|\r?\n?)*)?$/m.test(val);
+            hasTable = /^(\|[^\n]+\|\r?\n)((?:\|\s*:?[-]+:?\s*)+\|)(\n(?:\|[^\n]+\|\r?\n?)*)?$/m.test(val);
         }
         return hasMarkdown || hasTable;
     };


### PR DESCRIPTION
While adding support for markdown tables on HQ, we missed out this format which is not picked up by the regex we wrote. 
```
| Column1      | Column2 |
| ----------- | ----------- |
| 100      | 200     |
| 110   | 215        |
``` 

For more details see this comment https://github.com/dimagi/Vellum/pull/977#discussion_r494952540

https://regex101.com/r/2QZeLp/1
```
| col1    | col2    | col3 |
|:----:|:----:|:----:|
| r1c1 | r1c2 | r1c3 |
| r2c1 | r2c2 | r2c3 |
```

https://regex101.com/r/5mWDhq/1
```
| col1    | col2    | col3 |
|----|----|----|
| r1c1 | r1c2 | r1c3 |
| r2c1 | r2c2 | r2c3 |
```

https://regex101.com/r/Jbqsx3/1
```
| Column1      | Column2 |
| ----------- | ----------- |
| 100      | 200     |
| 110   | 215        |
```