### PR TITLE
Fix bug caused by group named 'body'

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -43,7 +43,7 @@ define([
 
         var xml = util.parseXML(xmlString),
             docNode = xml.find('h\\:xdoc'),
-            head = xml.find('h\\:head, head'),
+            head = xml.find(':root > h\\:head, :root > head'),
             title = head.children('h\\:title, title'),
             binds = head.find('bind'),
             instances = _getInstances(xml),
@@ -95,7 +95,7 @@ define([
 
         parseSetValues(form, setValues);
 
-        var controls = xml.find('h\\:body, body').children();
+        var controls = xml.find(':root > h\\:body, :root > body').children();
         parseControlTree(form, controls);
 
         var i;

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -7,6 +7,7 @@ define([
     'vellum/parser',
     'vellum/xml',
     'text!static/parser/accent-char-in-path.xml',
+    'text!static/parser/body-group.xml',
     'text!static/parser/other_item.xml',
     'text!static/parser/label-without-itext.xml',
     'text!static/parser/missing-bind.xml',
@@ -26,6 +27,7 @@ define([
     parser,
     xml,
     ACCENT_CHAR_IN_PATH_XML,
+    BODY_GROUP,
     OTHER_ITEM_XML,
     LABEL_WITHOUT_ITEXT_XML,
     MISSING_BIND_XML,
@@ -167,6 +169,14 @@ define([
             assert.equal(q3.p.requiredCondition, "#form/question2 = 'hello'");
             assert.equal(q3.messages.get("requiredAttr").length, 1, "requiredAttr messages");
             assert.equal(q3.messages.get("requiredCondition").length, 1, "requiredCondition messages");
+        });
+
+        it("should not create read-only mug for child of group named 'body'", function () {
+            util.loadXML(BODY_GROUP);
+            util.assertJSTreeState(
+                "body",
+                "  text"
+            );
         });
 
         describe("override", function() {

--- a/tests/static/parser/body-group.xml
+++ b/tests/static/parser/body-group.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/8730E8C4-2374-47E4-B293-7BA3936D0A4A" uiVersion="1" version="1" name="Untitled Form">
+					<body>
+						<text />
+					</body>
+				</data>
+			</instance>
+			<bind vellum:nodeset="#form/body" nodeset="/data/body" />
+			<bind vellum:nodeset="#form/body/text" nodeset="/data/body/text" type="xsd:string" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="body-label">
+						<value>body</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<group vellum:ref="#form/body" ref="/data/body">
+			<label ref="jr:itext('body-label')" />
+			<input vellum:ref="#form/body/text" ref="/data/body/text">
+				<label ref="jr:itext('body/text-label')" />
+			</input>
+		</group>
+	</h:body>
+</h:html>


### PR DESCRIPTION
An extra read-only control node was added to the form when it was loaded, resulting in a broken form.

### Automated test coverage

Yes.

### Safety story

Tested locally in a chromium-based browser and Firefox. Vellum automated test coverage is very good.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations (other than that the bug will return).
