### PR TITLE
Update js-xpath to v0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "requirejs-text": "2.0.15",
         "requirejs-undertemplate": "dimagi/requirejs-tpl#v0.0.5",
         "underscore": "1.13.1",
-        "xpath": "dimagi/js-xpath#v0.0.5",
+        "xpath": "dimagi/js-xpath#v0.0.6",
         "xrayquire": "npm:xrayquire-for-npm#^0.1.1"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3542,9 +3542,9 @@ ws@^3.2.0, ws@^5.2.3, ws@^7.2.3:
   dependencies:
     async-limiter "~1.0.0"
 
-xpath@dimagi/js-xpath#v0.0.5:
-  version "0.0.4"
-  resolved "https://codeload.github.com/dimagi/js-xpath/tar.gz/e65fd5396f2392c5099fb5d8e979f0e98eedc0c5"
+xpath@dimagi/js-xpath#v0.0.6:
+  version "0.0.6"
+  resolved "https://codeload.github.com/dimagi/js-xpath/tar.gz/a23afb724cd65088cb04c97ae7e5ecc2b425270e"
   dependencies:
     biginteger "^1.0.3"
 


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->
A followup to [this PR](https://github.com/dimagi/Vellum/pull/1024). I didn't update `package.json` in js-xpath to v0.0.5, so it was unclear which version was being referenced by vellum. Rather than messing with updating the v0.0.5 tag on js-xpath, we decided to make a new version that properly updates package.json. All this PR is responsible for is referencing that new tag.
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
