### PR TITLE
Upgraded version of node used in github actions

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -16,9 +16,9 @@ jobs:
       DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 14
+        node-version: 20
     - uses: actions/setup-python@v4
       with:
         python-version: |

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -25,7 +25,10 @@ jobs:
           3.9
     - name: Install dependencies
       run: |
+        mv package.json package.json.save
         npm install "yarn@^1"
+        rm package-lock.json
+        mv package.json.save package.json
         yarn install
     - name: Install dependency-metrics
       run: pip install dependency-metrics

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,10 @@ jobs:
         node-version: 20
     - name: Install dependencies
       run: |
+        mv package.json package.json.save
         npm install "yarn@^1"
+        rm package-lock.json
+        mv package.json.save package.json
         yarn install
     - name: Run tests
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,9 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 14
+        node-version: 20
     - name: Install dependencies
       run: |
         npm install "yarn@^1"


### PR DESCRIPTION
## Summary
https://dimagi.atlassian.net/browse/SAAS-17438

Cherry-picked from webpack migration, which adds `css-loader`, which requires node minimum 18.12.0. See [here](https://github.com/dimagi/Vellum/actions/runs/14499301585/job/40674880030) for a test run that failed on a proof of concept branch.

I also updated setup-node to v4 because that's what HQ does.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

It is tests.

### QA Plan

no

### Safety story
Only affects developer-facing workflows.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
