### PR TITLE
Updated limit for non-question atwho widgets

### DIFF
--- a/src/atwho.js
+++ b/src/atwho.js
@@ -55,6 +55,7 @@ define([
         var options = {
             at: "",
             data: choices,
+            limit: 10,
             maxLen: Infinity,
             suffix: "",
             tabSelectsMatch: false,


### PR DESCRIPTION
## Summary
https://dimagi.atlassian.net/browse/SAAS-16391

This raises the limit from the [default](https://dimagi.atlassian.net/browse/SAAS-16391) of 5 to 10, which is the [same](https://github.com/dimagi/Vellum/blob/b193bd450901efd6e419f952f4e42548b037b175/src/atwho.js#L160) used for the question dropdown (this list of questions that shows up when you type `#form`). Ten is bigger than working memory (which is 5-7 items), so it's long enough that people are less likely to look at it, grasp all the items, and feel like something is missing.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Not of this behavior.

### QA Plan

No.

### Safety story
Trivial config change.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
