### PR TITLE
Track metrics for vellum dependencies

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,30 @@
+name: vellum metrics
+on:
+  pull_request:
+    branches:
+    - master
+jobs:
+  tests:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    env:
+      DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 14
+    - uses: actions/setup-python@v4
+      with:
+        python-version: |
+          3.9
+    - name: Install dependencies
+      run: |
+        yarn_version=$(grep -Eo '^yarn@[^:]+' ./yarn.lock)
+        echo "lock file requires: $yarn_version"
+        npm install "$yarn_version"
+        yarn install
+    - name: Analyze metrics and push to Datadog
+      run: |
+        scripts/track-dependency-status.sh

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -4,7 +4,7 @@ on:
     branches:
     - master
 jobs:
-  tests:
+  metrics:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:

--- a/scripts/datadog-utils.sh
+++ b/scripts/datadog-utils.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Accepts three arguments: metric name, value, and type (gauge, count, or rate)
+# Usage:
+#   send_metric_to_datadog "commcare.foo.bar" 7 "gauge"
+# or with optional "tag" argument:
+#   send_metric_to_datadog "commcare.foo.bar" 7 "gauge" "domain:foo"
+function send_metric_to_datadog() {
+    if [ -z "$DATADOG_API_KEY" -o -z "$DATADOG_APP_KEY" ]; then
+        return
+    fi
+
+    EXTRA_TAG=""
+    if [[ "$4" ]]; then
+        EXTRA_TAG="\"$4\","
+    fi
+
+    if [ -n "$GITHUB_ACTIONS" ]; then
+      HOST=github.com
+      CI_ENV=github_actions
+    else
+      HOST=unknown
+      CI_ENV=unknown
+    fi
+
+    currenttime=$(date +%s)
+    curl  -s \
+          -X POST \
+          -H "Content-type: application/json" \
+          -H "DD-API-KEY: ${DATADOG_API_KEY}" \
+          -H "DD-APP-KEY: ${DATADOG_APP_KEY}" \
+          -d "{ \"series\" :
+                [{\"metric\":\"$1\",
+                  \"points\":[[$currenttime, $2]],
+                  \"type\":\"$3\",
+                  \"host\":\"$HOST\",
+                  \"tags\":[
+                    $EXTRA_TAG
+                    \"environment:$CI_ENV\",
+                    \"partition:$NOSE_DIVIDED_WE_RUN\"
+                  ]}
+                ]
+              }" \
+          "https://app.datadoghq.com/api/v1/series" >/dev/null || true
+}

