### PR TITLE
[security] ensure getobject is at least v 1.0.0 due to security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "test": "npm run test:mocha && npm run test:lint"
     },
     "resolutions": {
+        "getobject": "^1.0.0",
         "grunt": "^1.3.0",
         "jshint": "^2.12.0",
         "lodash": "^4.17.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1202,15 +1202,10 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-getobject@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/getobject/-/getobject-0.1.0.tgz#047a449789fa160d018f5486ed91320b6ec7885c"
-  integrity sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=
-
-getobject@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/getobject/-/getobject-1.0.1.tgz#17d86a05913c15d173a5bcf8662dc7c7ac5ce147"
-  integrity sha512-tj18lLe+917AACr6BdVoUuHnBPTVd9BEJp1vxnMZ58ztNvuxz9Ufa+wf3g37tlGITH35jggwZ2d9lcgHJJgXfQ==
+getobject@^1.0.0, getobject@~0.1.0, getobject@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/getobject/-/getobject-1.0.2.tgz#25ec87a50370f6dcc3c6ba7ef43c4c16215c4c89"
+  integrity sha512-2zblDBaFcb3rB4rF77XVnuINOE2h2k/OnqXAiy0IrTxUfV1iFp3la33oAQVY9pCpWU268WFYVt2t71hlMuLsOg==
 
 getpass@^0.1.1:
   version "0.1.7"


### PR DESCRIPTION
## Summary
Similar to the upgrade in commcare-hq, this PR ensures that `getobject`, a sub-sub dependency of `grunt`, resolves to at least `1.0.0` to address a security vulnerability concern. If tests pass, that should be good enough to merge.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Yes

### QA Plan
None

### Safety story
sub-sub dependency of `grunt`, so if tests pass this is good to go

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
