### PR TITLE
Fix save button in XPath editor

### DIFF
--- a/src/expressionEditor.js
+++ b/src/expressionEditor.js
@@ -450,6 +450,8 @@ define([
                 advancedInput.on('change keyup', handleChange);
             }
 
+            getTopLevelJoinSelect().change(handleChange);
+
             var done = function (val) {
                 options.done(val);
                 editorContent.empty();

--- a/tests/expressionEditor.js
+++ b/tests/expressionEditor.js
@@ -13,7 +13,7 @@ define([
 ) {
     var assert = chai.assert;
 
-    describe("The expression editor xpath validator", function () {
+    describe("The expression editor", function () {
         var form;
         before(function (done) {
             util.init({
@@ -25,12 +25,37 @@ define([
             });
         });
 
-        it("should not validate '#invalid/xpath ' prefix", function () {
-            var expr = "#invalid/xpath if(`#form/text`",
-                result = expressionEditor.validateXPath(form, expr);
-            assert.isNotOk(result[0], JSON.stringify(result));
-            assert.include(result[1].message, "if(#form/text");
-            assert.notInclude(result[1].message, "#invalid/xpath");
+        it("should trigger change event on join type changed", function () {
+            util.loadXML("");
+            var div = $("<div>"),
+                text = util.addQuestion("Text", "text"),
+                opts = makeOptions(text, '#form/text = "1" and #form/text = "yes"');
+            expressionEditor.showXPathEditor(div, opts);
+            var join = div.find(".top-level-join-select");
+            join.val("or").change();
+            assert.equal(opts.changed, true, "expected changed flag to be set");
+        });
+
+        describe("xpath validator", function () {
+            it("should not validate '#invalid/xpath ' prefix", function () {
+                var expr = "#invalid/xpath if(`#form/text`",
+                    result = expressionEditor.validateXPath(form, expr);
+                assert.isNotOk(result[0], JSON.stringify(result));
+                assert.include(result[1].message, "if(#form/text");
+                assert.notInclude(result[1].message, "#invalid/xpath");
+            });
         });
     });
+
+    function makeOptions(mug, value) {
+        var opts = {
+            mug: mug,
+            xpathType: "bool",
+            value: value,
+            changed: false,
+            change: function () { opts.changed = true; }
+        };
+        return opts;
+    }
+
 });


### PR DESCRIPTION
Changing the expression join type did not enable the save button.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Test added.

### QA Plan

No QA.

- [x] This PR can be reverted after deploy with no further considerations 
