### PR TITLE
Upgrade js-xpath to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "requirejs-text": "2.0.15",
         "requirejs-undertemplate": "0.0.4",
         "underscore": "1.8.3",
-        "xpath": "dimagi/js-xpath#v0.0.3",
+        "xpath": "dimagi/js-xpath#v0.0.4",
         "xrayquire": "npm:xrayquire-for-npm#^0.1.1"
     },
     "devDependencies": {

--- a/src/main.js
+++ b/src/main.js
@@ -50,7 +50,7 @@ requirejs.config({
         'XMLWriter': '../node_modules/XMLWriter/XMLWriter',
 
         // todo: should convert xpath submodule to AMD
-        'xpath': '../node_modules/xpath/xpath',
+        'xpath': '../node_modules/xpath/dist/js-xpath',
 
         'langCodes': '../node_modules/langcodes/langs.json',
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3331,9 +3331,9 @@ ws@^7.2.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.2.tgz#782100048e54eb36fe9843363ab1c68672b261dd"
   integrity sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==
 
-xpath@dimagi/js-xpath#v0.0.3:
-  version "0.0.3"
-  resolved "https://codeload.github.com/dimagi/js-xpath/tar.gz/f9a249581249c2fda914cc2483291dac1f815d87"
+xpath@dimagi/js-xpath#v0.0.4:
+  version "0.0.4"
+  resolved "https://codeload.github.com/dimagi/js-xpath/tar.gz/3a152a7bc5cd1f88a5d1da0055cb9d32e389003d"
   dependencies:
     biginteger "^1.0.3"
 


### PR DESCRIPTION
## Summary
We recently upgraded most of the dev dependencies for `dimagi/js-xpath` due to security vulnerabilities. This bumps the version referenced in vellum to that new release/tag in our repo

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
All tests pass locally!

### QA Plan
I think our tests are reliable enough that we would have caught any major issues, both in the xpath tests and in vellum specific tests.

### Safety story
Tests should cover any issues.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