--- a/scripts/outdated-dependency-metrics.py
+++ b/scripts/outdated-dependency-metrics.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+"""A convenience utility for calculating how far "behind" Vellum is on outdated
+dependencies.
+
+USAGE:
+
+$ yarn outdated --json | ./scripts/outdated-dependency-metrics.py yarn
+Behind   Package                      Latest       Version
+n/a      At.js                        exotic       1.5.3
+...
+0.0.1    bootstrap-timepicker         0.5.2        0.5.1
+...
+12.0.0   sinon                        14.0.0       2.3.2
+
+Enjoy!
+"""
+import argparse
+import json
+import sys
+
+
+def main():
+    stream_parsers = {
+        "yarn": parse_yarn,
+        "yarn-list": parse_yarn_list,
+    }
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "format",
+        choices=list(stream_parsers),
+        help="package information format (choices=%(choices)s)",
+    )
+    parser.add_argument(
+        "in_file",
+        metavar="FILE",
+        nargs="?",
+        type=argparse.FileType(mode="r"),
+        default=sys.stdin,
+        help="read package (JSON) information from %(metavar)s, specify a dash "
+             "(-) to read from STDIN (the default).",
+    )
+    parser.add_argument(
+        "--stats",
+        default=False,
+        action="store_true",
+        help="print package statistics and exit",
+    )
+    parser.add_argument(
+        "--no-labels",
+        dest="labels",
+        default=True,
+        action="store_false",
+        help="do not print data labels in the output",
+    )
+
+    opts = parser.parse_args()
+    if opts.stats:
+        func = package_stats
+    else:
+        func = package_list
+    func(opts.in_file, stream_parsers[opts.format], opts.labels)
+
+
+def package_list(stream, stream_parser, labels=True):
+
+    def print_line(behind, name, current, latest):
+        print(f"{behind:8s} {name:28s} {current:12s} {latest}")
+
+    records = sorted(stream_parser(stream))
+    try:
+        if labels:
+            print_line("Behind", "Package", "Latest", "Version")
+        for delta, name, current, latest in records:
+            if delta:
+                behind = ".".join(str(v) for v in delta)
+            else:
+                behind = "n/a"
+            print_line(behind, name, current, latest)
+    except IOError:
+        pass
+
+
+def package_stats(stream, stream_parser, labels=True):
+
+    def print_stat(label, value):
+        if labels:
+            print(f"{label}: ", end="")
+        print(value)
+
+    stats = {
+        "Outdated": 0,
+        "Multi-Major": 0,
+        "Major": 0,
+        "Minor": 0,
+        "Patch": 0,
+        "Exotic": 0,
+    }
+    for delta, name, current, latest in stream_parser(stream):
+        if delta:
+            major, minor, patch = delta
+            if major:
+                assert not minor and not patch, delta
+                if major == 1:
+                    key = "Major"
+                else:
+                    key = "Multi-Major"
+            elif minor:
+                assert not major and not patch, delta
+                key = "Minor"
+            else:
+                assert patch and not major and not minor, delta
+                key = "Patch"
+        else:
+            key = "Exotic"
+        stats[key] += 1
+        stats["Outdated"] += 1
+    # NOTE: subtle detail: we're depending on Python 3's ordered dict to
+    # maintain deterministic ordering here (critical when using --no-labels).
+    for key, value in stats.items():
+        print_stat(key, value)
+
+
+def parse_yarn(stream):
+    """Parse the output of command: yarn outdated --json"""
+    def fail():
+        raise ValueError(f"invalid yarn package data: {lines}")
+    lines = [line for line in stream.readlines() if line.rstrip()]
+    if len(lines) == 1:
+        blob = lines[0]
+    elif len(lines) == 2:
+        for_humans = json.loads(lines[0])
+        if for_humans["type"] != "info":
+            fail()
+        blob = lines[1]
+    else:
+        fail()
+    payload = json.loads(blob)
+    if payload["type"] != "table":
+        fail()
+    head = payload["data"]["head"]
+    body = payload["data"]["body"]
+    for record in body:
+        pkg = dict(zip(head, record))
+        name = pkg["Package"]
+        latest = pkg["Latest"]
+        current = pkg["Current"]
+        if latest == "exotic":
+            delta = []
+        else:
+            delta = behind(latest, current)
+        yield delta, name, latest, current
+
+
+def parse_yarn_list(stream):
+    """Parse the output of command: ./yarn-list.py --outdated --json"""
+    for pkg in json.load(stream):
+        # use partition because npm versions can contain a dash e.g: 0.0.1-alpha
+        latest = pkg["latest_version"].partition("-")[0]
+        current = pkg["version"].partition("-")[0]
+        if latest == "exotic":
+            delta = []
+        else:
+            delta = behind(latest, current)
+        yield delta, pkg["name"], latest, current
+
+
+def behind(latest, current):
+    delta = [0, 0, 0]
+    for index, (lat, cur) in enumerate(zip(vsplit(latest), vsplit(current))):
+        if lat != cur:
+            delta[index] = lat - cur
+            break
+    return delta
+
+
+def vsplit(version):
+    padded = f"{version}.0.0"  # append extra zeros for versions like '1' or '2.0'
+    return [int(n) for n in padded.split(".")[:3]]
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/track-dependency-status.sh
+++ b/scripts/track-dependency-status.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -e
+
+# import the datadog utils
+source ./scripts/datadog-utils.sh
+
+send_to_datadog=true
+
+
+function main {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                usage
+                return 0
+                ;;
+            -n|--dry-run)
+                echo "[DRY RUN] no metrics will be sent to datadog" >&2
+                # I would rather not use a global for this, but passing it two
+                # function calls deep feels messier in this case.
+                send_to_datadog=false
+                ;;
+            *)
+                usage "invalid args: $*"
+                return 1
+                ;;
+        esac
+        shift
+    done
+    local total=0
+
+    # get total Vellum dependency count (skip the first header line)
+    log_msg_with_time INFO "calculating Vellum package metrics"
+    total=$(./scripts/yarn-list.py | tail -n +2 | wc -l)
+    # publish vellum metrics
+    ./scripts/yarn-list.py --outdated --json | publish_metrics yarn-list "$total"
+
+    log_msg_with_time INFO "done"
+}
+
+
+function publish_metrics {
+    local data_format="$1"
+    local total="$2"
+
+    local metric_prefix="commcare.static_analysis.dependency.vellum"
+    local stats=$(cat - | ./scripts/outdated-dependency-metrics.py "$data_format" --stats)
+
+    local outdated=$(outdated_stat Outdated "$stats")
+    local multmajor=$(outdated_stat Multi-Major "$stats")
+    local major=$(outdated_stat Major "$stats")
+    local minor=$(outdated_stat Minor "$stats")
+    local patch=$(outdated_stat Patch "$stats")
+    local exotic=$(outdated_stat Exotic "$stats")
+
+    publish_datadog_gauge "${metric_prefix}.total" "$total"
+    publish_datadog_gauge "${metric_prefix}.outdated" "$outdated"
+    publish_datadog_gauge "${metric_prefix}.multi_major_outdated" "$multmajor"
+    publish_datadog_gauge "${metric_prefix}.major_outdated" "$major"
+    publish_datadog_gauge "${metric_prefix}.minor_outdated" "$minor"
+    publish_datadog_gauge "${metric_prefix}.patch_outdated" "$patch"
+    publish_datadog_gauge "${metric_prefix}.exotic_outdated" "$exotic"
+}
+
+
+function outdated_stat {
+    local label="$1"
+    local stats="$2"
+    echo "$stats" | grep -E "^${label}: " | awk -F': ' '{print $2}'
+}
+
+
+function publish_datadog_gauge {
+    local metric_path="$1"
+    local value="$2"
+    echo "$metric_path == $value"
+    if $send_to_datadog; then
+        send_metric_to_datadog "$metric_path" "$value" gauge
+    fi
+}
+
+
+function log_msg_with_time {
+    local level_name="$1"; shift
+    local msg="$*"
+    local now=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "[${now}] ${level_name}: $msg" >&2
+}
+
+
+function usage {
+    local script=$(basename "$0")
+    local msg="$*"
+    echo "USAGE: $script [-h|--help] [-n|--dry-run]" >&2
+    if [ -n "$msg" ]; then
+        echo "ERROR: $msg" >&2
+    fi
+}
+
+
+main "$@"

