### PR TITLE
Add support for HTML messages

### DIFF
--- a/src/mugs.js
+++ b/src/mugs.js
@@ -671,7 +671,7 @@ define([
             return _.isEmpty(this.messages);
         },
         getMessageText: function(message) {
-            return (message && message.hasOwnProperty("html")) ? message.html : message;
+            return (message && message.hasOwnProperty("markdown")) ? message.markdown: message;
         }
     };
 

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -805,8 +805,8 @@ define([
             if (seen.hasOwnProperty(messageKey)) { return; }
             seen[messageKey] = true;
             let htmlMessage = "";
-            if (msg.message.hasOwnProperty("html")) {
-                htmlMessage = msg.message.html;
+            if (msg.message.hasOwnProperty("markdown")) {
+                htmlMessage = util.markdown(msg.message.markdown);
             } else if (/n/.test(msg.message)) {
                 // html swallows newlines by default, so treat these messages as HTML to embed newline objects
                 htmlMessage = util.markdown(msg.message);

--- a/tests/core.js
+++ b/tests/core.js
@@ -71,17 +71,17 @@ define([
             chai.expect(messageDiv.html()).to.include("This is &lt;b&gt;bold&lt;/b&gt;");
         });
 
-        it("should preserve explicit HTML elements within a message", function () {
+        it("should respect markdown content", function () {
             util.loadXML("");
             const text = util.addQuestion("Text", "text"),
-                msg = {html: "This is <b>bold</b>"};
+                msg = {markdown: "Click [here](testurl)"};
             text.addMessage(null, {
                 key: "testing-1-2-3",
                 level: "error",
                 message: msg
             });
             const messageDiv = $("fieldset[data-slug='main'] + .messages");
-            chai.expect(messageDiv.html()).to.include(msg.html);
+            chai.expect(messageDiv.html()).to.include('Click <a href="testurl" target="_blank">here</a>');
         });
 
         it("should load form with save button in 'saved' state", function (done) {


### PR DESCRIPTION
## Product Description
Should have no direct effect yet, just adds backend support for HTML messages.

## Technical Summary
This PR adds HTML support for mug messages. Now, if a message object is added with an `html` property, that value will not be escaped, and thus will preserve any HTML. If the message object is instead a string (as its been previously) then the string is escaped before being displayed.

The intent behind this change was to allow us to include help links in message text, although this is not yet used.

## Feature Flag
None

## Safety Assurance

### Safety story

Verified locally with custom data. Existing behavior (with normal strings) is preserved, and no code uses the new functionality yet, so the impacts of this change should be minimal.

### Automated test coverage

Added two new tests in _core.js_

### QA Plan

No QA

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
