### PR TITLE
Fixed unexpected fonts displaying in atwho dropdowns

### DIFF
--- a/src/templates/atwho_display.html
+++ b/src/templates/atwho_display.html
@@ -1,5 +1,5 @@
 <li>
-  <i class="<%= icon %>" /> <%= displayPath %>
+  <i class="<%= icon %>"></i> <%= displayPath %>
     <% if (displayLabel) { %>
       <br />
       <span class="atwho-jrtext"><%= displayLabel %></span>


### PR DESCRIPTION
## Summary
https://dimagi.atlassian.net/browse/SAAS-16040

Atwho dropdowns have sometimes been displaying text in unexpected fonts:

<img width="572" alt="Screenshot 2025-02-26 at 10 26 43 AM" src="https://github.com/user-attachments/assets/e2cde6de-a4f3-4b04-a2ad-aa4fc276bc9c" />


This appears to be happening because the text is contained inside the icon's `<i>` tag:
<img width="1430" alt="Screenshot 2025-02-26 at 10 30 26 AM" src="https://github.com/user-attachments/assets/654cb053-a73a-4a91-b9d5-32e29ca23160" />

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Atwho has tests, though not of this kind of display behvior.

### QA Plan

Not requesting QA.

### Safety story
Tiny change to correct malformed HTML, and risk should be limited to atwho dropdowns.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
