### PR TITLE
[security] pin minimist to 1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "http-server": "^14.1.0",
         "jshint": "^2.13.4",
         "less": "2",
+        "minimist": "^1.2.6",
         "mocha": "7.2.0",
         "mocha-headless-chrome": "3.1.0",
         "yarn": "^1.22.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2199,6 +2199,11 @@ minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
 mitt@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mitt/-/mitt-2.1.0.tgz#f740577c23176c6205b121b2973514eade1b2230"


### PR DESCRIPTION
## Technical Summary
Similarly to https://github.com/dimagi/commcare-hq/pull/31313 `minimist` is not a sub-dependency of anything that runs live on prod. These dependencies are either part of the build process or test dependencies. I think it's safe to assume that if tests pass, then it's fine to pin this dependency.

## Safety Assurance

### Safety story
See description

### Automated test coverage
Yes

### QA Plan
No QA needed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
