### PR TITLE
Make sure that yarn is built properly before running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,5 @@ _tar:
 	tar -czf vellum.tar.gz -C _build .
 
 _test:
+	yarn testbuild
 	npm test

--- a/test
+++ b/test
@@ -22,6 +22,9 @@ fi
 
 temp="/tmp/test-$$.tmp"
 
+# Make sure the right build files have been generated
+yarn testbuild
+
 # run the tests
 node_modules/mocha-headless-chrome/bin/start -f http://localhost:${VELLUM_PORT:-8088}/?grep="$qs" -t 500000 | tee $temp
 


### PR DESCRIPTION
## Technical Summary
Followup for https://github.com/dimagi/Vellum/pull/1155

I realized that depending on which config of webpack you've most recently run with, running tests may fail with an error about require not being defined. This PR makes sure that the proper build files are available when you run via either the `test` script or the Makefile.

## Safety Assurance

### Safety story
It's all about tests.

### Automated test coverage

It's tests.

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
