### PR TITLE
Fixed font display in source XML

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -691,7 +691,7 @@ define([
         var _this = this,
             $modal, $updateForm, $textarea, codeMirror,
             warn = !this.data.core.form.isFormValid(validateMug) ?
-                " <i class='fd-valid-alert-icon fa fa-warning' /> " +
+                " <i class='fd-valid-alert-icon fa fa-warning'></i> " +
                 gettext("Validation failed. Form may not perform correctly on your device!") :
                 "";
 


### PR DESCRIPTION
## Summary
Same issue as https://github.com/dimagi/Vellum/pull/1135 just in a different place, causing unexpected fonts when viewing source XML:

<img width="1419" alt="Screenshot 2025-02-26 at 11 06 56 AM" src="https://github.com/user-attachments/assets/4c214512-5d18-45e6-98ed-e5017ea504bf" />

https://dimagi.atlassian.net/browse/SAAS-16526

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

doubt it

### QA Plan

no

### Safety story
Tiny change to correct malformed HTML.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
