### PR TITLE
Reduce usage of jsdiff

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -797,13 +797,11 @@ define([
             }
         ], gettext("Cancel"), "fa fa-warning");
 
-        var diff = util.xmlDiff(formText, serverForm || "");
-
         $overwriteForm = $(confirm_overwrite({
             description: gettext("Looks like someone else has edited this form " +
                          "since you loaded the page. Are you sure you want " +
                          "to overwrite their work?"),
-            xmldiff: util.escape(diff),
+            xmldiff: util.htmlXMLDiff(formText, serverForm || ""),
         }));
         $modal.find('.modal-body').html($overwriteForm);
 

--- a/src/main.js
+++ b/src/main.js
@@ -55,7 +55,6 @@ requirejs.config({
 
         'save-button': '../lib/SaveButton',
 
-        'jsdiff': '../node_modules/jsdiff/diff',
         'markdown-it': '../node_modules/markdown-it/dist/markdown-it',
         'caretjs': '../node_modules/Caret.js/dist/jquery.caret',
         'atjs': '../node_modules/at.js/dist/js/jquery.atwho',

--- a/src/templates/confirm_overwrite.html
+++ b/src/templates/confirm_overwrite.html
@@ -3,8 +3,6 @@
         <%=description%>
     </p>
     <div id="form-differences">
-      <pre>
-          <%=xmldiff%>
-      </pre>
+      <pre><%=xmldiff%></pre>
     </div>
 </div>

--- a/src/util.js
+++ b/src/util.js
@@ -329,7 +329,10 @@ define([
             diff = dmp.diff_main(localForm, serverForm);
 
         let html = dmp.diff_prettyHtml(diff);
+
+        // Strip paragraph symbols that diff-match-patch appends to each line
         html = html.replaceAll("&para;<br>", "<br>");
+
         return html;
     };
 

--- a/tests/core.js
+++ b/tests/core.js
@@ -4,7 +4,11 @@ define([
     'jquery',
     'underscore',
     'tests/utils',
+    'vellum/util',
     'text!static/core/test1.xml',
+    'text!static/core/diff1.xml',
+    'text!static/core/diff2.xml',
+    'text!static/core/diff-result.html',
     'text!static/core/group-rename.xml',
     'text!static/core/invalid-questions.xml',
     'text!static/core/increment-item.xml',
@@ -16,7 +20,11 @@ define([
     $,
     _,
     util,
+    vellumUtil,
     TEST_XML_1,
+    DIFF_1_XML,
+    DIFF_2_XML,
+    DIFF_RESULT_HTML,
     GROUP_RENAME_XML,
     INVALID_QUESTIONS_XML,
     INCREMENT_ITEM_XML,
@@ -497,6 +505,13 @@ define([
                 ]);
                 var mug = util.getMug("html-label-other");
                 assert.equal(mug.p.labelItext.get(), "a&b > & < a");
+            });
+        });
+
+        describe("XML diff display", function () {
+            it("should generate HTML disply of XML diff", function () {
+                var diff = vellumUtil.htmlXMLDiff(DIFF_1_XML, DIFF_2_XML);
+                assert.equal(diff.trim(), DIFF_RESULT_HTML.trim());
             });
         });
 

--- a/tests/main.js
+++ b/tests/main.js
@@ -42,7 +42,8 @@ requirejs(['jquery.vellum'], function () {
         paths: {
             'static': testBase + 'tests/static',
             'chai': testBase + 'node_modules/chai/chai',
-            'equivalent-xml': testBase + 'node_modules/equivalent-xml-js/src/equivalent-xml'
+            'equivalent-xml': testBase + 'node_modules/equivalent-xml-js/src/equivalent-xml',
+            'jsdiff': testBase + 'node_modules/jsdiff/diff',
         }
     });
 

--- a/tests/static/core/diff-result.html
+++ b/tests/static/core/diff-result.html
@@ -1,0 +1,1 @@
+<span>&lt;?xml version="1.0" encoding="UTF-8" ?&gt;<br>&lt;node&gt;<br>    &lt;value&gt;</span><del style="background:#ffe6e6;">aaa&lt;/value&gt;<br>&lt;/node&gt;<br>&lt;node&gt;<br>    &lt;value&gt;bbb</del><ins style="background:#e6ffe6;">ccc</ins><span>&lt;/value&gt;<br>&lt;/node&gt;<br></span>

--- a/tests/static/core/diff1.xml
+++ b/tests/static/core/diff1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<node>
+    <value>aaa</value>
+</node>
+<node>
+    <value>bbb</value>
+</node>

--- a/tests/static/core/diff2.xml
+++ b/tests/static/core/diff2.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<node>
+    <value>ccc</value>
+</node>


### PR DESCRIPTION
## Summary
This replaces the usage of `jsdiff` in the "Show overwrite warning" popup with usage of `diff_match_patch`.

`jsdiff` is one of the few libraries that's only on bower, not npm, which means it's one of the libraries keeping Vellum on yarn. I was hoping to remove it altogether but didn't realize that it's also used in a [test utility](https://github.com/dimagi/Vellum/blob/c109eaa51f203c4e14b23add33d2d1042c763a4a/tests/utils.js#L110-L115) to create diffs for test results like XML snippets and text representations of jstree schemas.

## Product Description
This changes the look and feel of the diff. I think it's an improvement, but I'm biased.

### Before
![Screenshot 2025-04-23 at 11 03 16 AM](https://github.com/user-attachments/assets/1f639d91-4ea3-4a23-8a1d-2de3fe10e0fb)

### After
![Screenshot 2025-04-23 at 11 13 10 AM](https://github.com/user-attachments/assets/001b0aed-7fdc-4821-a1c3-48a281888793)

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

Added in this PR

### QA Plan

Not requesting QA

### Safety story
This is a limited change to a minor workflow, and it has test coverage.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
