### PR TITLE
Upgraded requirejs from 2.36 to 2.37

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "langcodes": "dimagi/langcodes#master",
         "markdown-it": "12.3.2",
         "require-css": "0.1.10",
-        "requirejs": "2.3.6",
+        "requirejs": "2.3.7",
         "requirejs-plugins": "1.0.2",
         "requirejs-text": "2.0.16",
         "requirejs-undertemplate": "dimagi/requirejs-tpl#v0.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2281,10 +2281,10 @@ requirejs@2.3.3:
   resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.3.3.tgz#aa59fd3a0287eaf407959a138228044b5dd6a6a3"
   integrity sha1-qln9OgKH6vQHlZoTgigES13WpqM=
 
-requirejs@2.3.6:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.3.6.tgz#e5093d9601c2829251258c0b9445d4d19fa9e7c9"
-  integrity sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==
+requirejs@2.3.7:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.3.7.tgz#0b22032e51a967900e0ae9f32762c23a87036bd0"
+  integrity sha512-DouTG8T1WanGok6Qjg2SXuCMzszOo0eHeH9hDZ5Y4x8Je+9JB38HdTLT4/VA8OaUhBa0JPVHJ0pyBkM1z+pDsw==
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary
https://dimagi.atlassian.net/browse/SAAS-15983

HQ was done in https://github.com/dimagi/commcare-hq/pull/34917

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

There is test coverage, I'll also smoke test on staging.

### QA Plan

no

### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
