### PR TITLE
Only allow Document widget to be added if minimum CC version is met

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -347,9 +347,13 @@ define([
                 "Audio",
                 "Video",
                 "Signature",
-                "Document"
             ]
         };
+
+        if (this.opts().features.support_document_upload) {
+            mediaGroup.questions.push("Document");
+        }
+
         if (this.opts().features.case_micro_image) {
             mediaGroup.questions.push("MicroImage");
         }


### PR DESCRIPTION
## Summary
<!--
    Provide a link to the ticket or document which prompted this change,
    Describe the rationale and design decisions.
-->

[Main PR](https://github.com/dimagi/commcare-hq/pull/36034)

## Product Description
<!-- For non-invisible changes, describe user-facing effects. -->

Extra conditional that only allows Document uploads to be added to apps on version 2.57 and above.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below


### Safety story
<!--
Describe any other pieces to the safety story including
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
-->

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations 
