### PR TITLE
Hashtags should now use the provided alias name for a property rather…

### DIFF
--- a/src/datasources.js
+++ b/src/datasources.js
@@ -299,11 +299,13 @@ define([
                 }
 
                 var path = parentPath ? parentPath + "/" + id : id,
-                    tree = getTree(item, id, path, info);
+                    tree = getTree(item, id, path, info),
+                    name = tree.name;
+
                 return {
-                    name: tree.name,
+                    name: name,
                     description: tree.description,
-                    hashtag: info.hashtag && !index ? info.hashtag + '/' + id : null,
+                    hashtag: info.hashtag && !index ? info.hashtag + '/' + name : null,
                     parentPath: parentPath,
                     xpath: path,
                     index: index || false,

--- a/tests/datasources.js
+++ b/tests/datasources.js
@@ -90,6 +90,7 @@ define([
                 structure: {
                     dob: {},
                     parent: {},
+                    realName: {name: "anAlias"}
                 },
                 related: {
                     parent: {
@@ -189,6 +190,14 @@ define([
 
             it("should construct #case hashtag with reference.subset", function() {
                 assert.equal(nodes.child.nodes.dob.hashtag, "#case/dob");
+            });
+
+            it("should use aliases for hashtags", function() {
+                assert.equal(nodes.child.nodes.anAlias.hashtag, "#case/anAlias");
+            });
+
+            it("should reference an aliased property by its original id in its xpath", function() {
+                assert.match(nodes.child.nodes.anAlias.xpath, /\/realName$/);
             });
 
             it("should construct #case/parent hashtag with related subset", function() {


### PR DESCRIPTION
… than its id

Created because some properties we support are attributes -- '@property' rather than 'property'. However, attributes displayed with an @ sign break hashtags. The correct support is for them to be displayed with an alternate name property, while retaining the '@attribute' notation for its xpath.

Given that these changes pass all tests, I do not believe QA is required.