### PR TITLE
Avoid invalid XPath error on filtered hashtag

### DIFF
--- a/src/logic.js
+++ b/src/logic.js
@@ -218,9 +218,10 @@ define([
             }
         },
         _addReferences: function (mug, property, value) {
+            value = this.form.getLogicalXPath(value || mug.p[property]);
             var _this = this,
                 form = _this.form,
-                expr = new LogicExpression(value || mug.p[property], form.xpath),
+                expr = new LogicExpression(value, form.xpath),
                 unknowns = [],
                 messages = [],
                 warning = "",

--- a/src/richText.js
+++ b/src/richText.js
@@ -714,6 +714,23 @@ define([
     }
 
     /**
+     * Get unescaped hashtag expression
+     *
+     * @return - expression with hashtags as they were
+     *      originally typed if the given value is marked with the
+     *      invalid xpath prefix, otherwise the given value
+     */
+    function unescapeHashtags(value, form) {
+        if (isInvalid(value)) {
+            value = escapedHashtags.transform(
+                value.slice(INVALID_PREFIX.length),
+                form.normalizeHashtag.bind(form)
+            );
+        }
+        return value;
+    }
+
+    /**
      * Convert plain text to HTML to be edited in CKEditor
      *
      * Replace line breaks with <p> tags and preserve contiguous spaces.
@@ -932,5 +949,6 @@ define([
         toRichText: toRichText,
         isInvalid: isInvalid,
         unescapeXPath: unescapeXPath,
+        unescapeHashtags: unescapeHashtags,
     };
 });

--- a/tests/logic.js
+++ b/tests/logic.js
@@ -8,6 +8,7 @@ define([
     'vellum/xpath',
     'text!tests/static/logic/test-xml-1.xml',
     'text!tests/static/databrowser/mother-ref.xml',
+    'text!tests/static/logic/hashtag-filter.xml',
 ], function (
     chai,
     $,
@@ -16,7 +17,8 @@ define([
     logic,
     xpath,
     TEST_XML_1,
-    MOTHER_REF_XML
+    MOTHER_REF_XML,
+    HASHTAG_FILTER
 ) {
     var assert = chai.assert,
         call = util.call;
@@ -45,6 +47,12 @@ define([
             var mug = util.getMug("/data/mug");
             mug.p.calculateAttr = "#invalid/xpath dob`#case/dob`";
             assert(!util.isTreeNodeValid(mug), "mug should not be valid");
+        });
+
+        it("should not display invalid xpath error for hashtag filter expression", function () {
+            util.loadXML(HASHTAG_FILTER);
+            var calc = util.getMug("/data/calc");
+            assert(util.isTreeNodeValid(calc), "calc xpath should be valid");
         });
 
         it("should not update expressions for model iteration", function () {

--- a/tests/static/logic/hashtag-filter.xml
+++ b/tests/static/logic/hashtag-filter.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/1F4E4E8D-1C50-45D7-82DB-EFCD982B0046" uiVersion="1" version="1" name="Untitled Form">
+					<calc />
+				</data>
+			</instance>
+			<bind vellum:nodeset="#form/calc" nodeset="/data/calc" vellum:calculate="#invalid/xpath count( `#case/dob` [1=1])" calculate="count( instance('casedb')/cases/case[@case_id = instance('commcaresession')/session/data/case_id]/dob [1=1])" />
+			<itext>
+				<translation lang="en" default="" />
+			</itext>
+		</model>
+	</h:head>
+	<h:body />
+</h:html>


### PR DESCRIPTION
[Known limitation of js-xpath](https://github.com/dimagi/js-xpath?#known-limitations):

- Filter expressions are not supported due to a known bug in jison.

https://dimagi.atlassian.net/browse/SAAS-16886

Follow-up for https://github.com/dimagi/Vellum/pull/1138

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Yes.

### Safety story

This workaround looks for a specific error that is thrown when js-xpath parser hits a known limitation with filtered hashtag expressions. An example of the error looks like
```
Error: Parse error on line 1:
count( #case/dob [1=1])
-----------------^
Expecting 'EOF', 'RPAREN', 'OR', 'AND', 'EQ', 'NEQ', 'LT', 'LTE', 'GT', 'GTE', 'PLUS', 'MINUS', 'MULT', 'DIV', 'MOD', 'UNION', 'COMMA', 'SLASH', 'RBRACK', got 'LBRACK'
```
It additionally checks the erroneous expression for filtered and escaped hashtag syntax. If both of those conditions are met and the expression parses successfully after being converted to XPath without hashtags, only then is the `#invalid/xpath ` prefix ignored and the unescaped XPath expression is used in the logic manager instead of the faulty hashtag expression.

The error that this prevents from being displayed in the form builder was a false flag. The form was functional despite the presence of the error.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
