### PR TITLE
Implement ability to make all questions: 1. load case properties as default values 2. required

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,12 @@
     <script src="tests/typoglycemia.js"></script>
     <script data-main="tests/main" src="node_modules/requirejs/require.js"></script>
     <script src="node_modules/xrayquire/xrayquire.js"></script>
-    <script>mocha.setup('bdd');</script>
+    <script>
+      mocha.setup({
+        ui: 'bdd',
+        timeout: '10000',
+      });
+    </script>
 
     <style>
       .container-fluid {

--- a/src/core.js
+++ b/src/core.js
@@ -462,9 +462,12 @@ define([
             caseProperties = _this.datasources.getHashtagMap({});
         _this.data.core.form.walkMugs(function (mug) {
             if (mug.isVisible('defaultValue')) {
-                var caseProp = '#case/' + mug.p.nodeID;
+                var caseProp = '#case/' + mug.p.nodeID,
+                    userCaseProp = '#user/' + mug.p.nodeID;
                 if (caseProperties.hasOwnProperty(caseProp)) {
                     mug.p.defaultValue = caseProp;
+                } else if (caseProperties.hasOwnProperty(userCaseProp)) {
+                    mug.p.defaultValue = userCaseProp;
                 }
             }
         });

--- a/src/core.js
+++ b/src/core.js
@@ -247,7 +247,9 @@ define([
             // Allow onReady to access vellum instance (mostly for tests)
             _this.opts().core.onReady.apply(_this);
         }
-        this._init_bulk_update_questions();
+        if (_this.opts().features.allow_bulk_form_actions) {
+            this._init_bulk_update_questions();
+        }
         this._init_extra_tools();
         parser.init(this);
         this.loadXFormOrError(this.opts().core.form, function () {

--- a/src/core.js
+++ b/src/core.js
@@ -457,11 +457,11 @@ define([
 
     fn.defaultMatchingQuestionsToCaseProperties = function () {
         var _this = this,
-            caseProperties = _.keys(_this.datasources.getHashtagMap());
+            caseProperties = _this.datasources.getHashtagMap({});
         _this.data.core.form.walkMugs(function (mug) {
             if (mug.isVisible('defaultValue')) {
                 var caseProp = '#case/' + mug.p.nodeID;
-                if (caseProperties.indexOf(caseProp) !== -1) {
+                if (caseProperties.hasOwnProperty(caseProp)) {
                     mug.p.defaultValue = caseProp;
                 }
             }

--- a/src/core.js
+++ b/src/core.js
@@ -415,19 +415,22 @@ define([
     };
 
     fn.getBulkUpdateMenuItems = function () {
-        var _this = this;
-        return [
-            {
-                name: gettext('Make Required'),
-                confirmMessage: gettext("You are about to make all existing " +
-                    "questions on this form required. This action will overwrite " +
-                    "the current configuration of this form and can only be " +
-                    "undone by editing individual questions."),
-                confirmAction: function () {
-                    // todo
-                }
-            },
-            {
+        var _this = this,
+            menuItems =  [
+                {
+                    name: gettext('Make Required'),
+                    confirmMessage: gettext("You are about to make all existing " +
+                        "questions on this form required. This action will overwrite " +
+                        "the current configuration of this form and can only be " +
+                        "undone by editing individual questions."),
+                    confirmAction: function () {
+                        _this.makeAllQuestionsRequired();
+                    },
+                },
+            ];
+
+        if (_this.data.core.databrowser) {
+            menuItems.push({
                 name: gettext('Load Default Values'),
                 confirmMessage: gettext("You are about to set matching case " +
                     "properties as Default Values for all existing questions. " +
@@ -435,10 +438,35 @@ define([
                     "all questions with matching case properties and can only " +
                     "be undone by editing individual questions."),
                 confirmAction: function () {
-                    // todo
+                    _this.defaultMatchingQuestionsToCaseProperties();
                 },
-            },
-        ];
+            });
+        }
+        return menuItems;
+    };
+
+    fn.makeAllQuestionsRequired = function () {
+        var _this = this;
+        _this.data.core.form.walkMugs(function (mug) {
+            if (mug.spec.requiredAttr && mug.isVisible('requiredAttr')) {
+                mug.p.requiredAttr = true;
+            }
+        });
+        _this.refreshCurrentMug();
+    };
+
+    fn.defaultMatchingQuestionsToCaseProperties = function () {
+        var _this = this,
+            caseProperties = _.keys(_this.datasources.getHashtagMap());
+        _this.data.core.form.walkMugs(function (mug) {
+            if (mug.isVisible('defaultValue')) {
+                var caseProp = '#case/' + mug.p.nodeID;
+                if (caseProperties.indexOf(caseProp) !== -1) {
+                    mug.p.defaultValue = caseProp;
+                }
+            }
+        });
+        _this.refreshCurrentMug();
     };
 
     fn.showConfirmBulkActionModal = function (confirmMessage, confirmActionFn) {

--- a/src/core.js
+++ b/src/core.js
@@ -247,6 +247,7 @@ define([
             // Allow onReady to access vellum instance (mostly for tests)
             _this.opts().core.onReady.apply(_this);
         }
+        this._init_bulk_update_questions();
         this._init_extra_tools();
         parser.init(this);
         this.loadXFormOrError(this.opts().core.form, function () {
@@ -390,6 +391,71 @@ define([
             "Barcode",
             "Secret",
         ];
+    };
+
+    fn._init_bulk_update_questions = function () {
+        var _this = this,
+            menuItems = this.getBulkUpdateMenuItems();
+
+        var $lastItem = this.$f.find('.fd-bulk-update-header');
+        $lastItem.nextUntil(".divider").remove();
+        _(menuItems).each(function (menuItem) {
+            var $menuLink = $(util.format(
+                    "<a tabindex='-1' href='#'>{name}</a>",
+                    _.extend(menuItem)
+                )).click(function (e) {
+                    e.preventDefault();
+                    _this.showConfirmBulkActionModal(menuItem.confirmMessage, menuItem.confirmAction);
+                }),
+                $newItem = $("<li></li>").append($menuLink);
+            $lastItem.after($newItem);
+            $lastItem = $newItem;
+        });
+
+    };
+
+    fn.getBulkUpdateMenuItems = function () {
+        var _this = this;
+        return [
+            {
+                name: gettext('Make Required'),
+                confirmMessage: gettext("You are about to make all existing " +
+                    "questions on this form required. This action will overwrite " +
+                    "the current configuration of this form and can only be " +
+                    "undone by editing individual questions."),
+                confirmAction: function () {
+                    // todo
+                }
+            },
+            {
+                name: gettext('Load Default Values'),
+                confirmMessage: gettext("You are about to set matching case " +
+                    "properties as Default Values for all existing questions. " +
+                    "This action will overwrite existing Default Values for " +
+                    "all questions with matching case properties and can only " +
+                    "be undone by editing individual questions."),
+                confirmAction: function () {
+                    // todo
+                },
+            },
+        ];
+    };
+
+    fn.showConfirmBulkActionModal = function (confirmMessage, confirmActionFn) {
+        var _this = this,
+            $modal;
+        $modal = this.generateNewModal(gettext("Are you sure you want to perform this action?"), [
+            {
+                title: gettext('Continue'),
+                cssClasses: "btn-primary",
+                action: function () {
+                    _this.closeModal();
+                    confirmActionFn();
+                }
+            }
+        ], gettext("Cancel"));
+        $modal.find('.modal-body').html($('<p></p>').text(confirmMessage));
+        $modal.modal('show');
     };
 
     fn._init_extra_tools = function () {

--- a/src/javaRosa/plugin.js
+++ b/src/javaRosa/plugin.js
@@ -113,7 +113,7 @@ define([
                 return;
             }
             $menu.find('.language-selector').remove();
-            $menu.find('.fd-tools-menu').before(language_selector({languages: fullLangs}));
+            $menu.find('.fd-bulk-update-menu').before(language_selector({languages: fullLangs}));
             $items = $menu.find(".fd-display-item");
             $items.click(function (e) {
                 $input.val($(this).data("code")).change();

--- a/src/templates/main.html
+++ b/src/templates/main.html
@@ -32,6 +32,10 @@
                                     <%-gettext("Collapse All")%><span class="hotkey"><%-Ctrl%><%-Alt%>&ndash;</span>
                                 </a>
                             </li>
+                            <li class="divider fd-bulk-update-menu"></li>
+                            <li class="dropdown-header fd-bulk-update-header">
+                              <%-gettext("Bulk Update All Questions")%>
+                            </li>
                             <li class="divider fd-tools-menu"></li>
                         </ul>
                         <input type="hidden" class="fd-question-tree-display" />

--- a/tests/bulkActions.js
+++ b/tests/bulkActions.js
@@ -1,0 +1,158 @@
+define([
+    'chai',
+    'jquery',
+    'underscore',
+    'tests/utils',
+    'vellum/richText',
+    'vellum/javaRosa/util',
+], function(
+    chai,
+    $,
+    _,
+    util
+) {
+    var assert = chai.assert,
+        CASE_DATA = [{
+            id: "commcaresession",
+            uri: "jr://instance/session",
+            path: "/session",
+            name: "Session",
+            structure: {
+                "case_id": {
+                    reference: {
+                        hashtag: "#case",
+                        source: "casedb",
+                        subset: "case",
+                        subset_key: "@case_type",
+                        key: "@case_id",
+                    },
+                },
+            },
+        }, {
+            id: "casedb",
+            uri: "jr://instance/casedb",
+            path: "/casedb/case",
+            name: "Cases",
+            structure: {
+                name: {},
+            },
+            subsets: [{
+                id: "case",
+                name: "release",
+                key: "@case_type",
+                structure: {
+                    release_date: {},
+                    release_length: {},
+                    contact_number: {},
+                    format: {},
+                    genres: {},
+                    case_name: {},
+                    quantity: {},
+                },
+            }],
+        }];
+
+
+    describe("Bulk form actions", function() {
+
+        describe("should make all applicable questions required", function () {
+            function test(qType, isRequired) {
+                var requiredStatus = isRequired ? " is marked as required" : " is ignored";
+                it("question " + qType + requiredStatus, function () {
+                    var mug = map[qType];
+                    if (isRequired) {
+                        assert(mug.p.requiredAttr, "required is false");
+                    } else {
+                        assert(!mug.p.requiredAttr, "required is true");
+                    }
+                });
+            }
+            var form, map = {};
+            before(function () {
+                form = util.loadXML("");
+                map.Text = util.addQuestion("Text");
+                map.PhoneNumber = util.addQuestion("PhoneNumber");
+                map.HiddenValue = util.addQuestion("DataBindOnly");
+                map.Select = util.addQuestion("Select");
+                map.Choice = util.addQuestion("Choice");
+                map.Label = util.addQuestion("Trigger");
+                map.Group = util.addQuestion("Group", "groupA");
+                map.TextInGroup = util.addQuestion.bind({prevId: "groupA"})("Text", 'text2');
+                map.DataBindOnlyInGroup = util.addQuestion.bind({prevId: "groupA"})("DataBindOnly", 'hidden2');
+                form.vellum.makeAllQuestionsRequired();
+            });
+
+            test("Text", true);
+            test("PhoneNumber", true);
+            test("HiddenValue", false);
+            test("Select", true);
+            test("Choice", false);
+            test("Label", false);
+            test("Group", false);
+            test("TextInGroup", true);
+            test("DataBindOnlyInGroup", false);
+        });
+
+        describe("should set matching case properties as default values on applicable question types", function () {
+            var form, map = {};
+
+            function test(qType, isMatching, existingDefault) {
+                var defaultStatus = existingDefault ? " matched the existing default value" : " was not applicable",
+                    matchingStatus = isMatching ? " matches the expected case property" : defaultStatus;
+                it("the default value for " + qType + matchingStatus, function () {
+                    var mug = map[qType];
+                    if (isMatching) {
+                        assert(mug.p.defaultValue === '#case/' + mug.p.nodeID, "default value didn't match the case property");
+                    } else if (existingDefault) {
+                        assert(mug.p.defaultValue === existingDefault, "the default value changed");
+                    } else {
+                        assert(!mug.p.defaultValue, "the default value was set");
+                    }
+                });
+            }
+
+            before(function (done) {
+                util.init({
+                    javaRosa: { langs: ['en'] },
+                    core: {
+                        dataSourcesEndpoint: function (callback) { callback(CASE_DATA); },
+                        onReady: function () {
+                            map.MatchingText = util.addQuestion("Text", "release_date", {defaultValue: "existing default"});
+                            map.MatchingHiddenValue = util.addQuestion("DataBindOnly", "release_length");
+                            map.MatchingPhoneNumber = util.addQuestion("PhoneNumber", "contact_number");
+                            map.MatchingSelect = util.addQuestion("Select", "format");
+                            map.ChoiceOfMatchingSelect = util.addQuestion("Choice", "vinyl");
+                            map.Text = util.addQuestion("Text", 'no_match_01', {defaultValue: "already set"});
+                            map.HiddenValue = util.addQuestion("DataBindOnly", "no_match_02", {defaultValue: "already set"});
+                            map.Label = util.addQuestion("Trigger", "no_match_03");
+                            map.Group = util.addQuestion("Group", "groupA");
+                            map.MatchingTextInGroup = util.addQuestion.bind({prevId: "groupA"})("Text", 'quantity', {defaultValue: "existing default"});
+                            map.MatchingHiddenValueInGroup = util.addQuestion.bind({prevId: "groupA"})("DataBindOnly", 'genres');
+                            map.TextInGroup = util.addQuestion.bind({prevId: "groupA"})("Text", 'no_match_04', {defaultValue: "already set"});
+                            map.HiddenValueInGroup = util.addQuestion.bind({prevId: "groupA"})("DataBindOnly", 'no_match_05', {defaultValue: "already set"});
+                            form = this.data.core.form;
+                            form.vellum.defaultMatchingQuestionsToCaseProperties();
+                            done();
+                        },
+                    },
+                });
+            });
+
+            test("MatchingText", true);
+            test("MatchingHiddenValue", true);
+            test("MatchingPhoneNumber", true);
+            test("MatchingSelect", true);
+            test("ChoiceOfMatchingSelect", false);
+            test("Text", false, "already set");
+            test("HiddenValue", false, "already set");
+            test("Label", false);
+            test("Group", false);
+            test("MatchingTextInGroup", true);
+            test("MatchingHiddenValueInGroup", true);
+            test("TextInGroup", false, "already set");
+            test("HiddenValueInGroup", false, "already set");
+
+        });
+
+    });
+});

--- a/tests/bulkActions.js
+++ b/tests/bulkActions.js
@@ -18,13 +18,33 @@ define([
             path: "/session",
             name: "Session",
             structure: {
-                "case_id": {
-                    reference: {
-                        hashtag: "#case",
-                        source: "casedb",
-                        subset: "case",
-                        subset_key: "@case_type",
-                        key: "@case_id",
+                data: {
+                    merge: true,
+                    structure: {
+                        "case_id": {
+                            reference: {
+                                hashtag: "#case",
+                                source: "casedb",
+                                subset: "case",
+                                subset_key: "@case_type",
+                                key: "@case_id",
+                            },
+                        },
+                    },
+                },
+                context: {
+                    merge: true,
+                    structure: {
+                        "userid": {
+                            reference: {
+                                hashtag: "#user",
+                                source: "casedb",
+                                subset: "commcare-user",
+                                subset_key: "@case_type",
+                                subset_filter: true,
+                                key: "hq_user_id",
+                            },
+                        },
                     },
                 },
             },
@@ -48,6 +68,15 @@ define([
                     genres: {},
                     case_name: {},
                     quantity: {},
+                    footnote: {},
+                },
+            }, {
+                id: "commcare-user",
+                name: "user",
+                key: "@case_type",
+                structure: {
+                    role: {},
+                    footnote: {},
                 },
             }],
         }];
@@ -130,6 +159,8 @@ define([
                             map.MatchingHiddenValueInGroup = util.addQuestion.bind({prevId: "groupA"})("DataBindOnly", 'genres');
                             map.TextInGroup = util.addQuestion.bind({prevId: "groupA"})("Text", 'no_match_04', {defaultValue: "already set"});
                             map.HiddenValueInGroup = util.addQuestion.bind({prevId: "groupA"})("DataBindOnly", 'no_match_05', {defaultValue: "already set"});
+                            map.userCaseProp = util.addQuestion("DataBindOnly", "role");
+                            map.similarCaseProp = util.addQuestion("DataBindOnly", "footnote");
                             form = this.data.core.form;
                             form.vellum.defaultMatchingQuestionsToCaseProperties();
                             done();
@@ -151,6 +182,11 @@ define([
             test("MatchingHiddenValueInGroup", true);
             test("TextInGroup", false, "already set");
             test("HiddenValueInGroup", false, "already set");
+
+            it("user case properties are also matched with priority given to case properties", function () {
+                assert(map.userCaseProp.p.defaultValue === '#user/' + map.userCaseProp.p.nodeID, "user case property was not set as default");
+                assert(map.similarCaseProp.p.defaultValue === '#case/' + map.similarCaseProp.p.nodeID, "case property was not given priority over user case property");
+            });
 
         });
 

--- a/tests/main.js
+++ b/tests/main.js
@@ -117,6 +117,7 @@ requirejs(['jquery', 'jquery.vellum'], function ($) {
         'tests/questionProperties',
         'tests/atwho',
         'tests/escapedHashtags',
+        'tests/bulkActions',
         'tests/undomanager',
     ], function (
         options

--- a/tests/options.js
+++ b/tests/options.js
@@ -248,6 +248,7 @@ define(["underscore"], function (_) {
             'image_resize': true,
             'markdown_in_groups': true,
             'allow_data_reference_in_setvalue': true,
+            'allow_bulk_form_actions': true,
         }
     };
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11387

#### User-facing changes

Adds one option in registration/survey forms to mark all questions required:
![Screen Shot 2020-11-03 at 2 27 00 PM](https://user-images.githubusercontent.com/716573/98037108-b61a7880-1de0-11eb-9e48-800d681414a9.png)

adds an additional option in followup forms (or forms where the datasource panel is visible) to set default values of all matching properties to the existing matching case value:
![Screen Shot 2020-11-03 at 2 28 35 PM](https://user-images.githubusercontent.com/716573/98037238-e2ce9000-1de0-11eb-85db-f7c5d6cfb1b1.png)

confirmation dialog for marking all questions as required:
![Screen Shot 2020-11-03 at 2 29 18 PM](https://user-images.githubusercontent.com/716573/98037308-fa0d7d80-1de0-11eb-9961-fb053ce44f1c.png)

confirmation dialog for setting default values:
![Screen Shot 2020-11-03 at 2 29 46 PM](https://user-images.githubusercontent.com/716573/98037353-0abdf380-1de1-11eb-978f-cc7ff6acdbfb.png)

#### Risks
Definitely pushing this through QA.
