### PR TITLE
Fix - "Security Error" Dialogue Box in Firefox

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2343,6 +2343,7 @@ define([
                 hidePageSpinner();
                 _this.opts().core.onFormSave(data);
                 _this.data.core.lastSavedXForm = formText;
+                _this._setURLHash(_this._propertiesMug);
             }
         });
     };
@@ -2495,7 +2496,6 @@ define([
 
     fn.handleMugRename = function (form, mug, newId, oldId, newPath, oldPath, oldParent) {
         form.handleMugRename(mug, newId, oldId, newPath, oldPath, oldParent);
-        this._setURLHash(mug);
     };
 
     fn.duplicateMugProperties = function(mug) {};

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -350,8 +350,13 @@ define([
             super_updateValue();
         };
 
+        widget._setURLHash = _.debounce(function(){
+                mug.form.vellum._setURLHash(mug)
+            }, 500);
+        
         widget.handleChange = function () {
             super_handleChange();
+            widget._setURLHash(mug);            
             if (!mug.p.nodeID) {
                 // HACK drop errors; nodeID will be set automatically on save
                 mug.dropMessage("nodeID", "mug-nodeID-error");

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -350,7 +350,7 @@ define([
             super_updateValue();
         };
 
-        widget._setURLHash = _.debounce(function(){
+        widget._setURLHash = _.debounce(function(mug){
                 mug.form.vellum._setURLHash(mug)
             }, 500);
         

--- a/tests/urlHash.js
+++ b/tests/urlHash.js
@@ -29,13 +29,27 @@ requirejs([
             assert.equal(mug.absolutePath, "/data/group");
         });
 
-        it("should change the hash when you add a question", function(done) {
+        it("should change the hash when you add a question", function() {
             util.loadXML("");
-            util.addQuestion("Text", "text");
-            util.saveAndReload(function(){
-                assert.equal(window.location.hash, '#form/text');
-                done();
-            })
+            util.addQuestion("Text", "initial");
+            util.clickQuestion("initial");
+            assert.equal(window.location.hash, "#form/initial");
+        });
+
+        it("should change the hash when you delete a question", function() {
+            util.loadXML("");
+            
+            util.addQuestion("Text", "first");
+            util.clickQuestion("first");
+
+            util.addQuestion("Text", "second");
+            util.clickQuestion("second");
+            
+            assert.equal(window.location.hash, "#form/second");
+            
+            util.deleteQuestion("/data/second");
+            
+            assert.equal(window.location.hash, "#form/first");
         });
 
         it("should change the hash when you delete a question", function(done) {

--- a/tests/urlHash.js
+++ b/tests/urlHash.js
@@ -52,18 +52,26 @@ requirejs([
             assert.equal(window.location.hash, "#form/first");
         });
 
-        it("should change the hash when you delete a question", function(done) {
+        it("should call setURLHash only once when multiple questions are loaded", function(done){
+            
+            var count = 0;
             util.loadXML("");
-            util.addQuestion("Text", "text");
-            util.addQuestion("Text", "text2");
+            
+            var q1 = util.addQuestion("Text", "first");
+            util.clickQuestion("first");
+            
+            var q2 = util.addQuestion("Text", "second");
+            util.clickQuestion("second");
+            var prevFn = q1.form.vellum._setURLHash;
+            q1.form.vellum._setURLHash = function(){
+                count++;
+            }
             util.saveAndReload(function(){
-                // saveAndReload selects the first question by default
-                // so we need to click on question 2 to set the correct url hash
-                util.clickQuestion('/data/text2')
-                assert.equal(window.location.hash, '#form/text2');
-                util.deleteQuestion("/data/text2");
-                assert.equal(window.location.hash, '#form/text');
-                done()
+                assert.equal(count, 1);
+                done();
+            })
+            after(function(){
+                q1.form.vellum._setURLHash = prevFn;
             })
         });
     });

--- a/tests/urlHash.js
+++ b/tests/urlHash.js
@@ -29,19 +29,28 @@ requirejs([
             assert.equal(mug.absolutePath, "/data/group");
         });
 
-        it("should change the hash when you add a question", function() {
+        it("should change the hash when you add a question", function(done) {
             util.loadXML("");
             util.addQuestion("Text", "text");
-            assert.equal(window.location.hash, '#form/text');
+            util.saveAndReload(function(){
+                assert.equal(window.location.hash, '#form/text');
+                done();
+            })
         });
 
-        it("should change the hash when you delete a question", function() {
+        it("should change the hash when you delete a question", function(done) {
             util.loadXML("");
             util.addQuestion("Text", "text");
             util.addQuestion("Text", "text2");
-            assert.equal(window.location.hash, '#form/text2');
-            util.deleteQuestion("/data/text2");
-            assert.equal(window.location.hash, '#form/text');
+            util.saveAndReload(function(){
+                // saveAndReload selects the first question by default
+                // so we need to click on question 2 to set the correct url hash
+                util.clickQuestion('/data/text2')
+                assert.equal(window.location.hash, '#form/text2');
+                util.deleteQuestion("/data/text2");
+                assert.equal(window.location.hash, '#form/text');
+                done()
+            })
         });
     });
 });

--- a/tests/urlHash.js
+++ b/tests/urlHash.js
@@ -54,25 +54,26 @@ requirejs([
 
         it("should call setURLHash only once when multiple questions are loaded", function(done){
             
-            var count = 0;
+            var fnCallCount = 0;
             util.loadXML("");
             
             var q1 = util.addQuestion("Text", "first");
             util.clickQuestion("first");
             
-            var q2 = util.addQuestion("Text", "second");
+            util.addQuestion("Text", "second");
             util.clickQuestion("second");
-            var prevFn = q1.form.vellum._setURLHash;
+            
+            // Patching _setURLHash with a custom function
+            // which will tell how many times it was called
+            var originalFn = q1.form.vellum._setURLHash;
             q1.form.vellum._setURLHash = function(){
-                count++;
+                fnCallCount++;
             }
             util.saveAndReload(function(){
-                assert.equal(count, 1);
+                q1.form.vellum._setURLHash = originalFn;
+                assert.equal(fnCallCount, 1);
                 done();
-            })
-            after(function(){
-                q1.form.vellum._setURLHash = prevFn;
-            })
+            });
         });
     });
 });


### PR DESCRIPTION
Ticket Link - https://dimagi-dev.atlassian.net/browse/SAAS-11597

### Description

Whenever the page was getting loaded for the first time `window.replaceState` was getting called for every question in the form. This was causing a Security Error dialogue box to appear in Firefox.

The fix that we made calls the browser API only when it is required i.e whenever question_id is modified or changes in the forms are saved.