--- a/scripts/yarn-list.py
+++ b/scripts/yarn-list.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""A utility that outputs package information _like_ `pip list ...`, but for
+yarn packages.
+
+TODO:
+- dynamically calculate column widths rather than using hard-coded widths
+
+Examples:
+
+$ ./yarn-list.py
+Package                              Version
+colorama                             0.4.3
+...
+
+$ ./yarn-list.py --outdated
+Package                              Version     Latest
+colorama                             0.4.3       0.4.4
+...
+"""
+import argparse
+import json
+import sys
+from subprocess import DEVNULL, check_output
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--json",
+        default=False,
+        action="store_true",
+        help="output in JSON",
+    )
+    parser.add_argument(
+        "--outdated",
+        default=False,
+        action="store_true",
+        help="list outdated packages",
+    )
+    opts = parser.parse_args()
+    packages = package_list(opts.outdated)
+    if opts.json:
+        json.dump(packages, sys.stdout)
+    else:
+        print_table(packages, opts.outdated)
+
+
+def package_list(outdated):
+    yarn = Yarn()
+    all_packages = yarn.list()
+    if not outdated:
+        return all_packages
+    outdated_packages = []
+    for package in all_packages:
+        latest_version = yarn.latest_version(package["name"])
+        if package["version"] != latest_version:
+            package["latest_version"] = latest_version if latest_version else "exotic"
+            outdated_packages.append(package)
+    return outdated_packages
+
+
+def print_table(packages, show_latest=False):
+
+    def print_line(package):
+        line = f"{package['name']:36} {package['version']:8}"
+        if show_latest:
+            line = f"{line} {package['latest_version']}"
+        print(line.rstrip())
+
+    print_line({
+        "name": "Package",
+        "version": "Version",
+        "latest_version": "Latest",
+    })
+    for package in packages:
+        print_line(package)
+
+
+class Yarn:
+
+    def __init__(self):
+        yarn_version = check_output(["yarn", "--version"], text=True).strip()
+        if not yarn_version.startswith("1."):
+            raise Crash(f"Yarn Classic (v1.x) is required, found {yarn_version}")
+
+    def command(self, sub_args):
+        # discard first and last lines (yarn version and timing info)
+        # confirmed safe on subcommands:
+        # - info
+        # - list
+        return check_output(["yarn"] + sub_args, stderr=DEVNULL, text=True).splitlines()[1:-1]
+
+    def list(self):
+        lines = self.command(["list", "--depth", "0"])
+        packages = []
+        for line in lines:
+            line = line.rstrip()
+            if not line:
+                continue
+            # example:
+            # ├─ @ungap/promise-all-settled@1.1.2
+            # ├─ abbrev@1.1.1
+            name, x, version = line.split(None, 2)[1].rpartition("@")
+            packages.append({"name": name, "version": version})
+        return packages
+
+    def latest_version(self, name):
+        lines = self.command(["info", name, "dist-tags.latest"])
+        if not lines:
+            return None
+        assert len(lines) == 1, f"{name}: invalid latest: {lines!r}"
+        return lines[0].strip()
+
+
+class Crash(Exception):
+    pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(2)
+    except BrokenPipeError:
+        # Don't print a traceback (or exit with an error) when tools like 'head'
+        # or 'grep' close the stream early.
+        pass
+    except Crash as exc:
+        print(f"ERROR: {exc!s}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
Using the structure we have for tracking HQ dependencies, I've copied the relevant utilities to vellum (not my favorite solution) to push dependency metrics to Datadog. Metrics are pushed to Datadog with its own github action

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
N/A

### QA Plan
Just metrics

### Safety story
Just Metrics
