### PR TITLE
Fix save form with new language and missing itext

### DIFF
--- a/src/javaRosa/plugin.js
+++ b/src/javaRosa/plugin.js
@@ -448,7 +448,7 @@ define([
                             xmlWriter.writeEndElement();
                         }
                         if (item.hasMarkdown && !this.data.core.form.noMarkdown) {
-                            val = item.get('default', lang);
+                            val = item.getForm('default').getValueOrDefault(lang);
                             xmlWriter.writeStartElement("value");
                             xmlWriter.writeAttributeString('form', 'markdown');
                             writeValue(xmlWriter, val);

--- a/tests/javaRosa.js
+++ b/tests/javaRosa.js
@@ -21,6 +21,7 @@ define([
     'text!static/javaRosa/itext-item-non-auto-id.xml',
     'text!static/javaRosa/select1-help.xml',
     'text!static/javaRosa/single-lang-select.xml',
+    'text!static/javaRosa/single-lang-second-select-with-help.xml',
     'text!static/javaRosa/no-label-text-one-lang.xml',
     'text!static/javaRosa/test-xml-1.xml',
     'text!static/javaRosa/test-xml-2.xml',
@@ -52,6 +53,7 @@ define([
     ITEXT_ITEM_NON_AUTO_ID_XML,
     SELECT1_HELP_XML,
     SINGLE_LANG_SELECT_XML,
+    SINGLE_LANG_SECOND_SELECT_WITH_HELP_XML,
     NO_LABEL_TEXT_ONE_LANG_XML,
     TEST_XML_1,
     TEST_XML_2,
@@ -236,6 +238,13 @@ define([
                         done();
                     });
                 });
+            });
+
+            it("should not error on save question with markdown and missing language", function () {
+                util.loadXML(SINGLE_LANG_SECOND_SELECT_WITH_HELP_XML);
+                var xml = util.parseXML(call('createXML')),
+                    value = xml.find("translation[lang=hin]>text#select-help>value[form=markdown]");
+                assert.equal(value.html(), "**help**");
             });
         });
 

--- a/tests/static/javaRosa/single-lang-second-select-with-help.xml
+++ b/tests/static/javaRosa/single-lang-second-select-with-help.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/DB593648-07B6-4C6A-A8DB-D71E826DA82D" uiVersion="1" version="1" name="Untitled Form">
+					<question1 />
+					<select />
+				</data>
+			</instance>
+			<bind vellum:nodeset="#form/select" nodeset="/data/select" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="select-label">
+						<value>select</value>
+					</text>
+					<text id="select-help">
+						<value>**help**</value>
+						<value form="markdown">**help**</value>
+					</text>
+					<text id="select-choice-label">
+						<value>choice</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input vellum:ref="#form/question1" ref="/data/question1">
+			<label ref="jr:itext('select-label')" />
+		</input>
+		<select1 vellum:ref="#form/select" ref="/data/select">
+			<label ref="jr:itext('select-label')" />
+			<help ref="jr:itext('select-help')" />
+			<item>
+				<label ref="jr:itext('select-choice-label')" />
+				<value>choice</value>
+			</item>
+		</select1>
+	</h:body>
+</h:html>


### PR DESCRIPTION
When a new language has been added to the form, markdown itext for questions that are not selected during a form edit session may not be not initialized. This caused an error on write XML (save). Note that the first question is usually selected on initial form load, so this bug did not occur on forms having a single question.

```
TypeError: Cannot read property 'replace' of undefined
 at fixEmptyTags (src/xml.js:167:26)
 at Object.query (src/xml.js:36:20)
 at writeValue (src/javaRosa/plugin.js:416:27)
 at _instance.contributeToModelXML (src/javaRosa/plugin.js:455:29)
```

This bug was probably introduced in https://github.com/dimagi/Vellum/commit/6c95b1179963452d3a1b694cf2b1ca6bf278cca7#diff-07eb3730e4155b85f6aed124e86f5e4e485eba073d2019ffac83f7fef3fab313L1697-R1695 (translations were not copied correctly to new languages in the form after that change), although a more recent change (https://github.com/dimagi/Vellum/commit/b1a44e3b508cdf82704c73d81005c65fc9b53e1d) made it impossible to save the form when the bug appeared.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression

### Automated test coverage

Added.

### QA Plan

No QA.

- [x] This PR can be reverted after deploy with no further considerations 
