### PR TITLE
Put manifest.txt in a place not ignored by HQ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,7 @@ _rjs:
 	rm _build/src/local-deps.css _build/src/main-components.css
 	mv _build/src/images _build/
 	echo "$(VERSION)" > _build/version.txt
-	(yarn list || yarn list --offline) | \
-		grep -Ev "^(Vellum|yarn) " > _build/node_modules/manifest.txt
+	(yarn list || yarn list --offline) | grep -Ev "^(Vellum|yarn) " > _build/manifest.txt
 	python buildmain.py > _build/src/main.js
 
 _tar:


### PR DESCRIPTION
HQ has ignored all `node_modules` directories anywhere in the repo for a very long time (at least 6 years). When vellum switched from `bower` to `yarn`, `manifest.txt` moved from `_build/bower_components/` to `_build/node_modules/`, and became ignored by HQ, which removed visibility on library versions changing with each vellum deploy.
