### PR TITLE
update r.js path in build (so it works for M1 users)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ deps:
 
 _rjs:
 	rm -rf _build
-	PATH=$$(npm bin):$$PATH r.js -o build.js
+	node_modules/requirejs/bin/r.js -o build.js
 # r.js removeCombined option doesn't handle plugin resources
 	rm -r _build/src/exclude.js _build/src/templates _build/src/less-style
 	find _build/ -maxdepth 1 -mindepth 1 -not -name src -not -name lib -not -name README.md -not -name node_modules | xargs rm -rf


### PR DESCRIPTION
## Summary
Attempting to fix building vellum on M1 machines. Updating path to r.js to reference the version in node_modules

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
yes

### QA Plan
no

### Safety story
just affects the building of vellum. if the build no longer works as a result, we can revert this change. does not affect anything live on prod

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
