### PR TITLE
Install lock file version of yarn for GitHub actions tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,12 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 14
+    - name: Install dependencies
     - run: |
         yarn_version=$(grep -Eo '^yarn@[^:]+' ./yarn.lock)
         npm install "$yarn_version"
         yarn install
+    - name: Run tests
+    - run: |
         npm run testserver &
         make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
       with:
         node-version: 14
     - name: Install dependencies
-    - run: |
+      run: |
         yarn_version=$(grep -Eo '^yarn@[^:]+' ./yarn.lock)
         npm install "$yarn_version"
         yarn install
     - name: Run tests
-    - run: |
+      run: |
         npm run testserver &
         make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
     - name: Install dependencies
       run: |
         yarn_version=$(grep -Eo '^yarn@[^:]+' ./yarn.lock)
+        echo "lock file requires: $yarn_version"
         npm install "$yarn_version"
         yarn install
     - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,9 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 14
-    - run: npm install yarn@1.22.18
-    - run: yarn install
-    - run: npm run testserver &
-    - run: make test
+    - run: |
+        yarn_version=$(grep -Eo '^yarn@[^:]+' ./yarn.lock)
+        npm install "$yarn_version"
+        yarn install
+        npm run testserver &
+        make test


### PR DESCRIPTION
## Summary

Followup to #1063. Make GitHub actions install a version of yarn that complies with the `yarn.lock` requirement.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

GitHub actions (tests) only.

### Safety story

Tests only.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
