### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,24 @@
-## Summary
+## Product Description
+<!-- Where applicable, describe user-facing effects and include screenshots. -->
+
+## Technical Summary
 <!--
-    Provide a link to the ticket or document which prompted this change,
-    Describe the rationale and design decisions.
+    Provide a link to any tickets, design documents, and/or technical specifications
+    associated with this change. Describe the rationale and design decisions.
 -->
 
 ## Feature Flag
 <!-- If this is specific to a feature flag, which one? -->
 
-## Product Description
-<!-- For non-invisible changes, describe user-facing effects. -->
-
 ## Safety Assurance
 
-- [ ] Risk label is set correctly
-- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change
-- [ ] If QA is part of the safety story, the "Awaiting QA" label is used
-- [ ] I have confidence that this PR will not introduce a regression for the reasons below
+### Safety story
+<!--
+Describe how you became confident in this change, such as
+local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
+
+In particular consider how existing data may be impacted by this change.
+-->
 
 ### Automated test coverage
 
@@ -28,11 +31,6 @@
 - Link to QA Ticket
 -->
 
-### Safety story
-<!--
-Describe any other pieces to the safety story including
-local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.
--->
 
 ### Rollback instructions
 
@@ -41,4 +39,8 @@ If this PR follows standards of revertability, check the box below.
 Otherwise replace it with detailed instructions or reasons a rollback is impossible.
 -->
 
-- [ ] This PR can be reverted after deploy with no further considerations 
+- [ ] This PR can be reverted after deploy with no further considerations
+
+### Labels & Review
+- [ ] Risk label is set correctly
+- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change


### PR DESCRIPTION
## Summary
Going back and forth between Vellum and HQ PRs, the inconsistency between PR templates was bugging me, so this pulls in the latest PR template from HQ.

I removed the section about migrations, but everything else is relevant to Vellum.

## Safety Assurance

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
- [x] If QA is part of the safety story, the "Awaiting QA" label is used
- [x] I have confidence that this PR will not introduce a regression for the reasons below

### Automated test coverage

N/A

### QA Plan

no

### Safety story
This is a developer-facing change only.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations 
