### PR TITLE
Add some helpful github tools (labels, dependabot, PR templates) to vellum

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+## Summary
+<!--
+    Provide a link to the ticket or document which prompted this change,
+    Describe the rationale and design decisions.
+-->
+
+## Feature Flag
+<!-- If this is specific to a feature flag, which one? -->
+
+## Product Description
+<!-- For non-invisible changes, describe user-facing effects. -->
+
+## Safety Assurance
+
+- [ ] Risk label is set correctly
+- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
+- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
+- [ ] I am certain that this PR will not introduce a regression for the reasons below
+
+### Automated test coverage
+
+<!-- Identify the related test coverage and the tests it would catch -->
+
+### QA Plan
+
+<!--
+- Describe QA plan that along with automated test coverages proves this PR is regression free
+- Link to QA Ticket
+-->
+
+### Safety story
+<!--
+Describe any other pieces to the safety story including
+local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
+-->
+
+### Rollback instructions
+
+<!--
+If this PR follows standards of revertability, check the box below.
+Otherwise replace it with detailed instructions or reasons a rollback is impossible.
+-->
+
+- [ ] This PR can be reverted after deploy with no further considerations 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 5
+  labels:
+  - product/invisible

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,69 @@
+# See https://github.com/dimagi/label-bot
+disabled_actions:
+  - triage
+  - review
+  - lgtm
+
+# Label rules
+brace_expansion: true
+minus_negate: false
+
+rules:
+
+  - labels: ['dependencies']
+    patterns: ['package.json|yarn.lock']
+
+# WIP
+wip:
+  - 'Open for review: do not merge'
+  - 'awaiting QA'
+
+# Label management
+delete_labels: false
+
+colors:
+  navy: '#0366d6'
+  dark_orange: '#eb6420'
+  light_orange: '#fbca04'
+  royal: '#5319e7'
+  purple: '#9800c6'
+  lime: '#75ff68'
+  dark_green: '#0e8a16'
+  dark_purple: '#71239b'
+  sand: '#d38737'
+  grey: '#cfd2d6'
+  burnt_orange: '#bc4b29'
+  green: '#009800'
+  tan: '#fef2c0'
+  yellow: '#fcfa4e'
+  light_yellow: '#fffeb3'
+
+labels:
+- name: 'dependencies'
+  color: navy
+  description: 'Pull requests that update a dependency file'
+- name: 'awaiting QA'
+  color: light_orange
+  description: 'QA in progress. Do not merge'
+- name: 'Open for review: do not merge'
+  color: royal
+  description: 'A work in progress'
+- name: 'QA Passed'
+  color: green
+  description: ''
+- name: 'QA post deploy'
+  color: tan
+  description: 'Change should be re-tested once live'
+# labels below are part of the product triage system
+- name: 'product/all-users-all-environments'
+  color: dark_green
+  description: 'Change impacts all users on all environments'
+- name: 'product/feature-flag'
+  color: sand
+  description: 'Change will only affect users who have a specific feature flag enabled'
+- name: 'product/invisible'
+  color: grey
+  description: 'Change has no end-user visible impact'
+- name: 'product/prod-india-all-users'
+  color: burnt_orange
+  description: 'Change will only be deployed to Dimagi "SaaS" environments'


### PR DESCRIPTION
this adds config files for labels, dependabot, and PR templates to vellum to be more in line with hq's config