### PR TITLE
Display warning for invalid XPath expression

### DIFF
--- a/src/logic.js
+++ b/src/logic.js
@@ -7,12 +7,16 @@ define([
     _,
     util
 ) {
-    var EXTERNAL_REF = "#";
+    var EXTERNAL_REF = "#",
+        INVALID_XPATH = "#invalid/xpath ";
 
     function LogicExpression (exprText, xpathParser) {
         this._text = exprText || "";
         this._xpathParser = xpathParser;
-        if ($.trim(exprText)) {
+        if (typeof this._text === "string" && this._text.startsWith(INVALID_XPATH)) {
+            this.parsed = null;
+            this.error = INVALID_XPATH;
+        } else if ($.trim(exprText)) {
             try {
                 this.parsed = this._xpathParser.parse(exprText);
             } catch (err) {
@@ -225,6 +229,12 @@ define([
                 reverse = this.reverse,
                 refs;
 
+            messages.push({
+                key: "logic-invalid-xpath-warning",
+                level: mug.WARNING,
+                message: expr.error === INVALID_XPATH ? gettext("Invalid XPath expression.") : "",
+            });
+
             expr.analyze();
             if (expr.referencesSelf && !(spec && spec.mayReferenceSelf)) {
                 warning = util.format(gettext("The {property} for a question " +
@@ -233,7 +243,6 @@ define([
                     "or your form will have errors."),
                     {property: propertyName});
             }
-
             messages.push({
                 key: "core-circular-reference-warning",
                 level: mug.WARNING,

--- a/tests/logic.js
+++ b/tests/logic.js
@@ -40,6 +40,13 @@ define([
             assert.equal(mug.p.relevantAttr, "#form/question = #case/dob");
         });
 
+        it("should display error for invalid xpath expression", function () {
+            util.loadXML(MOTHER_REF_XML);
+            var mug = util.getMug("/data/mug");
+            mug.p.calculateAttr = "#invalid/xpath dob`#case/dob`";
+            assert(!util.isTreeNodeValid(mug), "mug should not be valid");
+        });
+
         it("should not update expressions for model iteration", function () {
             util.loadXML("");
             var repeat = util.addQuestion("Repeat", "product");


### PR DESCRIPTION
Invalid XPath expressions are now flagged with a warning message. Questions with warnings are highlighted in the question tree, and the save button displays an error on mouse-over.

![image](https://github.com/user-attachments/assets/9e3958bc-6a6b-47c5-9767-8d1d380c9c14)

https://dimagi.atlassian.net/browse/SAAS-16376

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Yes.

### Safety story

Simply adds a warning when an XPath expression is not valid. Invalid XPath expressions were previously not highlighted in any special way, although the logic manager could not parse them.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
