### PR TITLE
remove yarn pin from package.json

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -25,9 +25,7 @@ jobs:
           3.9
     - name: Install dependencies
       run: |
-        yarn_version=$(grep -Eo '^yarn@[^:]+' ./yarn.lock)
-        echo "lock file requires: $yarn_version"
-        npm install "$yarn_version"
+        npm install "yarn@^1"
         yarn install
     - name: Install dependency-metrics
       run: pip install dependency-metrics

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,7 @@ jobs:
         node-version: 14
     - name: Install dependencies
       run: |
-        yarn_version=$(grep -Eo '^yarn@[^:]+' ./yarn.lock)
-        echo "lock file requires: $yarn_version"
-        npm install "$yarn_version"
+        npm install "yarn@^1"
         yarn install
     - name: Run tests
       run: |

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
         "less": "2",
         "minimist": "^1.2.8",
         "mocha": "10.2.0",
-        "mocha-headless-chrome": "4.0.0",
-        "yarn": "^1.22.19"
+        "mocha-headless-chrome": "4.0.0"
     },
     "main": "src/main.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "requirejs-text": "2.0.16",
         "requirejs-undertemplate": "dimagi/requirejs-tpl#v0.0.5",
         "underscore": "1.13.1",
-        "xpath": "dimagi/js-xpath#v0.0.7",
+        "xpath": "dimagi/js-xpath#v0.0.8",
         "xrayquire": "npm:xrayquire-for-npm#^0.1.1"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2873,10 +2873,10 @@ yargs@16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yarn@^1.22.19:
-  version "1.22.19"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
-  integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==
+yarn@1.22.10:
+  version "1.22.10"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
+  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
 
 yauzl@^2.10.0:
   version "2.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2818,12 +2818,11 @@ ws@8.5.0, ws@^3.2.0, ws@^5.2.3:
   dependencies:
     async-limiter "~1.0.0"
 
-xpath@dimagi/js-xpath#v0.0.7:
-  version "0.0.7"
-  resolved "https://codeload.github.com/dimagi/js-xpath/tar.gz/cc482ce3cd8635ce311d9b4c82dba24998492a46"
+xpath@dimagi/js-xpath#v0.0.8:
+  version "0.0.8"
+  resolved "https://codeload.github.com/dimagi/js-xpath/tar.gz/54f9c68235a84de3cbd1360d840c51d013ddb110"
   dependencies:
     biginteger "^1.0.3"
-    yarn "1.22.10"
 
 "xrayquire@npm:xrayquire-for-npm#^0.1.1":
   version "0.1.1"
@@ -2872,11 +2871,6 @@ yargs@16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
-
-yarn@1.22.10:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
-  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
## Summary
This removes the `yarn` pin from `package.json`. This is not good practice to do.

This needs to be done so that the `vellum-to-hq` command can finish packaging vellum for HQ


## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage
yes

### QA Plan
no

### Safety story
safe. just updates dependency on `yarn`. tests will fail if this is a bad idea.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
