### PR TITLE
CommCare Connect plugin

### DIFF
--- a/PLUGIN_DEVEOPMENT.md
+++ b/PLUGIN_DEVEOPMENT.md
@@ -1,0 +1,102 @@
+# Vellum Plugin Development
+
+Each plugin should live in its own file under `src` and should be named "<plugin_name>.js".
+The plugin should be a RequireJS module with at least the following dependencies: `jquery`, `vellum/core`.
+The plugin must be added to the list of RequireJS dependencies in `src/main.js`.
+
+
+The main entry point for plugins is the `$.vellum.plugin` function.  It takes three arguments:
+- pluginName: The name of the plugin. This can be used to reference the plugin in the future.
+- defaults:  An object containing any default values for the plugin.
+- functions: An object containing hook functions for the plugin.
+
+A minimal plugin looks like this:
+
+```javascript
+define([
+    'jquery',
+    'vellum/core'
+], function (
+    $
+) {
+    $.vellum.plugin("<plugin name>", {}, {
+        ...
+    });
+});
+```
+
+## Common dependencies
+
+The following is a list of common dependencies:
+
+- `underscore` - Underscore.js
+- `vellum/mugs` - The Mugs module. Used when creating new mugs.
+- `vellum/tree` - The Tree module. Used when dealing with XML e.g. serializing mug data.
+- `vellum/util` - Utility functions e.g. `extend`
+- `vellum/widgets` - Vellum widgets
+
+## Hook Functions
+
+Adding functionality to Vellum requires implementing hook functions in the `functions` object
+passed to `$.vellum.plugin`. These functions can extend or override existing functionality.
+
+Each function is bound to the main Vellum instance i.e. Accessing `this`, will give you access
+to the main Vellum instance. Within in context of the hook function, the Vellum instance defines
+a `__callOld` function which can be used to call the original function:
+
+```javascript
+$.vellum.plugin("examplePlugin", {}, {
+    exampleHookFunction: function () {
+        // this is a noop since it just returns the value from the original function
+        return this.__callOld();
+    }
+});
+```
+
+The following list of functions are some of the more commonly used ones. The full list of functions
+as well as additional documentation for each function can be found in [src/core.js](src/core.js).
+
+Looking at existing plugin implementations is also helpful to see how to use the hook functions.
+
+### - getMugTypes
+
+Get all mug types definitions.
+
+### - getQuestionGroups
+
+Get the list of question groups to display in the sidebar.
+
+### - getAdvancedQuestions
+
+Get the list of mug types to display in the advanced questions section of the sidebar.
+
+### - getSections
+
+Get the list of sections to display in the editor window for the given mug.
+
+### - parseBindElement
+
+This is called when loading a form and is used to extract data from the bind elements in a form.
+If the bind element was created by a plugin, the plugin should return use this hook
+to read the data from the bind element.
+
+If the bind element does not belong to the plugin, the `__callOld` function should be called to
+pass parsing on to the next plugin.
+
+### - parseSetValue
+
+Similar to `parseBindElement` but for `setvalue` elements.
+
+
+## Mug Configuration
+
+The `getMugTypes` hook function is used to define new mug types. The common practice when defining new mugs
+is to extend the default mug options found in `mug.defaultOptions`:
+
+```javascript
+let newMug = utils.extend(mug.defaultOptions, {
+    // new mug options
+});
+```
+
+See `mug.defaultOptions` for a list of mug options.

--- a/PLUGIN_DEVEOPMENT.md
+++ b/PLUGIN_DEVEOPMENT.md
@@ -77,7 +77,7 @@ Get the list of sections to display in the editor window for the given mug.
 ### - parseBindElement
 
 This is called when loading a form and is used to extract data from the bind elements in a form.
