### PR TITLE
Fix escaping in regex and add tests

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -491,8 +491,8 @@ define([
         updateInstanceQuery: function (query, instanceId, oldId) {
             var regexp = INSTANCE_REGEXP;
             if (oldId) {
-                regexp = new RegExp("(^|\W)instance\\((['\"])" +
-                                    RegExp.escape(oldId) + "\2\\)", "ig");
+                regexp = new RegExp("(^|\\W)instance\\((['\"])" +
+                                    RegExp.escape(oldId) + "\\2\\)", "ig");
             }
             return query.replace(regexp, "$1instance('" + instanceId + "')");
         },

--- a/tests/form.js
+++ b/tests/form.js
@@ -713,5 +713,45 @@ define([
                 });
             });
         });
+
+        describe("updateInstanceQuery", function () {
+
+
+            it('should not replace ids if name closes with a 2', function() {
+                // This is just to test the previous behavior does not happen anymore
+                const form = util.loadXML("");
+                const query = "instance('oldId\2)/session/data/case_id";
+                const instanceId = "newId";
+                const oldInstanceId = "oldId";
+                const updatedQuery = form.updateInstanceQuery(query, instanceId, oldInstanceId);
+                assert.equal(updatedQuery, query);
+            });
+
+            it('should replace ids if old instance Id is provided', function() {
+                const form = util.loadXML("");
+                const query = "instance('oldId')/session/data/case_id";
+                const instanceId = "newId";
+                const oldInstanceId = "oldId";
+                const updatedQuery = form.updateInstanceQuery(query, instanceId, oldInstanceId);
+                assert.equal(updatedQuery, "instance('newId')/session/data/case_id");
+            });
+
+            it('should replace ids if there is leading white space', function() {
+                const form = util.loadXML("");
+                const query = "word instance('oldId')/session/data/case_id";
+                const instanceId = "newId";
+                const oldInstanceId = "oldId";
+                const updatedQuery = form.updateInstanceQuery(query, instanceId, oldInstanceId);
+                assert.equal(updatedQuery, "word instance('newId')/session/data/case_id");
+            });
+
+            it('should replace ids if there is no old', function() {
+                const form = util.loadXML("");
+                const query = "instance('oldId')/session/data/case_id";
+                const instanceId = "newId";
+                const updatedQuery = form.updateInstanceQuery(query, instanceId);
+                assert.equal(updatedQuery, "instance('newId')/session/data/case_id");
+            });
+        });
     });
 });


### PR DESCRIPTION
## Summary

Fix regex issue found be automated scan. I doubt that code path has been used

https://dimagi.atlassian.net/browse/USH-5176

## Feature Flag

None

## Product Description

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

`./test "updateInstanceQuery"`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

### Safety story

I am pretty sure this code path has not been used in a while, since it is not working as expected. See first of the tests.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
