### PR TITLE
Fix required properties on labels with non-minimal appearance

### DIFF
--- a/test
+++ b/test
@@ -42,7 +42,7 @@ else
 fi
 
 if [[ "$run_jshint" == "true" ]]; then
-    jshint src \
-        && jshint --config tests/.jshintrc tests \
+    npm exec -- jshint src \
+        && npm exec -- jshint --config tests/.jshintrc tests \
         && echo "jshint passed"
 fi

--- a/tests/mugs.js
+++ b/tests/mugs.js
@@ -101,10 +101,10 @@ define([
         it("should load required attribute on label with non-minimal appearance", function () {
             util.loadXML(REQUIRED_LABEL_XML);
             var label = util.getMug("label");
-            assert.isOk(label.p.requiredAttr);
+            assert.isTrue(label.p.requiredAttr);
             assert.equal(label.p.requiredCondition, "test()");
-            assert.isOk(label.isVisible("requiredAttr"), "required checkbox should be visible");
-            assert.isOk(label.isVisible("requiredCondition"), "required condition should be visible");
+            assert.isTrue(label.isVisible("requiredAttr"), "required checkbox should be visible");
+            assert.isTrue(label.isVisible("requiredCondition"), "required condition should be visible");
         });
 
         it("should remove required attribute when changing Text to Label", function () {
@@ -115,8 +115,8 @@ define([
             form.changeMugType(mug, "Trigger");
             assert.isUndefined(mug.p.requiredAttr);
             assert.isUndefined(mug.p.requiredCondition);
-            assert.isNotOk(mug.isVisible("requiredAttr"), "required checkbox should not be visible");
-            assert.isNotOk(mug.isVisible("requiredCondition"), "required condition should not be visible");
+            assert.isFalse(mug.isVisible("requiredAttr"), "required checkbox should not be visible");
+            assert.isFalse(mug.isVisible("requiredCondition"), "required condition should not be visible");
         });
     });
 });

--- a/tests/mugs.js
+++ b/tests/mugs.js
@@ -4,12 +4,14 @@ define([
     'jquery',
     'underscore',
     'static/mugs/blank-choice.xml',
+    'static/mugs/required-label.xml',
 ], function (
     util,
     chai,
     $,
     _,
-    BLANK_CHOICE_XML
+    BLANK_CHOICE_XML,
+    REQUIRED_LABEL_XML
 ) {
     var assert = chai.assert;
 
@@ -94,6 +96,27 @@ define([
             util.loadXML(BLANK_CHOICE_XML);
             var blank = util.getMug("select/blank");
             assert.equal(blank.p.labelItext.get(), "", "blank label itext");
+        });
+
+        it("should load required attribute on label with non-minimal appearance", function () {
+            util.loadXML(REQUIRED_LABEL_XML);
+            var label = util.getMug("label");
+            assert.isOk(label.p.requiredAttr);
+            assert.equal(label.p.requiredCondition, "test()");
+            assert.isOk(label.isVisible("requiredAttr"), "required checkbox should be visible");
+            assert.isOk(label.isVisible("requiredCondition"), "required condition should be visible");
+        });
+
+        it("should remove required attribute when changing Text to Label", function () {
+            var form = util.loadXML(""),
+                mug = util.addQuestion("Text", "text");
+            mug.p.requiredAttr = true;
+            mug.p.requiredCondition = "something()";
+            form.changeMugType(mug, "Trigger");
+            assert.isUndefined(mug.p.requiredAttr);
+            assert.isUndefined(mug.p.requiredCondition);
+            assert.isNotOk(mug.isVisible("requiredAttr"), "required checkbox should not be visible");
+            assert.isNotOk(mug.isVisible("requiredCondition"), "required condition should not be visible");
         });
     });
 });

--- a/tests/static/mugs/required-label.xml
+++ b/tests/static/mugs/required-label.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/86855C2C-46CB-4268-B445-0F8CBD35E3DA" uiVersion="1" version="1" name="Untitled Form">
+					<label />
+				</data>
+			</instance>
+			<bind vellum:nodeset="#form/label" nodeset="/data/label" required="test()" requiredCondition="test()" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="label-label">
+						<value>Label</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<trigger vellum:ref="#form/label" ref="/data/label">
+			<label ref="jr:itext('label-label')" />
+		</trigger>
+	</h:body>
+</h:html>


### PR DESCRIPTION
Previously, removing the "minimal" appearance from a label question would cause the required fields (checkbox and conditional expression) to appear in its properties, and those properties could be updated and saved, but their values were cleared on reloading the question.

Required properties are now loaded properly for labels without "minimal" appearance. However, since "minimal" is the default appearance for labels, required properties are removed when a question's type is changed to Label.

https://dimagi.atlassian.net/browse/SAAS-11058

The second commit is an unrelated tweak to the test script.

## Safety Assurance

### Safety story

Tested locally and with automated tests.

### Automated test coverage

Yes.

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations