### PR TITLE
commcare connect deliver unit mug

### DIFF
--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -323,7 +323,7 @@ define([
         parseBindElement: function (form, el, path) {
             let mug = form.getMugByPath(path);
             if (!mug) {
-                // check each mugConfig to see if this is path matches
+                // check each mugConfig to see if this path matches
                 let matched = Object.entries(mugConfigs).some(([mugName, mugConfig]) => {
                     // construct regex to match any of the child nodes
                     let children = mugConfig.childNodes.map(child => child.id).join('|'),

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -198,6 +198,46 @@ define([
                         "user_score",
                     ],
                 })],
+            },
+            ConnectDeliverUnit: {
+                rootName: "deliver",
+                childNodes: [
+                    "name",
+                ],
+                mugOptions: util.extend(baseMugOptions, {
+                    typeName: 'Deliver Unit',
+                    icon: 'fa fa-briefcase',
+                    init: mug => {
+                        mug.p.name = "";
+                    },
+                    getBindList: mug => {
+                        // return list of bind elements to add to the form
+                        let mugConfig = mugConfigs[mug.__className];
+                        return mugConfig.childNodes.map(childName => {
+                            return {
+                                nodeset: `${mug.absolutePath}/${mugConfig.rootName}/${childName}`,
+                                calculate: mug.p[childName],
+                            };
+                        });
+                    },
+                    spec: util.extend(baseSpec, {
+                        nodeID: {
+                            lstring: gettext('Delivery Unit ID'),
+                        },
+                        name: {
+                            lstring: gettext("Name"),
+                            visibility: 'visible',
+                            presence: 'required',
+                            widget: widgets.text,
+                        },
+                    })
+                }),
+                sections: [_.extend({}, baseSection, {
+                    properties: [
+                        "nodeID",
+                        "name",
+                    ],
+                })],
             }
         };
 

--- a/tests/commcareConnect.js
+++ b/tests/commcareConnect.js
@@ -6,6 +6,7 @@ define([
     'vellum/commcareConnect',
     'text!static/commcareConnect/learn_module.xml',
     'text!static/commcareConnect/assessment.xml',
+    'text!static/commcareConnect/deliver.xml',
 ], function (
     util,
     chai,
@@ -13,7 +14,8 @@ define([
     _,
     commcareConnect,
     LEARN_MODULE_XML,
-    ASSESSMENT_XML
+    ASSESSMENT_XML,
+    DELIVER_XML
 ) {
     var assert = chai.assert,
         call = util.call;
@@ -50,7 +52,19 @@ define([
                 var module = util.getMug("test_assessment");
                 assert.equal(module.__className, "ConnectAssessment");
                 assert.equal(module.p.user_score, "/data/score");
+                assert.equal(module.p.relevantAttr, "x = 1");
                 util.assertXmlEqual(call("createXML"), ASSESSMENT_XML);
+            });
+        });
+
+        describe("deliver unit", function () {
+            it("should load and save", function () {
+                util.loadXML(DELIVER_XML);
+                var module = util.getMug("unit_one");
+                assert.equal(module.__className, "ConnectDeliverUnit");
+                assert.equal(module.p.name, "unit 1");
+                assert.equal(module.p.relevantAttr, "x = 1");
+                util.assertXmlEqual(call("createXML"), DELIVER_XML);
             });
         });
     });

--- a/tests/commcareConnect.js
+++ b/tests/commcareConnect.js
@@ -63,6 +63,8 @@ define([
                 var module = util.getMug("unit_one");
                 assert.equal(module.__className, "ConnectDeliverUnit");
                 assert.equal(module.p.name, "unit 1");
+                assert.equal(module.p.entity_id, "instance('commcaresession')/session/data/value");
+                assert.equal(module.p.entity_name, "/data/name");
                 assert.equal(module.p.relevantAttr, "x = 1");
                 util.assertXmlEqual(call("createXML"), DELIVER_XML);
             });

--- a/tests/static/commcareConnect/assessment.xml
+++ b/tests/static/commcareConnect/assessment.xml
@@ -13,6 +13,7 @@
         </data>
       </instance>
       <bind vellum:nodeset="#form/score" nodeset="/data/score" type="xsd:int" required="true()" />
+      <bind vellum:nodeset="#form/test_assessment" nodeset="/data/test_assessment" relevant="x = 1" />
       <bind nodeset="/data/test_assessment/assessment/user_score" vellum:calculate="#form/score"  calculate="/data/score" />
       <itext>
         <translation lang="en" default="">

--- a/tests/static/commcareConnect/deliver.xml
+++ b/tests/static/commcareConnect/deliver.xml
@@ -8,13 +8,18 @@
 					<name />
 					<unit_one vellum:role="ConnectDeliverUnit">
 						<deliver xmlns="http://commcareconnect.com/data/v1/learn" id="unit_one">
-							<name>unit 1</name>
+                            <name>unit 1</name>
+                            <entity_id/>
+                            <entity_name/>
 						</deliver>
 					</unit_one>
 				</data>
 			</instance>
+			<instance src="jr://instance/session" id="commcaresession" />
 			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
 			<bind vellum:nodeset="#form/unit_one" nodeset="/data/unit_one" relevant="x = 1" />
+			<bind nodeset="/data/unit_one/deliver/entity_id" calculate="instance('commcaresession')/session/data/value" />
+			<bind nodeset="/data/unit_one/deliver/entity_name" vellum:calculate="#form/name" calculate="/data/name" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="name-label">

--- a/tests/static/commcareConnect/deliver.xml
+++ b/tests/static/commcareConnect/deliver.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/E1B03643-109D-4DC6-9737-815E4401DE79" uiVersion="1" version="1" name="Untitled Form">
+					<name />
+					<unit_one vellum:role="ConnectDeliverUnit">
+						<deliver xmlns="http://commcareconnect.com/data/v1/learn" id="unit_one">
+							<name>unit 1</name>
+						</deliver>
+					</unit_one>
+				</data>
+			</instance>
+			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
+			<bind vellum:nodeset="#form/unit_one" nodeset="/data/unit_one" relevant="x = 1" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="name-label">
+						<value>name</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input vellum:ref="#form/name" ref="/data/name">
+			<label ref="jr:itext('name-label')" />
+		</input>
+	</h:body>
+</h:html>


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/CCPC-110

## Summary
This adds a new 'mug' to the `commcareConnect` plugin which is used by CommCare Connect projects to track service delivery. A delivery unit XML block is added to a form that represents a unit of service delivery. When this form is forwarded to CommCare Connect, the details in the XML block are processed to record the service delivery.

```xml
<deliver xmlns="http://commcareconnect.com/data/v1/learn" id="unit_one">
    <name>unit 1</name>
    <entity_id>123123</entity_id>
    <entity_name>23 Mvuramanga Road</entity_name>
</deliver>
```

![image](https://github.com/dimagi/Vellum/assets/249606/74011554-1b72-404b-a818-7d280497260d)



## Feature Flag
CommCare Connect

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Updated unit tests.

### QA Plan
None

### Safety story
The changes are limited to the CommCare Connect plugin which is only enabled based on the FF. The changes have unit test coverage and were tested locally.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