-If the bind element was created by a plugin, the plugin should return use this hook
+If the bind element was created by a plugin, the plugin should use this hook
 to read the data from the bind element.
 
 If the bind element does not belong to the plugin, the `__callOld` function should be called to

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ intuitive items first.
   [JSTree](https://www.jstree.com/plugins/) plugin system. Many very important
   components are implemented as plugins, so just because something is a plugin
   does not mean it is a second-rate feature.
+  For more details on plugins, see [PLUGIN_DEVELOPMENT.md](PLUGIN_DEVELOPMENT.md).
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -123,7 +123,12 @@ or to run a specific test:
 ./test "Name of specific test"
 ```
 
-a block like the following:
+or pass a regex to run multiple tests:
+```
+./test "SaveToCase"  # run all tests with 'SaveToCase' in the name
+```
+
+A block like the following:
 ```
 describe('the test', () => ...
   describe('with this condition', () => ...

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -38,7 +38,6 @@ define([
             isTypeChangeable: false,
             isDataOnly: true,
             supportsDataNodeRole: true,
-            icon: 'fa fa-compress',
             getExtraDataAttributes: function (mug) {
                 return {
                     // allows the parser to know which mug to associate with this node
@@ -83,7 +82,7 @@ define([
                 return mugConfig.childNodes.map((childName) => {
                     return {
                         nodeset: `${mug.absolutePath}/${mugConfig.rootName}/${childName}`,
-                        calculate: wrapString(mug.p[childName]),
+                        calculate: mug.p[childName],
                     }
                 });
             },
@@ -98,6 +97,7 @@ define([
                 ],
                 mugOptions: util.extend(baseMugOptions, {
                     typeName: 'Learn Module',
+                    icon: 'fa fa-graduation-cap',
                     init: (mug, form) => {
                         mug.p.name = "";
                         mug.p.description = "";
@@ -114,7 +114,7 @@ define([
                             lstring: gettext("Description"),
                             visibility: 'visible',
                             presence: 'required',
-                            widget: widgets.text,
+                            widget: widgets.richTextarea,
                         },
                         time_estimate: {
                             lstring: gettext("Time Estimate"),
@@ -135,6 +135,36 @@ define([
                         "name",
                         "description",
                         "time_estimate",
+                    ],
+                })],
+            },
+            ConnectAssessment: {
+                rootName: "assessment",
+                childNodes: [
+                    "user_score",
+                ],
+                mugOptions: util.extend(baseMugOptions, {
+                    typeName: 'Assessment Score',
+                    icon: 'fa fa-leanpub',
+                    init: (mug, form) => {
+                        mug.p.user_score = "";
+                    },
+                    spec: util.extend(baseSpec, {
+                        user_score: {
+                            lstring: gettext("User Score"),
+                            visibility: 'visible',
+                            presence: 'required',
+                            widget: widgets.xPath,
+                            serialize: mugs.serializeXPath,
+                            deserialize: mugs.deserializeXPath,
+                            help: gettext('XPath expression for the users assessment score.'),
+                        },
+                    })
+                }),
+                sections: [_.extend({}, baseSection, {
+                    properties: [
+                        "nodeID",
+                        "user_score",
                     ],
                 })],
             }
@@ -171,7 +201,7 @@ define([
                         let attr = matchRet[1];
                         mug = form.getMugByPath(path.replace(regex, ""));
                         if (mug && mug.__className === mugName) {
-                            mug.p[attr] = unwrapString(el.xmlAttr("calculate"));
+                            mug.p[attr] = el.xmlAttr("calculate");
                             return true;
                         }
                     }
@@ -183,12 +213,4 @@ define([
             this.__callOld();
         },
     });
-
-    function wrapString(val) {
-        return `'${val}'`;
-    }
-
-    function unwrapString(val) {
-        return val.replace(/^'(.*)'$/, '$1');
-    }
 });

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -14,7 +14,7 @@ define([
     Tree,
     util,
     atwho,
-    widgets,
+    widgets
 ) {
     let CCC_XMLNS = 'http://commcareconnect.com/data/v1/learn',
         baseSection = {
@@ -48,7 +48,7 @@ define([
                 // Extract values from the data node
                 // Return an empty list of child nodes since children are handled
                 // by this plugin directly.
-                return $([])
+                return $([]);
             },
             dataChildFilter: (children, mug) => {
                 // called during write
@@ -83,7 +83,7 @@ define([
                     return {
                         nodeset: `${mug.absolutePath}/${mugConfig.rootName}/${childName}`,
                         calculate: mug.p[childName],
-                    }
+                    };
                 });
             },
         },

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -98,14 +98,14 @@ define([
                 mugOptions: util.extend(baseMugOptions, {
                     typeName: 'Learn Module',
                     icon: 'fa fa-graduation-cap',
-                    init: (mug, form) => {
+                    init: (mug) => {
                         mug.p.name = "";
                         mug.p.description = "";
                         mug.p.time_estimate = "";
                     },
                     spec: util.extend(baseSpec, {
                         nodeID: {
-                             lstring: gettext('Module ID'),
+                            lstring: gettext('Module ID'),
                         },
                         name: {
                             lstring: gettext("Name"),
@@ -149,12 +149,12 @@ define([
                 mugOptions: util.extend(baseMugOptions, {
                     typeName: 'Assessment Score',
                     icon: 'fa fa-leanpub',
-                    init: (mug, form) => {
+                    init: (mug) => {
                         mug.p.user_score = "";
                     },
                     spec: util.extend(baseSpec, {
                         nodeID: {
-                             lstring: gettext('Assessment ID'),
+                            lstring: gettext('Assessment ID'),
                         },
                         user_score: {
                             lstring: gettext("User Score"),
@@ -189,7 +189,7 @@ define([
             return types;
         },
         getSections: function (mug) {
-            if (mugConfigs.hasOwnProperty(mug.__className)) {
+            if (Object.hasOwn(mugConfigs, mug.__className)) {
                 return _.map(mugConfigs[mug.__className].sections, function (section) {
                     return _.clone(section);
                 });

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -1,10 +1,16 @@
+/**
+ * CommCare Connect plugin for Vellum
+ *
+ * This plugin adds two new mug types:
+ * - Learn Module
+ * - Assessment Score
+ */
 define([
     'jquery',
     'underscore',
     'vellum/mugs',
     'vellum/tree',
     'vellum/util',
-    'vellum/atwho',
     'vellum/widgets',
     'vellum/core'
 ], function (
@@ -13,7 +19,6 @@ define([
     mugs,
     Tree,
     util,
-    atwho,
     widgets
 ) {
     let CCC_XMLNS = 'http://commcareconnect.com/data/v1/learn',

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -15,22 +15,34 @@ define([
     util,
     atwho,
     widgets,
-){
+) {
     let CCC_XMLNS = 'http://commcareconnect.com/data/v1/learn',
-        MUG_NAME = 'CCCLearnModule',
-        cccMugOptions = {
-            typeName: 'CommCare Connect Metadata',
+        baseSection = {
+            slug: "main",
+            displayName: gettext("Basic"),
+            properties: [
+                "nodeID",
+            ],
+        },
+        baseSpec = {
+            xmlnsAttr: {
+                presence: "optional",
+                serialize: () => {},
+                deserialize: () => {}
+            },
+            requiredAttr: {presence: "notallowed"},
+            constraintAttr: {presence: "notallowed"},
+            calculateAttr: {presence: "notallowed"}
+        },
+        baseMugOptions = {
             isTypeChangeable: false,
             isDataOnly: true,
             supportsDataNodeRole: true,
             icon: 'fa fa-compress',
-            init: (mug, form) => {
-                mug.p.name = "";
-            },
             getExtraDataAttributes: function (mug) {
                 return {
                     // allows the parser to know which mug to associate with this node
-                    "vellum:role": MUG_NAME,
+                    "vellum:role": mug.__className,
                 };
             },
             parseDataNode: () => {
@@ -42,94 +54,141 @@ define([
             dataChildFilter: (children, mug) => {
                 // called during write
                 // return a list nodes to add to the forms data node
-                children = [
-                    new Tree.Node([], {
-                        getNodeID: function () { return "name"; },
+                children = mugConfigs[mug.__className].childNodes.map((childName) => {
+                    return new Tree.Node([], {
+                        getNodeID: function () {
+                            return childName;
+                        },
                         p: {rawDataAttributes: null},
-                        options: {getExtraDataAttributes: () => {}}
-                    })
-                ]
-                return [new Tree.Node(children, {
-                    getNodeID: function () { return "module"; },
-                    p: {rawDataAttributes: null},
-                    options: {
-                        getExtraDataAttributes: () => {
-                            return  {
-                                "xmlns": CCC_XMLNS,
-                                "id": mug.p.nodeID,
+                        options: {
+                            getExtraDataAttributes: () => {
                             }
                         }
+                    });
+                });
+                return [new Tree.Node(children, {
+                    getNodeID: () => mugConfigs[mug.__className].rootName,
+                    p: {rawDataAttributes: null},
+                    options: {
+                        getExtraDataAttributes: () => ({
+                            "xmlns": CCC_XMLNS,
+                            "id": mug.p.nodeID,
+                        })
                     }
                 })];
             },
             getBindList: (mug) => {
                 // return list of bind elements to add to the form
-                return [
-                    {
-                        nodeset: mug.absolutePath + "/module/name",
-                        calculate: `'${mug.p.name}'`,
+                let mugConfig = mugConfigs[mug.__className];
+                return mugConfig.childNodes.map((childName) => {
+                    return {
+                        nodeset: `${mug.absolutePath}/${mugConfig.rootName}/${childName}`,
+                        calculate: wrapString(mug.p[childName]),
                     }
-                ];
-            },
-            spec: {
-                xmlnsAttr: {
-                    presence: "optional",
-                    serialize: function () {},
-                    deserialize: function () {}
-                },
-                name: {
-                    lstring: gettext("Name"),
-                    visibility: 'visible',
-                    presence: 'required',
-                    widget: widgets.text,
-                },
-                requiredAttr: { presence: "notallowed" },
-                constraintAttr: { presence: "notallowed" },
-                calculateAttr: { presence: "notallowed" }
+                });
             },
         },
-        sectionData = [
-            // UI sections for the mug
-            {
-                slug: "main",
-                displayName: gettext("Basic"),
-                properties: [
-                    "nodeID",
+        mugConfigs = {
+            ConnectLearnModule: {
+                rootName: "module",
+                childNodes: [
                     "name",
+                    "description",
+                    "time_estimate",
                 ],
-            },
-        ];
+                mugOptions: util.extend(baseMugOptions, {
+                    typeName: 'Learn Module',
+                    init: (mug, form) => {
+                        mug.p.name = "";
+                        mug.p.description = "";
+                        mug.p.time_estimate = "";
+                    },
+                    spec: util.extend(baseSpec, {
+                        name: {
+                            lstring: gettext("Name"),
+                            visibility: 'visible',
+                            presence: 'required',
+                            widget: widgets.text,
+                        },
+                        description: {
+                            lstring: gettext("Description"),
+                            visibility: 'visible',
+                            presence: 'required',
+                            widget: widgets.text,
+                        },
+                        time_estimate: {
+                            lstring: gettext("Time Estimate"),
+                            visibility: 'visible',
+                            presence: 'required',
+                            widget: widgets.text,
+                            validationFunc: (mug) => {
+                                let val = mug.p.time_estimate;
+                                return val && val.match(/^\d+$/) ? "pass" : gettext("Must be an integer");
+                            },
+                            help: gettext('Estimated time to complete the module in hours.'),
+                        },
+                    })
+                }),
+                sections: [_.extend({}, baseSection, {
+                    properties: [
+                        "nodeID",
+                        "name",
+                        "description",
+                        "time_estimate",
+                    ],
+                })],
+            }
+        };
+
 
     $.vellum.plugin("commcareConnect", {}, {
         getAdvancedQuestions: function () {
-            return this.__callOld().concat([MUG_NAME]);
+            return this.__callOld().concat(Object.keys(mugConfigs));
         },
         getMugTypes: function () {
             let types = this.__callOld();
-            types.normal[MUG_NAME] = util.extend(mugs.defaultOptions, cccMugOptions);
+            Object.entries(mugConfigs).forEach(([mugType, config]) => {
+                types.normal[mugType] = util.extend(mugs.defaultOptions, config.mugOptions);
+            });
             return types;
         },
         getSections: function (mug) {
-            if (mug.__className !== MUG_NAME) return this.__callOld();
-            return _.clone(sectionData);
+            if (mugConfigs.hasOwnProperty(mug.__className)) {
+                return _.map(mugConfigs[mug.__className].sections, function (section) {
+                    return _.clone(section);
+                });
+            }
+            return this.__callOld();
         },
         parseBindElement: function (form, el, path) {
             let mug = form.getMugByPath(path);
             if (!mug) {
-                let pathRegex = /\/module\/(name)$/,
-                    matchRet = path.match(pathRegex),
-                    basePath;
-                if (matchRet && matchRet.length > 0) {
-                    basePath = path.replace(pathRegex, "");
-                    mug = form.getMugByPath(basePath);
-                    if (mug && mug.__className === MUG_NAME) {
+                let matched = Object.entries(mugConfigs).some(([mugName, mugConfig]) => {
+                    let children = mugConfig.childNodes.join('|'),
+                        regex = new RegExp(`/${mugConfig.rootName}/(${children})`),
+                        matchRet = path.match(regex);
+                    if (matchRet && matchRet.length > 0) {
                         let attr = matchRet[1];
-                        mug.p[attr] = el.xmlAttr("calculate");
-                        return;
+                        mug = form.getMugByPath(path.replace(regex, ""));
+                        if (mug && mug.__className === mugName) {
+                            mug.p[attr] = unwrapString(el.xmlAttr("calculate"));
+                            return true;
+                        }
                     }
+                });
+                if (matched) {
+                    return;
                 }
             }
             this.__callOld();
         },
     });
+
+    function wrapString(val) {
+        return `'${val}'`;
+    }
+
+    function unwrapString(val) {
+        return val.replace(/^'(.*)'$/, '$1');
+    }
 });

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -43,12 +43,10 @@ define([
             isTypeChangeable: false,
             isDataOnly: true,
             supportsDataNodeRole: true,
-            getExtraDataAttributes: function (mug) {
-                return {
-                    // allows the parser to know which mug to associate with this node
-                    "vellum:role": mug.__className,
-                };
-            },
+            getExtraDataAttributes: mug => ({
+                // allows the parser to know which mug to associate with this node
+                "vellum:role": mug.__className,
+            }),
             parseDataNode: () => {
                 // Extract values from the data node
                 // Return an empty list of child nodes since children are handled
@@ -58,15 +56,12 @@ define([
             dataChildFilter: (children, mug) => {
                 // called during write
                 // return a list nodes to add to the forms data node
-                children = mugConfigs[mug.__className].childNodes.map((childName) => {
+                children = mugConfigs[mug.__className].childNodes.map(childName => {
                     return new Tree.Node([], {
-                        getNodeID: function () {
-                            return childName;
-                        },
+                        getNodeID: () => childName,
                         p: {rawDataAttributes: null},
                         options: {
-                            getExtraDataAttributes: () => {
-                            }
+                            getExtraDataAttributes: () => {}
                         }
                     });
                 });
@@ -81,10 +76,10 @@ define([
                     }
                 })];
             },
-            getBindList: (mug) => {
+            getBindList: mug => {
                 // return list of bind elements to add to the form
                 let mugConfig = mugConfigs[mug.__className];
-                return mugConfig.childNodes.map((childName) => {
+                return mugConfig.childNodes.map(childName => {
                     return {
                         nodeset: `${mug.absolutePath}/${mugConfig.rootName}/${childName}`,
                         calculate: mug.p[childName],
@@ -103,7 +98,7 @@ define([
                 mugOptions: util.extend(baseMugOptions, {
                     typeName: 'Learn Module',
                     icon: 'fa fa-graduation-cap',
-                    init: (mug) => {
+                    init: mug => {
                         mug.p.name = "";
                         mug.p.description = "";
                         mug.p.time_estimate = "";
@@ -129,7 +124,7 @@ define([
                             visibility: 'visible',
                             presence: 'required',
                             widget: widgets.text,
-                            validationFunc: (mug) => {
+                            validationFunc: mug => {
                                 let val = mug.p.time_estimate;
                                 return val && val.match(/^\d+$/) ? "pass" : gettext("Must be an integer");
                             },
@@ -154,7 +149,7 @@ define([
                 mugOptions: util.extend(baseMugOptions, {
                     typeName: 'Assessment Score',
                     icon: 'fa fa-leanpub',
-                    init: (mug) => {
+                    init: mug => {
                         mug.p.user_score = "";
                     },
                     spec: util.extend(baseSpec, {
@@ -195,9 +190,7 @@ define([
         },
         getSections: function (mug) {
             if (Object.hasOwn(mugConfigs, mug.__className)) {
-                return _.map(mugConfigs[mug.__className].sections, function (section) {
-                    return _.clone(section);
-                });
+                return _.map(mugConfigs[mug.__className].sections, section => _.clone(section));
             }
             return this.__callOld();
         },

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -1,0 +1,135 @@
+define([
+    'jquery',
+    'underscore',
+    'vellum/mugs',
+    'vellum/tree',
+    'vellum/util',
+    'vellum/atwho',
+    'vellum/widgets',
+    'vellum/core'
+], function (
+    $,
+    _,
+    mugs,
+    Tree,
+    util,
+    atwho,
+    widgets,
+){
+    let CCC_XMLNS = 'http://commcareconnect.com/data/v1/learn',
+        MUG_NAME = 'CCCLearnModule',
+        cccMugOptions = {
+            typeName: 'CommCare Connect Metadata',
+            isTypeChangeable: false,
+            isDataOnly: true,
+            supportsDataNodeRole: true,
+            icon: 'fa fa-compress',
+            init: (mug, form) => {
+                mug.p.name = "";
+            },
+            getExtraDataAttributes: function (mug) {
+                return {
+                    // allows the parser to know which mug to associate with this node
+                    "vellum:role": MUG_NAME,
+                };
+            },
+            parseDataNode: () => {
+                // Extract values from the data node
+                // Return an empty list of child nodes since children are handled
+                // by this plugin directly.
+                return $([])
+            },
+            dataChildFilter: (children, mug) => {
+                // called during write
+                // return a list nodes to add to the forms data node
+                children = [
+                    new Tree.Node([], {
+                        getNodeID: function () { return "name"; },
+                        p: {rawDataAttributes: null},
+                        options: {getExtraDataAttributes: () => {}}
+                    })
+                ]
+                return [new Tree.Node(children, {
+                    getNodeID: function () { return "module"; },
+                    p: {rawDataAttributes: null},
+                    options: {
+                        getExtraDataAttributes: () => {
+                            return  {
+                                "xmlns": CCC_XMLNS,
+                                "id": mug.p.nodeID,
+                            }
+                        }
+                    }
+                })];
+            },
+            getBindList: (mug) => {
+                // return list of bind elements to add to the form
+                return [
+                    {
+                        nodeset: mug.absolutePath + "/module/name",
+                        calculate: `'${mug.p.name}'`,
+                    }
+                ];
+            },
+            spec: {
+                xmlnsAttr: {
+                    presence: "optional",
+                    serialize: function () {},
+                    deserialize: function () {}
+                },
+                name: {
+                    lstring: gettext("Name"),
+                    visibility: 'visible',
+                    presence: 'required',
+                    widget: widgets.text,
+                },
+                requiredAttr: { presence: "notallowed" },
+                constraintAttr: { presence: "notallowed" },
+                calculateAttr: { presence: "notallowed" }
+            },
+        },
+        sectionData = [
+            // UI sections for the mug
+            {
+                slug: "main",
+                displayName: gettext("Basic"),
+                properties: [
+                    "nodeID",
+                    "name",
+                ],
+            },
+        ];
+
+    $.vellum.plugin("commcareConnect", {}, {
+        getAdvancedQuestions: function () {
+            return this.__callOld().concat([MUG_NAME]);
+        },
+        getMugTypes: function () {
+            let types = this.__callOld();
+            types.normal[MUG_NAME] = util.extend(mugs.defaultOptions, cccMugOptions);
+            return types;
+        },
+        getSections: function (mug) {
+            if (mug.__className !== MUG_NAME) return this.__callOld();
+            return _.clone(sectionData);
+        },
+        parseBindElement: function (form, el, path) {
+            let mug = form.getMugByPath(path);
+            if (!mug) {
+                let pathRegex = /\/module\/(name)$/,
+                    matchRet = path.match(pathRegex),
+                    basePath;
+                if (matchRet && matchRet.length > 0) {
+                    basePath = path.replace(pathRegex, "");
+                    mug = form.getMugByPath(basePath);
+                    if (mug && mug.__className === MUG_NAME) {
+                        let attr = matchRet[1];
+                        mug.p[attr] = el.xmlAttr("calculate");
+                        return;
+                    }
+                }
+            }
+            this.__callOld();
+        },
+    });
+});

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -104,6 +104,9 @@ define([
                         mug.p.time_estimate = "";
                     },
                     spec: util.extend(baseSpec, {
+                        nodeID: {
+                             lstring: gettext('Module ID'),
+                        },
                         name: {
                             lstring: gettext("Name"),
                             visibility: 'visible',
@@ -150,6 +153,9 @@ define([
                         mug.p.user_score = "";
                     },
                     spec: util.extend(baseSpec, {
+                        nodeID: {
+                             lstring: gettext('Assessment ID'),
+                        },
                         user_score: {
                             lstring: gettext("User Score"),
                             visibility: 'visible',

--- a/src/core.js
+++ b/src/core.js
@@ -2541,7 +2541,7 @@ define([
      * Parse data from a `bind` element during form loading.
      *
      * @param {Form} form - The form instance being loaded.
-     * @param {jQuery} el - JQuery object represent the bind element being processed.
+     * @param {jQuery} el - JQuery object representing the bind element being processed.
      * @param {String} path - The path of the element within the form.
      */
     fn.parseBindElement = function (form, el, path) {
@@ -2552,7 +2552,7 @@ define([
      * Parse data from a `setvalue` element during form loading.
      *
      * @param {Form} form - The form instance being loaded.
-     * @param {jQuery} el - JQuery object represent the bind element being processed.
+     * @param {jQuery} el - JQuery object representing the bind element being processed.
      * @param {String} path - The path of the element within the form.
      */
     fn.parseSetValue = function (form, el, path) {

--- a/src/core.js
+++ b/src/core.js
@@ -266,6 +266,11 @@ define([
         },
     };
 
+    /**
+     * Get all Mug types.
+     *
+     * @returns {Object} - Object with `normal` and `auxiliary` properties containing mug definitions.
+     */
     fn.getMugTypes = function () {
         return mugs.baseMugTypes;
     };
@@ -326,6 +331,14 @@ define([
         this.data.core.saveButton.ui.appendTo($saveButtonContainer);
     };
 
+    /**
+     * Get question groups to display.
+     *
+     * @returns {Object} - List of group configurations. Each group configuration is an object with the
+     *              following properties:
+     *              - group: [groupName, groupDisplayName]
+     *              - questions: [mugType, ...]
+     */
     fn.getQuestionGroups = function () {
         return [
             {
@@ -2348,6 +2361,18 @@ define([
         });
     };
 
+    /**
+     * Get UI sections for the mug. This controls the UI for the mug.
+     *
+     * @param {Mug} mug - The mug to get sections for.
+     * @return {Array<Object>} List of sections to display for the given mug.
+     *      Each section is an object with the following properties:
+     *      - slug: The slug of the section.
+     *      - displayName: The display name of the section. Should be tagged for translation with `gettext`.
+     *      - properties: List of mug properties to display.
+     *      - help: Help configuration with `title`, `text` and `link` properties.
+     *      - isCollapsed: Boolean indicating whether the section should be collapsed by default.
+     */
     fn.getSections = function (mug) {
         return [
             {
@@ -2512,12 +2537,26 @@ define([
         return parser.parseDataElement(form, el, parentMug, role);
     };
 
+    /**
+     * Parse data from a `bind` element during form loading.
+     *
+     * @param {Form} form - The form instance being loaded.
+     * @param {jQuery} el - JQuery object represent the bind element being processed.
+     * @param {String} path - The path of the element within the form.
+     */
     fn.parseBindElement = function (form, el, path) {
-        return parser.parseBindElement(form, el, path);
+        parser.parseBindElement(form, el, path);
     };
 
+    /**
+     * Parse data from a `setvalue` element during form loading.
+     *
+     * @param {Form} form - The form instance being loaded.
+     * @param {jQuery} el - JQuery object represent the bind element being processed.
+     * @param {String} path - The path of the element within the form.
+     */
     fn.parseSetValue = function (form, el, path) {
-        return parser.parseSetValue(form, el, path);
+        parser.parseSetValue(form, el, path);
     };
 
     fn.getControlNodeAdaptorFactory = function (tagName) {

--- a/src/main.js
+++ b/src/main.js
@@ -179,7 +179,8 @@ define([
     'vellum/window',
     'vellum/polyfills',
     'vellum/copy-paste',
-    'vellum/commander'
+    'vellum/commander',
+    'vellum/commcareConnect',
     // end buildmain.py delimiter
 ], function () {
     // adds $.vellum as a side-effect

--- a/src/mugs.js
+++ b/src/mugs.js
@@ -1173,7 +1173,7 @@ define([
          *
          * @param mug - The mug object.
          * @param node - This mug's data node, a jQuery object.
-         * @returns - A jquery collection of child nodes.
+         * @returns - A jquery collection of child nodes which will be passed through the parser in turn.
          */
         parseDataNode: function (mug, $node) {
             return $node.children();
@@ -1181,7 +1181,9 @@ define([
         controlNodeChildren: null,
 
         /**
-         * Get data node path name
+         * Get data node path name.
+         *
+         * Use this to override the default path name.
          *
          * @param mug - The mug.
          * @param name - The default path name.
@@ -1190,7 +1192,9 @@ define([
          */
         getPathName: null,
         /**
-         * Get data node tag name
+         * Get data node tag name.
+         *
+         * Use this to override the default tag name.
          *
          * @param mug - The mug.
          * @param name - The default tag name.
@@ -1198,19 +1202,34 @@ define([
          */
         getTagName: null,
 
-        // XForm writer integration:
-        //  `childFilter(treeNodes, parentMug) -> treeNodes`
-        // The writer passes these filter functions to `processChildren` of
-        // `Tree.walk`. See `Tree.walk` documentation for more details.
+        /**
+         * Filter function for data node children.
+         *
+         * This allows integration into the XForm writer. It can be used to filter out
+         * child elements or generate additional child elements.
+         *
+         * The writer passes these filter functions to `processChildren` of
+         * `Tree.walk`. See `Tree.walk` documentation for more details.
+         *
+         *  @param treeNodes - The list of child nodes.
+         *  @param parentMug - The parent mug.
+         *  @returns {Array<Tree.Node>} - The list of child nodes to add to the form XML data element.
+         */
         dataChildFilter: null,
         controlChildFilter: null,
 
-        // data node writer options
-        getExtraDataAttributes: null, // function (mug) { return {...}; }
+        /**
+         * Get extra data node attributes to write to the XML.
+         *
+         * @param {Mug} mug - The mug.
+         * @returns {Object} - An object containing extra attributes to write to the XML.
+         */
+        getExtraDataAttributes: null,
         writeDataNodeXML: null,       // function (xmlWriter, mug) { ... }
 
         /**
-         * Returns a list of objects containing bind element attributes
+         * Returns a list of objects containing bind element attributes which will
+         * be written to the form XML.
          */
         getBindList: function (mug) {
             var constraintMsgItext = mug.p.constraintMsgItext,
@@ -1246,6 +1265,10 @@ define([
             return attrs.nodeset ? [attrs] : [];
         },
 
+        /**
+         * Returns a list of objects containing `setvalue` element attributes which will
+         * be written to the form XML.
+         */
         getSetValues: function (mug) {
             var ret = [];
 
@@ -1278,7 +1301,33 @@ define([
             return mug.options.icon;
         },
         isHashtaggable: true,
+        /**
+         * Init function called when adding a mug to a form. Typically used ot initialize
+         * mug properties.
+         *
+         * @param {Mug} mug
+         * @param {Form} form
+         */
         init: function (mug, form) {},
+
+        /**
+         * Attribute spec for the mug. Each attribute on the object
+         * defines the attribute spec for that attribute. The attribute
+         * spec is an object with the following properties:
+         * - visibility: 'visible', 'hidden', 'visible_if_present', 'visible_if_not_present'
+         * - presence: 'required', 'optional', 'notallowed'
+         * - lstring: The label string to use for the attribute on the UI
+         * - widget: The widget to use for the attribute. See `widgets.js`.
+         * - defaultOptions: The default options for the widget
+         * - validationFunc: A function to validate the attribute.
+         *      // (mug) => isValid ? "pass" : gettext("Error message")
+         * - mayReferenceSelf: Whether the attribute may reference the mug itself
+         * - enabled: A function to determine whether the attribute is enabled
+         *      // (mug) => true/false
+         * - help: Help text for the attribute
+         * - serialize: A function to serialize the attribute e.g. `mug.serializeXPath`
+         * - deserialize: A function to deserialize the attribute e.g. `mug.deserializeXPath`
+         */
         spec: {}
     };
 

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -4,6 +4,7 @@
     "asi": false,
     "bitwise": true,
     "boss": false,
+    "esversion": 6,
     "eqeqeq": true,
     "evil": false,
     "forin": false,

--- a/tests/commcareConnect.js
+++ b/tests/commcareConnect.js
@@ -1,0 +1,38 @@
+define([
+    'tests/utils',
+    'chai',
+    'jquery',
+    'underscore',
+    'vellum/commcareConnect',
+    'text!static/commcareConnect/learn_module.xml',
+], function (
+    util,
+    chai,
+    $,
+    _,
+    commcareConnect,
+    LEARN_MODULE_XML,
+) {
+    var assert = chai.assert,
+        call = util.call;
+
+    describe("The CommCareConnect module", function() {
+        before(function (done) {
+            util.init({
+                javaRosa: {langs: ['en']},
+                core: {onReady: function () { done(); }},
+            });
+        });
+
+        it("should load and save a learn module", function () {
+            util.loadXML(LEARN_MODULE_XML);
+            var module = util.getMug("module_1");
+            console.log(module.p);
+            assert.equal(module.__className, "ConnectLearnModule");
+            assert.equal(module.p.name, "'module 1'");
+            assert.equal(module.p.description, "'Module 1 is fun\nLearning is fun'");
+            assert.equal(module.p.time_estimate, "2");
+            util.assertXmlEqual(call("createXML"), LEARN_MODULE_XML);
+        });
+    });
+});

--- a/tests/commcareConnect.js
+++ b/tests/commcareConnect.js
@@ -5,6 +5,7 @@ define([
     'underscore',
     'vellum/commcareConnect',
     'text!static/commcareConnect/learn_module.xml',
+    'text!static/commcareConnect/assessment.xml',
 ], function (
     util,
     chai,
@@ -12,6 +13,7 @@ define([
     _,
     commcareConnect,
     LEARN_MODULE_XML,
+    ASSESSMENT_XML,
 ) {
     var assert = chai.assert,
         call = util.call;
@@ -27,12 +29,19 @@ define([
         it("should load and save a learn module", function () {
             util.loadXML(LEARN_MODULE_XML);
             var module = util.getMug("module_1");
-            console.log(module.p);
             assert.equal(module.__className, "ConnectLearnModule");
             assert.equal(module.p.name, "'module 1'");
             assert.equal(module.p.description, "'Module 1 is fun\nLearning is fun'");
             assert.equal(module.p.time_estimate, "2");
             util.assertXmlEqual(call("createXML"), LEARN_MODULE_XML);
+        });
+
+        it("should load and save a assessment", function () {
+            util.loadXML(ASSESSMENT_XML);
+            var module = util.getMug("test_assessment");
+            assert.equal(module.__className, "ConnectAssessment");
+            assert.equal(module.p.user_score, "/data/score");
+            util.assertXmlEqual(call("createXML"), ASSESSMENT_XML);
         });
     });
 });

--- a/tests/commcareConnect.js
+++ b/tests/commcareConnect.js
@@ -31,8 +31,8 @@ define([
                 util.loadXML(LEARN_MODULE_XML);
                 var module = util.getMug("module_1");
                 assert.equal(module.__className, "ConnectLearnModule");
-                assert.equal(module.p.name, "'module 1'");
-                assert.equal(module.p.description, "'Module 1 is fun\nLearning is fun'");
+                assert.equal(module.p.name, "module 1");
+                assert.equal(module.p.description, "Module 1 is fun\nLearning is fun");
                 assert.equal(module.p.time_estimate, "2");
                 util.assertXmlEqual(call("createXML"), LEARN_MODULE_XML);
             });

--- a/tests/commcareConnect.js
+++ b/tests/commcareConnect.js
@@ -13,12 +13,12 @@ define([
     _,
     commcareConnect,
     LEARN_MODULE_XML,
-    ASSESSMENT_XML,
+    ASSESSMENT_XML
 ) {
     var assert = chai.assert,
         call = util.call;
 
-    describe("The CommCareConnect module", function() {
+    describe("The CommCareConnect", function() {
         before(function (done) {
             util.init({
                 javaRosa: {langs: ['en']},
@@ -26,22 +26,32 @@ define([
             });
         });
 
-        it("should load and save a learn module", function () {
-            util.loadXML(LEARN_MODULE_XML);
-            var module = util.getMug("module_1");
-            assert.equal(module.__className, "ConnectLearnModule");
-            assert.equal(module.p.name, "'module 1'");
-            assert.equal(module.p.description, "'Module 1 is fun\nLearning is fun'");
-            assert.equal(module.p.time_estimate, "2");
-            util.assertXmlEqual(call("createXML"), LEARN_MODULE_XML);
+        describe("learn module", function () {
+             it("should load and save", function () {
+                util.loadXML(LEARN_MODULE_XML);
+                var module = util.getMug("module_1");
+                assert.equal(module.__className, "ConnectLearnModule");
+                assert.equal(module.p.name, "'module 1'");
+                assert.equal(module.p.description, "'Module 1 is fun\nLearning is fun'");
+                assert.equal(module.p.time_estimate, "2");
+                util.assertXmlEqual(call("createXML"), LEARN_MODULE_XML);
+            });
+
+            it("requires time_estimate to be an integer", function () {
+                var mug = util.addQuestion("ConnectLearnModule", "mug");
+                mug.p.time_estimate = "foo";
+                assert.equal(mug.spec.time_estimate.validationFunc(mug), "Must be an integer");
+            });
         });
 
-        it("should load and save a assessment", function () {
-            util.loadXML(ASSESSMENT_XML);
-            var module = util.getMug("test_assessment");
-            assert.equal(module.__className, "ConnectAssessment");
-            assert.equal(module.p.user_score, "/data/score");
-            util.assertXmlEqual(call("createXML"), ASSESSMENT_XML);
+        describe("assessment module", function () {
+            it("should load and save", function () {
+                util.loadXML(ASSESSMENT_XML);
+                var module = util.getMug("test_assessment");
+                assert.equal(module.__className, "ConnectAssessment");
+                assert.equal(module.p.user_score, "/data/score");
+                util.assertXmlEqual(call("createXML"), ASSESSMENT_XML);
+            });
         });
     });
 });

--- a/tests/main.js
+++ b/tests/main.js
@@ -97,7 +97,6 @@ requirejs(['jquery.vellum'], function () {
         'tests/markdown',
         'tests/datasources',
         'tests/databrowser',
-        'tests/saveToCase',
         'tests/setvalue',
         'tests/richText',
         'tests/questionProperties',

--- a/tests/main.js
+++ b/tests/main.js
@@ -105,6 +105,7 @@ requirejs(['jquery.vellum'], function () {
         'tests/escapedHashtags',
         'tests/bulkActions',
         'tests/undomanager',
+        'tests/commcareConnect',
     ], function ($, options) {
         var session = window.sessionStorage;
 

--- a/tests/options.js
+++ b/tests/options.js
@@ -232,6 +232,7 @@ define(["underscore"], function (_) {
             'modeliteration',
             'commtrack',
             'saveToCase',
+            'commcareConnect',
             'atwho',
         ],
         features: {

--- a/tests/static/commcareConnect/assessment.xml
+++ b/tests/static/commcareConnect/assessment.xml
@@ -1,0 +1,31 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+  <h:head>
+    <h:title>Untitled Form</h:title>
+    <model>
+      <instance>
+        <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/E1B03643-109D-4DC6-9737-815E4401DE79" uiVersion="1" version="1" name="Untitled Form">
+          <score />
+          <test_assessment vellum:role="ConnectAssessment">
+            <assessment xmlns="http://commcareconnect.com/data/v1/learn" id="test_assessment">
+              <user_score />
+            </assessment>
+          </test_assessment>
+        </data>
+      </instance>
+      <bind vellum:nodeset="#form/score" nodeset="/data/score" type="xsd:int" required="true()" />
+      <bind nodeset="/data/test_assessment/assessment/user_score" vellum:calculate="#form/score"  calculate="/data/score" />
+      <itext>
+        <translation lang="en" default="">
+          <text id="score-label">
+            <value>score</value>
+          </text>
+        </translation>
+      </itext>
+    </model>
+  </h:head>
+  <h:body>
+    <input vellum:ref="#form/score" ref="/data/score">
+      <label ref="jr:itext('score-label')" />
+    </input>
+  </h:body>
+</h:html>

--- a/tests/static/commcareConnect/learn_module.xml
+++ b/tests/static/commcareConnect/learn_module.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/E1B03643-109D-4DC6-9737-815E4401DE79" uiVersion="1" version="1" name="Untitled Form">
+					<name />
+					<module_1 vellum:role="ConnectLearnModule">
+						<module xmlns="http://commcareconnect.com/data/v1/learn" id="module_1">
+							<name />
+							<description />
+							<time_estimate />
+						</module>
+					</module_1>
+				</data>
+			</instance>
+			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
+			<bind nodeset="/data/module_1/module/name" calculate="'module 1'" />
+			<bind nodeset="/data/module_1/module/description" calculate="'Module 1 is fun&#10;Learning is fun'" />
+			<bind nodeset="/data/module_1/module/time_estimate" calculate="2" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="name-label">
+						<value>name</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input vellum:ref="#form/name" ref="/data/name">
+			<label ref="jr:itext('name-label')" />
+		</input>
+	</h:body>
+</h:html>

--- a/tests/static/commcareConnect/learn_module.xml
+++ b/tests/static/commcareConnect/learn_module.xml
@@ -8,17 +8,14 @@
 					<name />
 					<module_1 vellum:role="ConnectLearnModule">
 						<module xmlns="http://commcareconnect.com/data/v1/learn" id="module_1">
-							<name />
-							<description />
-							<time_estimate />
+							<name>module 1</name>
+							<description>Module 1 is fun&#10;Learning is fun</description>
+							<time_estimate>2</time_estimate>
 						</module>
 					</module_1>
 				</data>
 			</instance>
 			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
-			<bind nodeset="/data/module_1/module/name" calculate="'module 1'" />
-			<bind nodeset="/data/module_1/module/description" calculate="'Module 1 is fun&#10;Learning is fun'" />
-			<bind nodeset="/data/module_1/module/time_estimate" calculate="2" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="name-label">


### PR DESCRIPTION
## Summary
A new plugin for CommCare Connect which adds two 'advanced' question types:

* Learn Module
  * A question for recording metadata about a CommCare Connect learn module
  * Contains static elements `name`, `description`, `time_estimate`
* Assessment Score
  * A question for recording a user's assessment score.

The XML for the 'questions' is as follows:

```xml
<module xmlns="http://commcareconnect.com/data/v1/learn" id="intro_x">
    <name>Introduction</name>
    <description>An introduction to X</description>
    <time_estimate>2</time_estimate>
</module>

<assessment xmlns="http://commcareconnect.com/data/v1/learn" id="pmtct_basic_v1">
    <user_score>63</user_score>
</assessment>
```

More details in the spec: https://docs.google.com/document/d/1cImuUqpEzdXbgIaty8yX6-cRjHO4Tc92xvhNW7VbBxw/edit#heading=h.ubg1wxo6vbti

## Feature Flag
This plugin will be put behind in FF in CommCare HQ.

## Product Description

**Learn Module Question**
![image](https://github.com/dimagi/Vellum/assets/249606/c9f2550e-68ed-4282-af47-387cf43497fe)


**Assessment Question**
![image](https://github.com/dimagi/Vellum/assets/249606/ebcf4e95-6705-4e81-a24e-acc650a87063)

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Added tests for the module.

### QA Plan
QA on prod using a FF.

### Safety story
All (almost) changes are limited to the new module with the exception of documentation removing to unnecessary 'return' statements (see inline comments).

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
