### PR TITLE
update readme with useful test hints and new status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Vellum
 ======
 
-[![Build Status](https://travis-ci.com/dimagi/Vellum.svg?branch=master)](https://travis-ci.com/dimagi/Vellum)
+![build status](https://github.com/dimagi/vellum/actions/workflows/tests.yml/badge.svg)
 
 Vellum is a JavaRosa [XForm](http://en.wikipedia.org/wiki/XForms) designer used
 in [CommCare HQ](http://github.com/dimagi/commcare-hq).
@@ -90,10 +90,18 @@ Vellum targets modern browsers.  IE8 and earlier are not supported.
 Tests
 -----
 
-Make sure everything is up to date:
+### Prerequisites
+
+Make sure you have Node.js 14.x installed and are using `node 14.x` in your working directory (tip: manage multiple versions of node.js with nvm)
+
+Make sure you have `npm 7.x` installed (`npm install npm@7`)
+
+### Running Tests
+
+Make sure everything is up-to-date:
 
 ```
-$ yarn upgrade
+$ yarn install --frozen-lockfile
 ```
 
 Test in a browser:


### PR DESCRIPTION
## Summary
Some small readme updates.

- Updates the build status badge to read from github actions
- Adds some pre-requisite hints for running tests locally (`node 14.x` and `npm 7.x` required)

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Safety story
Just updates to Readme
