### PR TITLE
Include case_id in save-to-case data sent to HQ

### DIFF
--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -458,6 +458,7 @@ var CASE_XMLNS = "http://commcarehq.org/case/transaction/v2",
             );
             return {
                 case_type: mug.p.case_type || '',
+                case_id: mug.p.case_id || '',
                 properties: _.filter(propertyNames, _.identity), // filter out empty properties
                 create: mug.p.useCreate || false,
                 close: mug.p.useClose || false,

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -203,6 +203,7 @@ describe("The SaveToCase module", function() {
             save: {
                 "/data/group/save_to_case_in_group": {
                     "case_type": "child",
+                    "case_id": "'case_id_in_group'",
                     "close": false,
                     "create": false,
                     "properties": [
@@ -212,6 +213,7 @@ describe("The SaveToCase module", function() {
                 },
                 "/data/save_to_case_create": {
                     "case_type": "mother",
+                    "case_id": "'case_id_normal'",
                     "close": false,
                     "create": true,
                     "properties": [
@@ -223,6 +225,7 @@ describe("The SaveToCase module", function() {
                 },
                 "/data/save_to_case_close": {
                     "case_type": "close_case",
+                    "case_id": "'case_id_close'",
                     "close": true,
                     "create": false,
                     "properties": []


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
No user-facing changes. This adds `case_id` to the case metadata JSON that Vellum sends to HQ, enabling a future HQ change to infer `case_type` from `case_id` for non-create save-to-case actions.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19457

This data is sent to HQ via `caseReferences()` JSON and consumed by HQ's `CaseSaveReference` model.

A follow-up HQ PR will add a `case_id` field to `CaseSaveReference` and use it to infer `case_type` for non-create save-to-case questions. 

HQ's `CaseSaveReference` is a `DocumentSchema` with `_allow_dynamic_properties = False`, so the extra `case_id` field is silently dropped until the HQ-side field is added. This change is safe to merge independently.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`VELLUM_SAVE_TO_CASE`
## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
This adds one field to a JSON payload. On the HQ side, `CaseSaveReference` has `_allow_dynamic_properties = False`, meaning the unknown `case_id` field is silently dropped during `wrap()`. No existing behavior changes until the HQ-side PR adds the corresponding field.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
Updated the "should provide case references to the logic manager" test to include `case_id` in the expected `caseReferences()` output for all three save-to-case entries in `logic_test.xml`.

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
