### PR TITLE
Upgrade tar-fs subdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "lodash": "^4.17.19",
         "mime": "^1.4.1",
         "minimatch": "^3.0.2",
+        "mocha-headless-chrome/puppeteer/tar-fs": "^2.1.2",
         "qs": "^6.0.4",
         "request": "^2.88.2",
         "set-value": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,10 +2058,10 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-tar-fs@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
-  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+tar-fs@2.1.1, tar-fs@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.2.tgz#425f154f3404cb16cb8ff6e671d45ab2ed9596c5"
+  integrity sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==
   dependencies:
     chownr "^1.1.1"
     mkdirp-classic "^0.5.2"


### PR DESCRIPTION
Patch upgrade of a testing sub-depenedency.

https://dimagi.atlassian.net/browse/SAAS-17480

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

This is a test runner dependency.

### Safety story

Affects tests only.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations 
