### PR TITLE
update yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2873,6 +2873,11 @@ yargs@16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
+yarn@1.22.10:
+  version "1.22.10"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
+  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
+
 yarn@^1.22.19:
   version "1.22.19"
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"


### PR DESCRIPTION
## Summary
Update `yarn.lock` so that build can complete. This was the output after running `yarn install` locally.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
Yes

### QA Plan
No

### Safety story
Safe change as this is only affecting the `yarn.lock` file. need to update otherwise the `vellum-to-hq` command won't complete.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
