### PR TITLE
Add validation for Case ID field in save-to-case questions

### DIFF
--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -169,6 +169,21 @@ var CASE_XMLNS = "http://commcarehq.org/case/transaction/v2",
                 widget: widgets.xPath,
                 serialize: mugs.serializeXPath,
                 deserialize: mugs.deserializeXPath,
+                validationFunc: function (mug) {
+                    var value = mug.p.case_id;
+                    if (!value) {
+                        return gettext("Case ID is required");
+                    }
+                    var hasPathOrReference = /[\/']/.test(value);
+                    var isUuid = /^uuid\(\)$/.test(value);
+                    if (!hasPathOrReference && !isUuid) {
+                        return gettext("Case ID must be an XPath expression");
+                    }
+                    if (!createsCase(mug) && isUuid) {
+                        return gettext("Case ID cannot be uuid() without a Create action. It must reference an existing case.");
+                    }
+                    return 'pass';
+                },
             },
             useCreate: {
                 lstring: gettext("Create Case"),

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -174,7 +174,7 @@ var CASE_XMLNS = "http://commcarehq.org/case/transaction/v2",
                     if (!value) {
                         return gettext("Case ID is required");
                     }
-                    var hasPathOrFunctionCall = /\/|[a-z]+\(.+\)/.test(value)
+                    var hasPathOrFunctionCall = /\/|[a-z]+\(.+\)/.test(value);
                     var isUuid = value === 'uuid()';
                     if (/uuid\([^)]+\)/.test(value)) {
                         return gettext("uuid() should not have arguments");

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -174,9 +174,9 @@ var CASE_XMLNS = "http://commcarehq.org/case/transaction/v2",
                     if (!value) {
                         return gettext("Case ID is required");
                     }
-                    var hasPathOrReference = /[\/']/.test(value);
+                    var hasPathOrFunctionCall = /\/|[a-z]+\(.+\)/.test(value)
                     var isUuid = value === 'uuid()';
-                    if (!hasPathOrReference && !isUuid) {
+                    if (!hasPathOrFunctionCall && !isUuid) {
                         return gettext("Case ID must be an XPath expression");
                     }
                     if (!createsCase(mug) && isUuid) {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -176,6 +176,9 @@ var CASE_XMLNS = "http://commcarehq.org/case/transaction/v2",
                     }
                     var hasPathOrFunctionCall = /\/|[a-z]+\(.+\)/.test(value)
                     var isUuid = value === 'uuid()';
+                    if (/uuid\([^)]+\)/.test(value)) {
+                        return gettext("uuid() should not have arguments");
+                    }
                     if (!hasPathOrFunctionCall && !isUuid) {
                         return gettext("Case ID must be an XPath expression");
                     }

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -175,7 +175,7 @@ var CASE_XMLNS = "http://commcarehq.org/case/transaction/v2",
                         return gettext("Case ID is required");
                     }
                     var hasPathOrReference = /[\/']/.test(value);
-                    var isUuid = /^uuid\(\)$/.test(value);
+                    var isUuid = value === 'uuid()';
                     if (!hasPathOrReference && !isUuid) {
                         return gettext("Case ID must be an XPath expression");
                     }

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -247,6 +247,16 @@ describe("The SaveToCase module", function() {
             assert.notEqual(mug.spec.case_id.validationFunc(mug), "pass");
         });
 
+        it("should reject plain text with quotes", function () {
+            mug.p.case_id = "''";
+            assert.notEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
+        it("should reject function calls without arguments", function () {
+            mug.p.case_id = "foo()";
+            assert.notEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
         it("should reject uuid with arguments", function () {
             mug.p.case_id = "uuid(36)";
             assert.notEqual(mug.spec.case_id.validationFunc(mug), "pass");

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -195,6 +195,90 @@ describe("The SaveToCase module", function() {
         assert.strictEqual(mug.spec.indexProperty.validationFunc(mug), "pass");
     });
 
+    describe("case_id validation", function () {
+        var mug;
+        beforeEach(function () {
+            util.loadXML("");
+            mug = util.addQuestion("SaveToCase", "mug");
+        });
+
+        it("should accept absolute path references", function () {
+            mug.p.case_id = "/data/some_question";
+            assert.strictEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
+        it("should accept current() relative paths", function () {
+            mug.p.case_id = "current()/../../../patient_case_id";
+            assert.strictEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
+        it("should accept instance() references", function () {
+            mug.p.case_id = "instance('commcaresession')/session/data/case_id_new_person_0";
+            assert.strictEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
+        it("should accept coalesce with uuid()", function () {
+            mug.p.case_id = "coalesce(/data/existing_case_id, uuid())";
+            assert.strictEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
+        it("should accept if() expressions", function () {
+            mug.p.case_id = "if(/data/has_case = 'yes', /data/case_id, uuid())";
+            assert.strictEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
+        it("should accept casedb lookup", function () {
+            mug.p.case_id = "instance('casedb')/casedb/case[@case_type = 'patient']/@case_id";
+            assert.strictEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
+        it("should reject plain text numbers", function () {
+            mug.p.case_id = "1";
+            assert.notEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
+        it("should reject plain text strings", function () {
+            mug.p.case_id = "bob jones";
+            assert.notEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
+        it("should reject plain text with dashes", function () {
+            mug.p.case_id = "some-case-id";
+            assert.notEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
+        it("should reject uuid with arguments", function () {
+            mug.p.case_id = "uuid(36)";
+            assert.notEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
+        it("should reject empty value", function () {
+            mug.p.case_id = "";
+            assert.notEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
+        it("should reject uuid() without create action", function () {
+            mug.p.useCreate = false;
+            mug.p.useUpdate = true;
+            mug.p.case_id = "uuid()";
+            assert.strictEqual(mug.spec.case_id.validationFunc(mug),
+                "Case ID cannot be uuid() without a Create action. It must reference an existing case.");
+        });
+
+        it("should accept uuid() with create action", function () {
+            mug.p.useCreate = true;
+            mug.p.case_id = "uuid()";
+            assert.strictEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+
+        it("should accept path reference without create action", function () {
+            mug.p.useCreate = false;
+            mug.p.useUpdate = true;
+            mug.p.case_id = "/data/meta/caseID";
+            assert.strictEqual(mug.spec.case_id.validationFunc(mug), "pass");
+        });
+    });
+
     it("should provide case references to the logic manager", function () {
         var form = util.loadXML(LOGIC_TEST_XML),
             manager = form._logicManager;


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The Case ID field is currently fully editable with no restrictions. Users can type anything, including literal values like "1" or "1234". There are 230 unique Case ID values in the wild for Create operations.

Adds client-side validation to the Case ID field in save-to-case (Advanced Case Actions) questions to prevent two types of mistakes:

  1. Plain text values (e.g., "1", "bob jones", "some-case-id") — Case ID must be a valid XPath expression such as `uuid()`, a path reference, or a function call.
  2. `uuid()` without a Create action — If the question only updates/closes/indexes a case, the Case ID must reference an existing case, not generate a new one.
<img width="895" height="364" alt="image" src="https://github.com/user-attachments/assets/b0062467-09f9-40ca-a896-a1274c61cf6b" />
<img width="902" height="410" alt="image" src="https://github.com/user-attachments/assets/eb85b58c-3ea2-4fab-b836-4d984e4cc825" />

For invalid xpath, it will be caught when user make a new version
<img width="1285" height="218" alt="image" src="https://github.com/user-attachments/assets/c05f0ec2-aefa-40e7-b0cc-73a3fa86976b" />


## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19501

Pull Case ID value in prod showed that every legitimate Case ID value either:
- Is `uuid()` (for create operations)
- References existing data via XPath (`/data/...`, `current()/...`, `instance(...)`, `coalesce(...)`, `if(...)`)

The validation uses a simple heuristic: any valid XPath reference will contain `/` or `'`, so we reject values that lack both and aren't exactly `uuid()`. Invalid XPath syntax (e.g., `//`, `(()` is already caught
separately by the existing XPath parser.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`VELLUM_SAVE_TO_CASE`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->

  - This is a client-side validation only — it does not modify any data or form XML
  - Validation runs when editing in Vellum; it does not affect existing saved forms
  - The heuristic was validated against all production save-to-case forms — every legitimate value passes the check

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Test added in `tests/saveToCase.js`

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

  - Create a save-to-case question with Create action → verify uuid() is accepted
  - Create a save-to-case question with Update action → verify uuid() is rejected, path reference is accepted
  - Try entering plain text like "test" → verify validation error is shown
  
### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
