### PR TITLE
Turn Case Type into a required dropdown populated with existing case types

### DIFF
--- a/src/less-style/question-props.less
+++ b/src/less-style/question-props.less
@@ -93,6 +93,12 @@
                     margin: 10px 0 0 0;
                 }
 
+                .fd-mode-toggle-link {
+                    display: inline-block;
+                    margin-top: 4px;
+                    font-size: @fontSizeSmall;
+                }
+
                 // Blocks of itext, like when adding multimedia or advanced > other content
                 .itext-block-container {
                     .btn-danger {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -157,6 +157,14 @@ function caseTypeDropdownWidget(mug, opts) {
 
     function initSelect2() {
         var value = widget.input.val();
+        // When Create is turned off, remove custom case types that
+        // aren't in the data dictionary — they were only valid for creation.
+        if (!createsCase(mug) && value && !_.contains(existingCaseTypes, value)) {
+            widget.input.find('option[value="' + value + '"]').remove();
+            widget.input.val('');
+            value = '';
+            mug.p.case_type = '';
+        }
         if (widget.input.data('select2')) {
             widget.input.select2('destroy');
         }
@@ -336,7 +344,7 @@ var slugToProp = {
                     if (!val && createsCase(mug)) {
                         return gettext("Case Type is required");
                     }
-                    if (!CASE_TYPE_REGEX.test(val)) {
+                    if (val && !CASE_TYPE_REGEX.test(val)) {
                         return gettext("Case types can only include the characters a-z, 0-9, '-' and '_'");
                     }
                     if (val === 'commcare-user') {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -353,8 +353,12 @@ var slugToProp = {
                     if (mug.p.case_type || !createsCase(mug)) {
                         return 'pass';
                     }
-                    if (!mug.p.caseTypeXPath) {
+                    var val = mug.p.caseTypeXPath;
+                    if (!val) {
                         return gettext("Case Type is required");
+                    }
+                    if (CASE_TYPE_REGEX.test(val)) {
+                        return gettext("This looks like a literal value. Use the dropdown instead, or wrap it in quotes like '" + val + "'.");
                     }
                     return 'pass';
                 },

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -148,10 +148,7 @@ function caseTypeDropdownWidget(mug, opts) {
         if (val && /\s/.test(val)) {
             widget.setValue(val.replace(/\s/g, '_'));
         }
-        // User chose a value directly; drop any stashed xpath reference
-        mug.p.caseTypeXPath = null;
         super_updateValue();
-        // Re-validate the xpath field since its validation depends on case_type
         mug.validate('caseTypeXPath');
     };
 

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -373,7 +373,15 @@ var slugToProp = {
 
             var actions = [];
             if (createsCase(mug)) {
-                actions.push(simpleNode('create', makeColumns(mug.p.createProperty)));
+                // Include a case_type column in the create action subtree when mug.p.case_type
+                // is set so that the tree shape matches legacy forms that has case_type
+                // under create section alongside other properties.
+                var createProps = {};
+                if (mug.p.case_type) {
+                    createProps.case_type = {};
+                }
+                _.extend(createProps, mug.p.createProperty);
+                actions.push(simpleNode('create', makeColumns(createProps)));
             }
 
             if (updatesCase(mug)) {
@@ -422,6 +430,14 @@ var slugToProp = {
                     ret = ret.concat({
                         nodeset: mug.absolutePath + "/case/@case_id",
                         calculate: mug.p.case_id
+                    });
+                }
+                // Emit /case/create/case_type from mug.p.case_type so XForm matches legacy
+                // save-to-case layout (create subtree) while the UI keeps Case Type top-level.
+                if (mug.p.case_type) {
+                    ret.push({
+                        nodeset: mug.absolutePath + "/case/create/case_type",
+                        calculate: mug.p.case_type
                     });
                 }
                 ret = ret.concat(generateBinds('create', mug.p.createProperty));
@@ -634,11 +650,20 @@ $.vellum.plugin("saveToCase", {}, {
                 if (mug && mug.__className === "SaveToCase") {
                     if (matchRet[2]) {
                         var prop = matchRet[2],
-                            pKey = {
+                            action = matchRet[1];
+
+                        // Skip create/case_type bind — case_type is set by parseDataNode
+                        // from vellum:case_type. We still consume the bind to prevent it
+                        // from going into createProperty.
+                        if (action === "create" && prop === "case_type") {
+                            return;
+                        }
+
+                        var pKey = {
                                 create: "createProperty",
                                 update: "updateProperty",
                                 index: "indexProperty",
-                            }[matchRet[1]];
+                            }[action];
 
                         if (!mug.p[pKey]) {
                             mug.p[pKey] = {};

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -150,7 +150,7 @@ function caseTypeDropdownWidget(mug, opts) {
     // Keep parsed Case Type values visible in the dropdown even when they are
     // not present in configured case type options.
     if (mug.p.case_type && !_.contains(existingCaseTypes, mug.p.case_type)) {
-        existingCaseTypes = existingCaseTypes.concat([mug.p.case_type]);
+        existingCaseTypes.push(mug.p.case_type);
     }
     opts.defaultOptions = existingCaseTypes.map(function (ct) {
         return { text: ct, value: ct };

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -145,6 +145,8 @@ var propertyWidget = function (mug, options) {
         return widget;
     };
 
+var CASE_TYPE_REGEX = /^[\w-]+$/;
+
 function caseTypeDropdownWidget(mug, opts) {
     var existingCaseTypes = opts.vellum.data.saveToCase?.existingCaseTypes || [];
     // Keep parsed Case Type values visible in the dropdown even when they are
@@ -243,6 +245,21 @@ var slugToProp = {
                 visibility: 'visible',
                 presence: 'required',
                 widget: caseTypeDropdownWidget,
+                validationFunc: function (mug) {
+                    var val = mug.p.case_type;
+                    if (val && !CASE_TYPE_REGEX.test(val)) {
+                        return gettext("Case types can only include the characters a-z, 0-9, '-' and '_'");
+                    }
+                    if (val === 'commcare-user') {
+                        if (createsCase(mug) || closesCase(mug) || indexesCase(mug)) {
+                            return gettext("'commcare-user' cases can only be updated, not created, closed, or linked");
+                        }
+                    }
+                    if (val === 'user-owner-mapping-case') {
+                        return gettext("This is a reserved case type. Please choose another name.");
+                    }
+                    return 'pass';
+                },
             },
             "case_id": {
                 lstring: gettext("Case ID"),

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -673,10 +673,14 @@ $.vellum.plugin("saveToCase", {}, {
                         var prop = matchRet[2],
                             action = matchRet[1];
 
-                        // Skip create/case_type bind — case_type is set by parseDataNode
-                        // from vellum:case_type. We still consume the bind to prevent it
-                        // from going into createProperty.
+                        // Consume /case/create/case_type into the top-level Case Type field.
+                        // Prefer a non-empty bind over vellum:case_type
                         if (action === "create" && prop === "case_type") {
+                            var caseTypeBindValue = el.xmlAttr("calculate") || '',
+                                stripped = caseTypeBindValue.replace(/^'(.*)'$/, '$1');
+                            if (stripped) {
+                                mug.p.case_type = stripped;
+                            }
                             return;
                         }
 

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -550,6 +550,12 @@ var slugToProp = {
     };
 
 $.vellum.plugin("saveToCase", {}, {
+    init: function () {
+        var opts = this.opts().saveToCase || {};
+        this.data.saveToCase = {
+            existingCaseTypes: opts.existingCaseTypes || [],
+        };
+    },
     getAdvancedQuestions: function () {
         return this.__callOld().concat(["SaveToCase"]);
     },

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -151,6 +151,8 @@ function caseTypeDropdownWidget(mug, opts) {
         // User chose a value directly; drop any stashed xpath reference
         mug.p.caseTypeXPath = null;
         super_updateValue();
+        // Re-validate the xpath field since its validation depends on case_type
+        mug.validate('caseTypeXPath');
     };
 
     function initSelect2() {
@@ -210,6 +212,8 @@ function caseTypeXpathWidget(mug, opts) {
         var val = $.trim(widget.getValue());
         mug.p.caseTypeXPath = val || null;
         super_updateValue();
+        // Re-validate the dropdown since its validation depends on caseTypeXPath
+        mug.validate('case_type');
     };
 
     widget.postRender = function () {
@@ -252,6 +256,8 @@ function switchToXpathMode(mug, dropdownWidget, $dropdownRow) {
 
     $dropdownRow.hide();
     $xpathRow.show();
+    mug.validate('case_type');
+    mug.validate('caseTypeXPath');
 }
 
 function switchToDropdownMode(mug, xpathWidget, $xpathRow) {
@@ -277,6 +283,8 @@ function switchToDropdownMode(mug, xpathWidget, $xpathRow) {
 
     $xpathRow.hide();
     $dropdownRow.show();
+    mug.validate('case_type');
+    mug.validate('caseTypeXPath');
 }
 
 var slugToProp = {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -841,8 +841,9 @@ $.vellum.plugin("saveToCase", {}, {
                                 stripped = caseTypeBindValue.replace(/^(['"])(.*)\1$/, '$2');
                             if (stripped && stripped === caseTypeBindValue) {
                                 // No quotes stripped — xpath expression;
-                                // stash for resolution in handleMugParseFinish
+                                // show in xpath field, override vellum:case_type
                                 mug.p.caseTypeXPath = caseTypeBindValue;
+                                mug.p.case_type = '';
                             } else if (stripped) {
                                 // Route create/case_type to the Case Type dropdown.
                                 mug.p.case_type = stripped;

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -33,15 +33,15 @@ function usesCases(mug) {
 
 // Try to resolve an xpath expression to a string literal.
 // Handles:
-//   - Quoted strings:  'household'  →  household
+//   - Quoted strings:  'household' or "household"  →  household
 //   - Path references:  /data/q     →  follow the question's calculateAttr
 function resolveToLiteral(form, expr) {
     if (!expr) {
         return null;
     }
-    var quotedMatch = expr.match(/^'([^']*)'$/);
+    var quotedMatch = expr.match(/^(['"])([^'"]*)\1$/);
     if (quotedMatch) {
-        return quotedMatch[1] || null;
+        return quotedMatch[2] || null;
     }
     var refMug = form.getMugByPath(expr);
     if (refMug && refMug.p.calculateAttr) {
@@ -760,7 +760,7 @@ $.vellum.plugin("saveToCase", {}, {
 
                         if (action === "create" && prop === "case_type") {
                             var caseTypeBindValue = el.xmlAttr("calculate") || '',
-                                stripped = caseTypeBindValue.replace(/^'(.*)'$/, '$1');
+                                stripped = caseTypeBindValue.replace(/^(['"])(.*)\1$/, '$2');
                             if (stripped && stripped === caseTypeBindValue) {
                                 // No quotes stripped — xpath expression;
                                 // stash for resolution in handleMugParseFinish

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -172,6 +172,13 @@ function caseTypeDropdownWidget(mug, opts) {
 
     widget.postRender = function () {
         initSelect2();
+        var $dropdownRow = widget.input.closest('.widget');
+        addModeToggle($dropdownRow, gettext('Use an xpath expression'), function () {
+            switchToXpathMode(mug, widget, $dropdownRow);
+        });
+        if (mug.p._caseTypeCalc && !mug.p.case_type) {
+            $dropdownRow.hide();
+        }
         mug.on('property-changed', function (e) {
             if (e.property === 'useCreate') {
                 initSelect2();
@@ -196,7 +203,68 @@ function caseTypeXpathWidget(mug, opts) {
         super_updateValue();
     };
 
+    widget.postRender = function () {
+        var $xpathRow = widget.input.closest('.widget');
+        addModeToggle($xpathRow, gettext('Use a dropdown'), function () {
+            switchToDropdownMode(mug, widget, $xpathRow);
+        });
+        if (!mug.p._caseTypeCalc || mug.p.case_type) {
+            $xpathRow.hide();
+        }
+    };
     return widget;
+}
+
+function addModeToggle($row, text, onClick) {
+    var $link = $('<a href="#" style="font-size:12px;margin-top:4px;display:inline-block;" />')
+        .text(text)
+        .on('click', function (e) {
+            e.preventDefault();
+            onClick();
+        });
+    $row.find('.controls .messages').before($link);
+}
+
+function switchToXpathMode(mug, dropdownWidget, $dropdownRow) {
+    // Save current dropdown value for later restoration
+    mug.p._savedCaseType = mug.p.case_type;
+    mug.p.case_type = '';
+    dropdownWidget.setValue('');
+
+    // Restore previously saved xpath value if any
+    var $xpathRow = $dropdownRow.next('.widget'),
+        xpathWidget = $xpathRow.data('vellum_widget');
+    if (mug.p._savedCaseTypeCalc && xpathWidget) {
+        mug.p._caseTypeCalc = mug.p._savedCaseTypeCalc;
+        xpathWidget.setValue(mug.p._savedCaseTypeCalc);
+        mug.p._savedCaseTypeCalc = null;
+    }
+
+    $dropdownRow.hide();
+    $xpathRow.show();
+}
+
+function switchToDropdownMode(mug, xpathWidget, $xpathRow) {
+    // Save current xpath value for later restoration
+    mug.p._savedCaseTypeCalc = mug.p._caseTypeCalc;
+    mug.p._caseTypeCalc = null;
+    xpathWidget.setValue('');
+
+    // Restore previously saved dropdown value if any
+    if (mug.p._savedCaseType) {
+        mug.p.case_type = mug.p._savedCaseType;
+        mug.p._savedCaseType = null;
+    }
+
+    var $dropdownRow = $xpathRow.prev('.widget'),
+        dropdownWidget = $dropdownRow.data('vellum_widget');
+    if (dropdownWidget) {
+        dropdownWidget.setValue(mug.p.case_type);
+        dropdownWidget.handleChange();
+    }
+
+    $xpathRow.hide();
+    $dropdownRow.show();
 }
 
 var slugToProp = {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -233,7 +233,7 @@ function caseTypeXpathWidget(mug, opts) {
 }
 
 function addModeToggle($row, text, onClick) {
-    var $link = $('<a href="#" style="font-size:12px;margin-top:4px;display:inline-block;" />')
+    var $link = $('<a href="#" class="fd-mode-toggle-link" />')
         .text(text)
         .on('click', function (e) {
             e.preventDefault();

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -161,7 +161,9 @@ function caseTypeDropdownWidget(mug, opts) {
         widget.input.select2({
             tags: createsCase(mug),
             allowClear: true,
-            placeholder: gettext('Select a case type or create a new one'),
+            placeholder: createsCase(mug)
+                ? gettext('Select a case type or create a new one')
+                : gettext('Select a case type'),
             createTag: function (params) {
                 var term = params.term.replace(/\s/g, '_');
                 return { id: term, text: term };

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -131,6 +131,7 @@ function caseTypeDropdownWidget(mug, opts) {
     opts.defaultOptions = existingCaseTypes.map(function (ct) {
         return { text: ct, value: ct };
     });
+    opts.noCustom = true;
     var widget = widgets.dropdown(mug, opts);
     widget.postRender = function () {
         widget.input.select2({

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -168,9 +168,7 @@ function caseTypeDropdownWidget(mug, opts) {
         widget.input.select2({
             tags: createsCase(mug),
             allowClear: true,
-            placeholder: createsCase(mug)
-                ? gettext('Select a case type or create a new one')
-                : gettext('Select a case type'),
+            placeholder: createsCase(mug) ? gettext('Select a case type or create a new one') : gettext('Select a case type'),
             createTag: function (params) {
                 var term = params.term.replace(/\s/g, '_');
                 return { id: term, text: term };

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -185,7 +185,7 @@ function caseTypeDropdownWidget(mug, opts) {
     widget.postRender = function () {
         initSelect2();
         var $dropdownRow = widget.input.closest('.widget'),
-            $toggleLink = addModeToggle($dropdownRow, gettext('Use an xpath expression'), function () {
+            $toggleLink = addModeToggle($dropdownRow, gettext('Select case type with XPath'), function () {
                 switchToXpathMode(mug, widget, $dropdownRow);
             });
         if (!createsCase(mug)) {
@@ -226,7 +226,7 @@ function caseTypeXpathWidget(mug, opts) {
 
     widget.postRender = function () {
         var $xpathRow = widget.input.closest('.widget');
-        addModeToggle($xpathRow, gettext('Use a dropdown'), function () {
+        addModeToggle($xpathRow, gettext('Select case type from a list'), function () {
             switchToDropdownMode(mug, widget, $xpathRow);
         });
         if (!createsCase(mug) || !mug.p.caseTypeXPath || mug.p.case_type) {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -126,6 +126,27 @@ var propertyWidget = function (mug, options) {
         return widget;
     };
 
+function caseTypeDropdownWidget(mug, opts) {
+    var existingCaseTypes = (opts.vellum.data.saveToCase || {}).existingCaseTypes || [];
+    opts.defaultOptions = existingCaseTypes.map(function (ct) {
+        return { text: ct, value: ct };
+    });
+    var widget = widgets.dropdown(mug, opts);
+    widget.postRender = function () {
+        widget.input.select2({
+            tags: true,
+            allowClear: true,
+            placeholder: '',
+        });
+        widget.input.on('remove', function () {
+            if (widget.input.data('select2')) {
+                widget.input.select2('destroy');
+            }
+        });
+    };
+    return widget;
+}
+
 var slugToProp = {
         create: "useCreate",
         update: "useUpdate",
@@ -165,8 +186,8 @@ var slugToProp = {
             "case_type": {
                 lstring: gettext("Case Type"),
                 visibility: 'visible',
-                presence: 'optional',
-                widget: widgets.text,
+                presence: 'required',
+                widget: caseTypeDropdownWidget,
             },
             "case_id": {
                 lstring: gettext("Case ID"),

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -127,7 +127,7 @@ var propertyWidget = function (mug, options) {
     };
 
 function caseTypeDropdownWidget(mug, opts) {
-    var existingCaseTypes = (opts.vellum.data.saveToCase || {}).existingCaseTypes || [];
+    var existingCaseTypes = opts.vellum.data.saveToCase?.existingCaseTypes || [];
     // Keep parsed Case Type values visible in the dropdown even when they are
     // not present in configured case type options.
     if (mug.p.case_type && !_.contains(existingCaseTypes, mug.p.case_type)) {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -149,7 +149,7 @@ function caseTypeDropdownWidget(mug, opts) {
             widget.setValue(val.replace(/\s/g, '_'));
         }
         // User chose a value directly; drop any stashed xpath reference
-        mug.p._caseTypeCalc = null;
+        mug.p.caseTypeXPath = null;
         super_updateValue();
     };
 
@@ -176,7 +176,7 @@ function caseTypeDropdownWidget(mug, opts) {
         addModeToggle($dropdownRow, gettext('Use an xpath expression'), function () {
             switchToXpathMode(mug, widget, $dropdownRow);
         });
-        if (mug.p._caseTypeCalc && !mug.p.case_type) {
+        if (mug.p.caseTypeXPath && !mug.p.case_type) {
             $dropdownRow.hide();
         }
         mug.on('property-changed', function (e) {
@@ -199,7 +199,7 @@ function caseTypeXpathWidget(mug, opts) {
     var super_updateValue = widget.updateValue;
     widget.updateValue = function () {
         var val = $.trim(widget.getValue());
-        mug.p._caseTypeCalc = val || null;
+        mug.p.caseTypeXPath = val || null;
         super_updateValue();
     };
 
@@ -208,7 +208,7 @@ function caseTypeXpathWidget(mug, opts) {
         addModeToggle($xpathRow, gettext('Use a dropdown'), function () {
             switchToDropdownMode(mug, widget, $xpathRow);
         });
-        if (!mug.p._caseTypeCalc || mug.p.case_type) {
+        if (!mug.p.caseTypeXPath || mug.p.case_type) {
             $xpathRow.hide();
         }
     };
@@ -234,10 +234,10 @@ function switchToXpathMode(mug, dropdownWidget, $dropdownRow) {
     // Restore previously saved xpath value if any
     var $xpathRow = $dropdownRow.next('.widget'),
         xpathWidget = $xpathRow.data('vellum_widget');
-    if (mug.p._savedCaseTypeCalc && xpathWidget) {
-        mug.p._caseTypeCalc = mug.p._savedCaseTypeCalc;
-        xpathWidget.setValue(mug.p._savedCaseTypeCalc);
-        mug.p._savedCaseTypeCalc = null;
+    if (mug.p._savedCaseTypeXPath && xpathWidget) {
+        mug.p.caseTypeXPath = mug.p._savedCaseTypeXPath;
+        xpathWidget.setValue(mug.p._savedCaseTypeXPath);
+        mug.p._savedCaseTypeXPath = null;
     }
 
     $dropdownRow.hide();
@@ -246,8 +246,8 @@ function switchToXpathMode(mug, dropdownWidget, $dropdownRow) {
 
 function switchToDropdownMode(mug, xpathWidget, $xpathRow) {
     // Save current xpath value for later restoration
-    mug.p._savedCaseTypeCalc = mug.p._caseTypeCalc;
-    mug.p._caseTypeCalc = null;
+    mug.p._savedCaseTypeXPath = mug.p.caseTypeXPath;
+    mug.p.caseTypeXPath = null;
     xpathWidget.setValue('');
 
     // Restore previously saved dropdown value if any
@@ -309,7 +309,7 @@ var slugToProp = {
                 presence: 'optional',
                 widget: caseTypeDropdownWidget,
                 validationFunc: function (mug) {
-                    if (mug.p._caseTypeCalc) {
+                    if (mug.p.caseTypeXPath) {
                         return 'pass';
                     }
                     var val = mug.p.case_type;
@@ -330,7 +330,7 @@ var slugToProp = {
                     return 'pass';
                 },
             },
-            "_caseTypeCalc": {
+            "caseTypeXPath": {
                 lstring: gettext("Case Type"),
                 visibility: 'visible',
                 presence: 'optional',
@@ -341,7 +341,7 @@ var slugToProp = {
                     if (mug.p.case_type) {
                         return 'pass';
                     }
-                    if (!mug.p._caseTypeCalc) {
+                    if (!mug.p.caseTypeXPath) {
                         return gettext("Case Type is required");
                     }
                     return 'pass';
@@ -553,7 +553,7 @@ var slugToProp = {
                 // is set so that the tree shape matches legacy forms that has case_type
                 // under create section alongside other properties.
                 var createProps = {};
-                if (mug.p.case_type || mug.p._caseTypeCalc) {
+                if (mug.p.case_type || mug.p.caseTypeXPath) {
                     createProps.case_type = {};
                 }
                 _.extend(createProps, mug.p.createProperty);
@@ -611,10 +611,10 @@ var slugToProp = {
                 // Emit /case/create/case_type bind.
                 // Use the original xpath reference if available,
                 // otherwise wrap the literal in single quotes.
-                if (mug.p.case_type || mug.p._caseTypeCalc) {
+                if (mug.p.case_type || mug.p.caseTypeXPath) {
                     ret.push({
                         nodeset: mug.absolutePath + "/case/create/case_type",
-                        calculate: mug.p._caseTypeCalc || "'" + mug.p.case_type + "'"
+                        calculate: mug.p.caseTypeXPath || "'" + mug.p.case_type + "'"
                     });
                 }
                 ret = ret.concat(generateBinds('create', mug.p.createProperty));
@@ -701,7 +701,7 @@ var slugToProp = {
             // case_type is now a dedicated field rather than a createProperty entry,
             // but we still include it in the properties list to keep the data
             // structure sent to HQ consistent with what it was before.
-            if (mug.p.useCreate && (mug.p.case_type || mug.p._caseTypeCalc)) {
+            if (mug.p.useCreate && (mug.p.case_type || mug.p.caseTypeXPath)) {
                 propertyNames.push("case_type");
             }
             return {
@@ -722,7 +722,7 @@ var slugToProp = {
                     "date_modified",
                     "user_id",
                     "case_type",
-                    "_caseTypeCalc",
+                    "caseTypeXPath",
                     "case_id",
                     "caseActions",
                 ],
@@ -842,7 +842,7 @@ $.vellum.plugin("saveToCase", {}, {
                             if (stripped && stripped === caseTypeBindValue) {
                                 // No quotes stripped — xpath expression;
                                 // stash for resolution in handleMugParseFinish
-                                mug.p._caseTypeCalc = caseTypeBindValue;
+                                mug.p.caseTypeXPath = caseTypeBindValue;
                             } else if (stripped) {
                                 // Route create/case_type to the Case Type dropdown.
                                 mug.p.case_type = stripped;

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -521,6 +521,12 @@ var slugToProp = {
                 _.keys(mug.p.createProperty || {}),
                 _.keys(mug.p.updateProperty || {})
             );
+            // case_type is now a dedicated field rather than a createProperty entry,
+            // but we still include it in the properties list to keep the data
+            // structure sent to HQ consistent with what it was before.
+            if (mug.p.useCreate && mug.p.case_type) {
+                propertyNames.push("case_type");
+            }
             return {
                 case_type: mug.p.case_type || '',
                 properties: _.filter(propertyNames, _.identity), // filter out empty properties

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -147,7 +147,7 @@ function caseTypeDropdownWidget(mug, opts) {
         widget.input.select2({
             tags: true,
             allowClear: true,
-            placeholder: '',
+            placeholder: gettext('Select a case type or create a new one'),
             createTag: function (params) {
                 var term = params.term.replace(/\s/g, '_');
                 return { id: term, text: term };

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -471,7 +471,7 @@ var slugToProp = {
                 if (mug.p.case_type) {
                     ret.push({
                         nodeset: mug.absolutePath + "/case/create/case_type",
-                        calculate: mug.p.case_type
+                        calculate: "'" + mug.p.case_type + "'"
                     });
                 }
                 ret = ret.concat(generateBinds('create', mug.p.createProperty));

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -148,9 +148,13 @@ function caseTypeDropdownWidget(mug, opts) {
         super_updateValue();
     };
 
-    widget.postRender = function () {
+    function initSelect2() {
+        var value = widget.input.val();
+        if (widget.input.data('select2')) {
+            widget.input.select2('destroy');
+        }
         widget.input.select2({
-            tags: true,
+            tags: createsCase(mug),
             allowClear: true,
             placeholder: gettext('Select a case type or create a new one'),
             createTag: function (params) {
@@ -158,6 +162,16 @@ function caseTypeDropdownWidget(mug, opts) {
                 return { id: term, text: term };
             },
         });
+        widget.input.val(value).trigger('change.select2');
+    }
+
+    widget.postRender = function () {
+        initSelect2();
+        mug.on('property-changed', function (e) {
+            if (e.property === 'useCreate') {
+                initSelect2();
+            }
+        }, null, 'teardown-mug-properties');
         widget.input.on('remove', function () {
             if (widget.input.data('select2')) {
                 widget.input.select2('destroy');

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -449,7 +449,7 @@ var slugToProp = {
                 // is set so that the tree shape matches legacy forms that has case_type
                 // under create section alongside other properties.
                 var createProps = {};
-                if (mug.p.case_type) {
+                if (mug.p.case_type || mug.p._caseTypeCalc) {
                     createProps.case_type = {};
                 }
                 _.extend(createProps, mug.p.createProperty);
@@ -507,7 +507,7 @@ var slugToProp = {
                 // Emit /case/create/case_type bind.
                 // Use the original xpath reference if available,
                 // otherwise wrap the literal in single quotes.
-                if (mug.p.case_type) {
+                if (mug.p.case_type || mug.p._caseTypeCalc) {
                     ret.push({
                         nodeset: mug.absolutePath + "/case/create/case_type",
                         calculate: mug.p._caseTypeCalc || "'" + mug.p.case_type + "'"
@@ -597,7 +597,7 @@ var slugToProp = {
             // case_type is now a dedicated field rather than a createProperty entry,
             // but we still include it in the properties list to keep the data
             // structure sent to HQ consistent with what it was before.
-            if (mug.p.useCreate && mug.p.case_type) {
+            if (mug.p.useCreate && (mug.p.case_type || mug.p._caseTypeCalc)) {
                 propertyNames.push("case_type");
             }
             return {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -31,6 +31,25 @@ function usesCases(mug) {
         indexesCase(mug);
 }
 
+// Try to resolve an xpath expression to a string literal.
+// Handles:
+//   - Quoted strings:  'household'  →  household
+//   - Path references:  /data/q     →  follow the question's calculateAttr
+function resolveToLiteral(form, expr) {
+    if (!expr) {
+        return null;
+    }
+    var quotedMatch = expr.match(/^'([^']*)'$/);
+    if (quotedMatch) {
+        return quotedMatch[1] || null;
+    }
+    var refMug = form.getMugByPath(expr);
+    if (refMug && refMug.p.calculateAttr) {
+        return resolveToLiteral(form, refMug.p.calculateAttr);
+    }
+    return null;
+}
+
 var propertyWidget = function (mug, options) {
         var widget = widgets.normal(mug, options),
             id = options.id,
@@ -145,6 +164,8 @@ function caseTypeDropdownWidget(mug, opts) {
         if (val && /\s/.test(val)) {
             widget.setValue(val.replace(/\s/g, '_'));
         }
+        // User chose a value directly; drop any stashed xpath reference
+        mug.p._caseTypeCalc = null;
         super_updateValue();
     };
 
@@ -466,12 +487,13 @@ var slugToProp = {
                         calculate: mug.p.case_id
                     });
                 }
-                // Emit /case/create/case_type from mug.p.case_type so XForm matches legacy
-                // save-to-case layout (create subtree) while the UI keeps Case Type top-level.
+                // Emit /case/create/case_type bind.
+                // Use the original xpath reference if available,
+                // otherwise wrap the literal in single quotes.
                 if (mug.p.case_type) {
                     ret.push({
                         nodeset: mug.absolutePath + "/case/create/case_type",
-                        calculate: "'" + mug.p.case_type + "'"
+                        calculate: mug.p._caseTypeCalc || "'" + mug.p.case_type + "'"
                     });
                 }
                 ret = ret.concat(generateBinds('create', mug.p.createProperty));
@@ -652,6 +674,15 @@ $.vellum.plugin("saveToCase", {}, {
                 return value === inner;
             });
         }
+        if (mug.p._caseTypeCalc) {
+            var resolved = resolveToLiteral(mug.form, mug.p._caseTypeCalc);
+            if (resolved) {
+                mug.p.case_type = resolved;
+            } else {
+                // drop the stashed xpath reference if it's not resolvable
+                mug.p._caseTypeCalc = null;
+            }
+        }
     },
     getMugToolbar: function (mug, multiselect) {
         var $toolbar = this.__callOld();
@@ -692,12 +723,15 @@ $.vellum.plugin("saveToCase", {}, {
                         var prop = matchRet[2],
                             action = matchRet[1];
 
-                        // Consume /case/create/case_type into the top-level Case Type field.
-                        // Prefer a non-empty bind over vellum:case_type
                         if (action === "create" && prop === "case_type") {
                             var caseTypeBindValue = el.xmlAttr("calculate") || '',
                                 stripped = caseTypeBindValue.replace(/^'(.*)'$/, '$1');
-                            if (stripped) {
+                            if (stripped && stripped === caseTypeBindValue) {
+                                // No quotes stripped — xpath expression;
+                                // stash for resolution in handleMugParseFinish
+                                mug.p._caseTypeCalc = caseTypeBindValue;
+                            } else if (stripped) {
+                                // Route create/case_type to the Case Type dropdown.
                                 mug.p.case_type = stripped;
                             }
                             return;

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -213,6 +213,7 @@ function caseTypeDropdownWidget(mug, opts) {
 }
 
 function caseTypeXpathWidget(mug, opts) {
+    opts.widget = widgets.xPath;
     var widget = widgets.xPath(mug, opts);
 
     var super_updateValue = widget.updateValue;

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -128,6 +128,11 @@ var propertyWidget = function (mug, options) {
 
 function caseTypeDropdownWidget(mug, opts) {
     var existingCaseTypes = (opts.vellum.data.saveToCase || {}).existingCaseTypes || [];
+    // Keep parsed Case Type values visible in the dropdown even when they are
+    // not present in configured case type options.
+    if (mug.p.case_type && !_.contains(existingCaseTypes, mug.p.case_type)) {
+        existingCaseTypes = existingCaseTypes.concat([mug.p.case_type]);
+    }
     opts.defaultOptions = existingCaseTypes.map(function (ct) {
         return { text: ct, value: ct };
     });

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -172,16 +172,23 @@ function caseTypeDropdownWidget(mug, opts) {
 
     widget.postRender = function () {
         initSelect2();
-        var $dropdownRow = widget.input.closest('.widget');
-        addModeToggle($dropdownRow, gettext('Use an xpath expression'), function () {
-            switchToXpathMode(mug, widget, $dropdownRow);
-        });
+        var $dropdownRow = widget.input.closest('.widget'),
+            $toggleLink = addModeToggle($dropdownRow, gettext('Use an xpath expression'), function () {
+                switchToXpathMode(mug, widget, $dropdownRow);
+            });
+        if (!createsCase(mug)) {
+            $toggleLink.hide();
+        }
         if (mug.p.caseTypeXPath && !mug.p.case_type) {
             $dropdownRow.hide();
         }
         mug.on('property-changed', function (e) {
             if (e.property === 'useCreate') {
                 initSelect2();
+                $toggleLink.toggle(createsCase(mug));
+                if (!createsCase(mug) && mug.p.caseTypeXPath) {
+                    switchToDropdownMode(mug, null, $dropdownRow.next('.widget'));
+                }
             }
         }, null, 'teardown-mug-properties');
         widget.input.on('remove', function () {
@@ -208,7 +215,7 @@ function caseTypeXpathWidget(mug, opts) {
         addModeToggle($xpathRow, gettext('Use a dropdown'), function () {
             switchToDropdownMode(mug, widget, $xpathRow);
         });
-        if (!mug.p.caseTypeXPath || mug.p.case_type) {
+        if (!createsCase(mug) || !mug.p.caseTypeXPath || mug.p.case_type) {
             $xpathRow.hide();
         }
     };
@@ -223,6 +230,7 @@ function addModeToggle($row, text, onClick) {
             onClick();
         });
     $row.find('.controls .messages').before($link);
+    return $link;
 }
 
 function switchToXpathMode(mug, dropdownWidget, $dropdownRow) {
@@ -248,7 +256,9 @@ function switchToDropdownMode(mug, xpathWidget, $xpathRow) {
     // Save current xpath value for later restoration
     mug.p._savedCaseTypeXPath = mug.p.caseTypeXPath;
     mug.p.caseTypeXPath = null;
-    xpathWidget.setValue('');
+    if (xpathWidget) {
+        xpathWidget.setValue('');
+    }
 
     // Restore previously saved dropdown value if any
     if (mug.p._savedCaseType) {
@@ -313,7 +323,7 @@ var slugToProp = {
                         return 'pass';
                     }
                     var val = mug.p.case_type;
-                    if (!val) {
+                    if (!val && createsCase(mug)) {
                         return gettext("Case Type is required");
                     }
                     if (!CASE_TYPE_REGEX.test(val)) {
@@ -338,7 +348,7 @@ var slugToProp = {
                 serialize: mugs.serializeXPath,
                 deserialize: mugs.deserializeXPath,
                 validationFunc: function (mug) {
-                    if (mug.p.case_type) {
+                    if (mug.p.case_type || !createsCase(mug)) {
                         return 'pass';
                     }
                     if (!mug.p.caseTypeXPath) {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -186,6 +186,19 @@ function caseTypeDropdownWidget(mug, opts) {
     return widget;
 }
 
+function caseTypeXpathWidget(mug, opts) {
+    var widget = widgets.xPath(mug, opts);
+
+    var super_updateValue = widget.updateValue;
+    widget.updateValue = function () {
+        var val = $.trim(widget.getValue());
+        mug.p._caseTypeCalc = val || null;
+        super_updateValue();
+    };
+
+    return widget;
+}
+
 var slugToProp = {
         create: "useCreate",
         update: "useUpdate",
@@ -225,11 +238,17 @@ var slugToProp = {
             "case_type": {
                 lstring: gettext("Case Type"),
                 visibility: 'visible',
-                presence: 'required',
+                presence: 'optional',
                 widget: caseTypeDropdownWidget,
                 validationFunc: function (mug) {
+                    if (mug.p._caseTypeCalc) {
+                        return 'pass';
+                    }
                     var val = mug.p.case_type;
-                    if (val && !CASE_TYPE_REGEX.test(val)) {
+                    if (!val) {
+                        return gettext("Case Type is required");
+                    }
+                    if (!CASE_TYPE_REGEX.test(val)) {
                         return gettext("Case types can only include the characters a-z, 0-9, '-' and '_'");
                     }
                     if (val === 'commcare-user') {
@@ -239,6 +258,23 @@ var slugToProp = {
                     }
                     if (val === 'user-owner-mapping-case') {
                         return gettext("This is a reserved case type. Please choose another name.");
+                    }
+                    return 'pass';
+                },
+            },
+            "_caseTypeCalc": {
+                lstring: gettext("Case Type"),
+                visibility: 'visible',
+                presence: 'optional',
+                widget: caseTypeXpathWidget,
+                serialize: mugs.serializeXPath,
+                deserialize: mugs.deserializeXPath,
+                validationFunc: function (mug) {
+                    if (mug.p.case_type) {
+                        return 'pass';
+                    }
+                    if (!mug.p._caseTypeCalc) {
+                        return gettext("Case Type is required");
                     }
                     return 'pass';
                 },
@@ -618,6 +654,7 @@ var slugToProp = {
                     "date_modified",
                     "user_id",
                     "case_type",
+                    "_caseTypeCalc",
                     "case_id",
                     "caseActions",
                 ],

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -31,24 +31,6 @@ function usesCases(mug) {
         indexesCase(mug);
 }
 
-// Try to resolve an xpath expression to a string literal.
-// Handles:
-//   - Quoted strings:  'household' or "household"  →  household
-//   - Path references:  /data/q     →  follow the question's calculateAttr
-function resolveToLiteral(form, expr) {
-    if (!expr) {
-        return null;
-    }
-    var quotedMatch = expr.match(/^(['"])([^'"]*)\1$/);
-    if (quotedMatch) {
-        return quotedMatch[2] || null;
-    }
-    var refMug = form.getMugByPath(expr);
-    if (refMug && refMug.p.calculateAttr) {
-        return resolveToLiteral(form, refMug.p.calculateAttr);
-    }
-    return null;
-}
 
 var propertyWidget = function (mug, options) {
         var widget = widgets.normal(mug, options),
@@ -708,15 +690,6 @@ $.vellum.plugin("saveToCase", {}, {
             mug.form.dropSetValues(function(inner) {
                 return value === inner;
             });
-        }
-        if (mug.p._caseTypeCalc) {
-            var resolved = resolveToLiteral(mug.form, mug.p._caseTypeCalc);
-            if (resolved) {
-                mug.p.case_type = resolved;
-            } else {
-                // drop the stashed xpath reference if it's not resolvable
-                mug.p._caseTypeCalc = null;
-            }
         }
     },
     getMugToolbar: function (mug, multiselect) {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -133,11 +133,25 @@ function caseTypeDropdownWidget(mug, opts) {
     });
     opts.noCustom = true;
     var widget = widgets.dropdown(mug, opts);
+
+    var super_updateValue = widget.updateValue;
+    widget.updateValue = function () {
+        var val = widget.getValue();
+        if (val && /\s/.test(val)) {
+            widget.setValue(val.replace(/\s/g, '_'));
+        }
+        super_updateValue();
+    };
+
     widget.postRender = function () {
         widget.input.select2({
             tags: true,
             allowClear: true,
             placeholder: '',
+            createTag: function (params) {
+                var term = params.term.replace(/\s/g, '_');
+                return { id: term, text: term };
+            },
         });
         widget.input.on('remove', function () {
             if (widget.input.data('select2')) {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -239,7 +239,7 @@ var slugToProp = {
                 validationFunc: function (mug) {
                     if (mug.p.useCreate) {
                         var props = _.without(_.keys(mug.p.createProperty), ""),
-                            required = ["case_type", "case_name"],
+                            required = ["case_name"],
                             optional = ["owner_id"],
                             legal = _.union(required, optional),
                             illegalProps = _.difference(props, legal),

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -329,6 +329,18 @@ describe("The SaveToCase module", function() {
             assert.notOk(mug.p._caseTypeCalc);
         });
 
+        it("should parse double-quoted case_type literal", function () {
+            util.loadXML(
+                LEGACY_CASE_TYPE_BIND_XML
+                    .replace(
+                        "calculate=\"'legacy_case_type_input'\"",
+                        'calculate="&quot;legacy_case_type_input&quot;"'
+                    )
+            );
+            var mug = util.getMug("question1");
+            assert.equal(mug.p.case_type, 'legacy_case_type_input');
+        });
+
         it("should not let empty create/case_type bind override vellum:case_type", function () {
             util.loadXML(
                 LEGACY_CASE_TYPE_BIND_XML

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -280,53 +280,51 @@ describe("The SaveToCase module", function() {
             );
         });
 
-        it("should use non-empty create/case_type bind when vellum:case_type is empty", function () {
+        it("should show dropdown when create/case_type bind is a literal", function () {
             util.loadXML(LEGACY_CASE_TYPE_BIND_XML);
             var mug = util.getMug("question1");
             assert.equal(mug.p.case_type, 'legacy_case_type_input');
-        });
-
-        it("should show parsed create/case_type bind value in the Case Type widget", function () {
-            util.loadXML(LEGACY_CASE_TYPE_BIND_XML);
+            assert.notOk(mug.p.caseTypeXPath);
             util.clickQuestion("question1");
-            assert.equal($("[name=property-case_type]").val(), "legacy_case_type_input");
+            var $dropdown = $("[name=property-case_type]");
+            assert.equal($dropdown.val(), "legacy_case_type_input");
+            assert.ok($dropdown.closest(".widget").is(":visible"), "dropdown row is visible");
+            assert.notOk(
+                $("[name=property-caseTypeXPath]").closest(".widget").is(":visible"),
+                "xpath case type row is hidden when literal is used"
+            );
         });
 
-        it("should prefer create/case_type bind when it differs from vellum:case_type", function () {
+        it("should prefer create/case_type bind over vellum:case_type for literals", function () {
             util.loadXML(LEGACY_CASE_TYPE_BIND_XML.replace('vellum:case_type=""', 'vellum:case_type="top_section_case_type"'));
             var mug = util.getMug("question1");
             assert.equal(mug.p.case_type, 'legacy_case_type_input');
         });
 
-        it("should resolve xpath case_type reference to a literal", function () {
+        it("should show xpath field when create/case_type bind is an xpath", function () {
             util.loadXML(XPATH_CASE_TYPE_XML);
             var mug = util.getMug("question1");
-            assert.equal(mug.p.case_type, "household");
+            assert.notOk(mug.p.case_type);
             assert.equal(mug.p.caseTypeXPath, "/data/case_type_val");
-            assert.equal(
-                mug.p.createProperty.case_type,
-                undefined
+            util.clickQuestion("question1");
+            var $xpath = $("[name=property-caseTypeXPath]");
+            assert.ok($xpath.closest(".widget").is(":visible"), "xpath row is visible");
+            assert.notOk(
+                $("[name=property-case_type]").closest(".widget").is(":visible"),
+                "dropdown row is hidden when xpath is used"
             );
+            var xpathWidget = util.getWidget("property-caseTypeXPath");
+            assert.equal(xpathWidget.getValue(), mug.p.caseTypeXPath, "xpath field should show create/case_type bind value");
         });
 
-        it("should preserve xpath reference in generated bind", function () {
-            util.loadXML(XPATH_CASE_TYPE_XML);
-            var xml = call("createXML"),
-                $xml = $(xml);
-            assert.equal(
-                $xml.find('bind[nodeset="/data/question1/case/create/case_type"]').attr('calculate'),
-                '/data/case_type_val'
-            );
-        });
-
-        it("should drop bare words without quotes as invalid xpath", function () {
+        it("should show xpath field for bare words so user can fix them", function () {
             util.loadXML(XPATH_CASE_TYPE_XML.replace(
                 "calculate=\"/data/case_type_val\"",
                 "calculate=\"worker_role\""
             ));
             var mug = util.getMug("question1");
             assert.notOk(mug.p.case_type);
-            assert.notOk(mug.p.caseTypeXPath);
+            assert.equal(mug.p.caseTypeXPath, "worker_role");
         });
 
         it("should parse double-quoted case_type literal", function () {

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -26,7 +26,7 @@ describe("The SaveToCase module", function() {
         util.loadXML(CREATE_PROPERTY_XML);
         var create = util.getMug("save_to_case"),
             props = create.p.createProperty;
-        assert.equal(props.case_type.calculate, "caseType");
+        assert.equal(create.p.case_type, "caseType");
         assert.equal(props.case_name.calculate, "/data/name");
         assert.equal(create.p.useCreate, true);
         assert.equal(props.owner_id.calculate, '/data/meta/userID');
@@ -122,8 +122,8 @@ describe("The SaveToCase module", function() {
             case_id: 'uuid()',
             user_id: 'uuid()',
             useCreate: true,
+            case_type: 'type',
             createProperty: {
-                'case_type': 'type',
                 'case_name': 'name'
             }
         });
@@ -148,10 +148,8 @@ describe("The SaveToCase module", function() {
             user_id: 'uuid()',
             useCreate: true,
         });
+        mug.p.case_type = 'type';
         mug.p.createProperty = {
-            'case_type': {
-                'calculate': 'type'
-            },
             'case_name': {
                 'calculate': 'name',
             },

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -8,6 +8,7 @@ import UPDATE_PROPERTY_XML from "static/saveToCase/update_property.xml";
 import INDEX_PROPERTY_XML from "static/saveToCase/index_property.xml";
 import CASE_TYPE_PROPERTY_XML from "static/saveToCase/case_type_property.xml";
 import CREATE_2_PROPERTY_XML from "static/saveToCase/create_2_property.xml";
+import LEGACY_CASE_TYPE_BIND_XML from "static/saveToCase/legacy_case_type_bind.xml";
 import LOGIC_TEST_XML from "static/saveToCase/logic_test.xml";
 import TWO_SAME_NAME_XML from "static/saveToCase/two-same-name.xml";
 
@@ -250,6 +251,31 @@ describe("The SaveToCase module", function() {
                 $xml.find('bind[nodeset="/data/stc/case/create/case_type"]').length,
                 0
             );
+        });
+
+        it("should use non-empty create/case_type bind when vellum:case_type is empty", function () {
+            util.loadXML(LEGACY_CASE_TYPE_BIND_XML);
+            var mug = util.getMug("question1");
+            assert.equal(mug.p.case_type, 'legacy_case_type_input');
+        });
+
+        it("should prefer create/case_type bind when it differs from vellum:case_type", function () {
+            util.loadXML(LEGACY_CASE_TYPE_BIND_XML.replace('vellum:case_type=""', 'vellum:case_type="top_section_case_type"'));
+            var mug = util.getMug("question1");
+            assert.equal(mug.p.case_type, 'legacy_case_type_input');
+        });
+
+        it("should not let empty create/case_type bind override vellum:case_type", function () {
+            util.loadXML(
+                LEGACY_CASE_TYPE_BIND_XML
+                    .replace('vellum:case_type=""', 'vellum:case_type="top_section_case_type"')
+                    .replace(
+                        'calculate="\'legacy_case_type_input\'"',
+                        'calculate=""'
+                    )
+            );
+            var mug = util.getMug("question1");
+            assert.equal(mug.p.case_type, 'top_section_case_type');
         });
     });
 

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -302,7 +302,7 @@ describe("The SaveToCase module", function() {
             util.loadXML(XPATH_CASE_TYPE_XML);
             var mug = util.getMug("question1");
             assert.equal(mug.p.case_type, "household");
-            assert.equal(mug.p._caseTypeCalc, "/data/case_type_val");
+            assert.equal(mug.p.caseTypeXPath, "/data/case_type_val");
             assert.equal(
                 mug.p.createProperty.case_type,
                 undefined
@@ -326,7 +326,7 @@ describe("The SaveToCase module", function() {
             ));
             var mug = util.getMug("question1");
             assert.notOk(mug.p.case_type);
-            assert.notOk(mug.p._caseTypeCalc);
+            assert.notOk(mug.p.caseTypeXPath);
         });
 
         it("should parse double-quoted case_type literal", function () {

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -259,6 +259,12 @@ describe("The SaveToCase module", function() {
             assert.equal(mug.p.case_type, 'legacy_case_type_input');
         });
 
+        it("should show parsed create/case_type bind value in the Case Type widget", function () {
+            util.loadXML(LEGACY_CASE_TYPE_BIND_XML);
+            util.clickQuestion("question1");
+            assert.equal($("[name=property-case_type]").val(), "legacy_case_type_input");
+        });
+
         it("should prefer create/case_type bind when it differs from vellum:case_type", function () {
             util.loadXML(LEGACY_CASE_TYPE_BIND_XML.replace('vellum:case_type=""', 'vellum:case_type="top_section_case_type"'));
             var mug = util.getMug("question1");

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -193,6 +193,66 @@ describe("The SaveToCase module", function() {
         assert.strictEqual(mug.spec.indexProperty.validationFunc(mug), "pass");
     });
 
+    describe("create/case_type backward compatibility", function () {
+        it("should generate create/case_type node and bind from top-section case_type", function () {
+            util.loadXML("");
+            util.addQuestion("SaveToCase", "stc", {
+                case_id: 'uuid()',
+                useCreate: true,
+                case_type: 'household',
+                createProperty: {
+                    'case_name': { 'calculate': 'name' },
+                }
+            });
+            var xml = call("createXML"),
+                $xml = $(xml);
+            assert.equal($xml.find('stc').xmlAttr('vellum:case_type'), 'household');
+            assert.equal($xml.find('create case_type').length, 1);
+            assert.equal(
+                $xml.find('bind[nodeset="/data/stc/case/create/case_type"]').attr('calculate'),
+                'household'
+            );
+        });
+
+        it("should not generate create/case_type node when case_type is empty", function () {
+            util.loadXML("");
+            util.addQuestion("SaveToCase", "stc", {
+                case_id: 'uuid()',
+                useCreate: true,
+                createProperty: {
+                    'case_name': { 'calculate': 'name' },
+                }
+            });
+            var xml = call("createXML"),
+                $xml = $(xml);
+            assert.equal($xml.find('create case_type').length, 0);
+            assert.equal(
+                $xml.find('bind[nodeset="/data/stc/case/create/case_type"]').length,
+                0
+            );
+        });
+
+        it("should not generate create/case_type for non-create actions", function () {
+            util.loadXML("");
+            util.addQuestion("SaveToCase", "stc", {
+                case_id: 'a-real-exisitng-case-id',
+                case_type: 'household',
+                useUpdate: true,
+                updateProperty: {
+                    'name': { 'calculate': '/data/name' },
+                }
+            });
+            var xml = call("createXML"),
+                $xml = $(xml);
+            assert.equal($xml.find('stc').xmlAttr('vellum:case_type'), 'household');
+            assert.equal($xml.find('create').length, 0);
+            assert.equal(
+                $xml.find('bind[nodeset="/data/stc/case/create/case_type"]').length,
+                0
+            );
+        });
+    });
+
     it("should provide case references to the logic manager", function () {
         var form = util.loadXML(LOGIC_TEST_XML),
             manager = form._logicManager;

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -9,6 +9,7 @@ import INDEX_PROPERTY_XML from "static/saveToCase/index_property.xml";
 import CASE_TYPE_PROPERTY_XML from "static/saveToCase/case_type_property.xml";
 import CREATE_2_PROPERTY_XML from "static/saveToCase/create_2_property.xml";
 import LEGACY_CASE_TYPE_BIND_XML from "static/saveToCase/legacy_case_type_bind.xml";
+import XPATH_CASE_TYPE_XML from "static/saveToCase/xpath_case_type.xml";
 import LOGIC_TEST_XML from "static/saveToCase/logic_test.xml";
 import TWO_SAME_NAME_XML from "static/saveToCase/two-same-name.xml";
 
@@ -295,6 +296,37 @@ describe("The SaveToCase module", function() {
             util.loadXML(LEGACY_CASE_TYPE_BIND_XML.replace('vellum:case_type=""', 'vellum:case_type="top_section_case_type"'));
             var mug = util.getMug("question1");
             assert.equal(mug.p.case_type, 'legacy_case_type_input');
+        });
+
+        it("should resolve xpath case_type reference to a literal", function () {
+            util.loadXML(XPATH_CASE_TYPE_XML);
+            var mug = util.getMug("question1");
+            assert.equal(mug.p.case_type, "household");
+            assert.equal(mug.p._caseTypeCalc, "/data/case_type_val");
+            assert.equal(
+                mug.p.createProperty.case_type,
+                undefined
+            );
+        });
+
+        it("should preserve xpath reference in generated bind", function () {
+            util.loadXML(XPATH_CASE_TYPE_XML);
+            var xml = call("createXML"),
+                $xml = $(xml);
+            assert.equal(
+                $xml.find('bind[nodeset="/data/question1/case/create/case_type"]').attr('calculate'),
+                '/data/case_type_val'
+            );
+        });
+
+        it("should drop bare words without quotes as invalid xpath", function () {
+            util.loadXML(XPATH_CASE_TYPE_XML.replace(
+                "calculate=\"/data/case_type_val\"",
+                "calculate=\"worker_role\""
+            ));
+            var mug = util.getMug("question1");
+            assert.notOk(mug.p.case_type);
+            assert.notOk(mug.p._caseTypeCalc);
         });
 
         it("should not let empty create/case_type bind override vellum:case_type", function () {

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -237,7 +237,7 @@ describe("The SaveToCase module", function() {
             assert.equal($xml.find('create case_type').length, 1);
             assert.equal(
                 $xml.find('bind[nodeset="/data/stc/case/create/case_type"]').attr('calculate'),
-                'household'
+                "'household'"
             );
         });
 

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -314,7 +314,11 @@ describe("The SaveToCase module", function() {
                 "dropdown row is hidden when xpath is used"
             );
             var xpathWidget = util.getWidget("property-caseTypeXPath");
-            assert.equal(xpathWidget.getValue(), mug.p.caseTypeXPath, "xpath field should show create/case_type bind value");
+            assert.equal(
+                xpathWidget.getValue(),
+                mug.form.normalizeHashtag(mug.p.caseTypeXPath),
+                "xpath field should show create/case_type bind value"
+            );
         });
 
         it("should show xpath field for bare words so user can fix them", function () {

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -343,6 +343,48 @@ describe("The SaveToCase module", function() {
             assert.equal(mug.p.case_type, 'legacy_case_type_input');
         });
 
+        it("should preserve values when switching between dropdown and xpath modes", function () {
+            util.loadXML("");
+            util.addQuestion("SaveToCase", "question1", {
+                case_id: 'uuid()',
+                useCreate: true,
+                case_type: 'household',
+            });
+            util.clickQuestion("question1");
+            var $dropdownRow = $("[name=property-case_type]").closest(".widget"),
+                $xpathRow = $("[name=property-caseTypeXPath]").closest(".widget"),
+                mug = util.getMug("question1");
+
+            // Start in dropdown mode
+            assert.equal(mug.p.case_type, 'household');
+            assert.ok($dropdownRow.is(":visible"), "dropdown visible");
+            assert.notOk($xpathRow.is(":visible"), "xpath hidden");
+
+            // Click "Use an xpath expression" to switch to xpath mode
+            $dropdownRow.find('.controls > a').trigger('click');
+            assert.notOk(mug.p.case_type, "case_type cleared");
+            assert.notOk($dropdownRow.is(":visible"), "dropdown hidden");
+            assert.ok($xpathRow.is(":visible"), "xpath visible");
+
+            // Enter a value in xpath field
+            var xpathWidget = $xpathRow.data('vellum_widget');
+            xpathWidget.setValue('/data/dynamic_type');
+            xpathWidget.handleChange();
+            assert.equal(mug.p.caseTypeXPath, '/data/dynamic_type');
+
+            // Click "Select case type from a list" to switch back to dropdown and verify dropdown is restored
+            $xpathRow.find('.controls > a').trigger('click');
+            assert.equal(mug.p.case_type, 'household', "dropdown value restored");
+            assert.notOk(mug.p.caseTypeXPath, "xpath cleared");
+            assert.ok($dropdownRow.is(":visible"), "dropdown visible again");
+            assert.notOk($xpathRow.is(":visible"), "xpath hidden again");
+
+            // Click "Use an xpath expression" again to verify xpath is restored
+            $dropdownRow.find('.controls > a').trigger('click');
+            assert.equal(mug.p.caseTypeXPath, '/data/dynamic_type', "xpath value restored");
+            assert.notOk(mug.p.case_type, "case_type cleared again");
+        });
+
         it("should not let empty create/case_type bind override vellum:case_type", function () {
             util.loadXML(
                 LEGACY_CASE_TYPE_BIND_XML

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -92,6 +92,32 @@ describe("The SaveToCase module", function() {
         util.assertXmlEqual(call("createXML"), CASE_TYPE_PROPERTY_XML);
     });
 
+    it("should only allow custom case types for create actions", function () {
+        util.loadXML("");
+        util.addQuestion("SaveToCase", "stc_update", {
+            case_id: 'a-real-exisitng-case-id',
+            case_type: 'household',
+            useUpdate: true,
+            updateProperty: {
+                'name': { 'calculate': '/data/name' },
+            }
+        });
+        util.addQuestion("SaveToCase", "stc_create", {
+            case_id: 'uuid()',
+            case_type: 'household',
+            useCreate: true,
+            createProperty: {
+                'case_name': { 'calculate': '/data/name' },
+            }
+        });
+
+        util.clickQuestion("stc_update");
+        assert.strictEqual($("[name=property-case_type]").data('select2').options.options.tags, false);
+
+        util.clickQuestion("stc_create");
+        assert.strictEqual($("[name=property-case_type]").data('select2').options.options.tags, true);
+    });
+
     it("should support two questions with same name", function () {
         util.loadXML(TWO_SAME_NAME_XML);
         var one = util.getMug("one/save"),

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -340,6 +340,8 @@ describe("The SaveToCase module", function() {
             );
             var mug = util.getMug("question1");
             assert.equal(mug.p.case_type, 'top_section_case_type');
+        });
+    });
     describe("case_id validation", function () {
         var mug;
         beforeEach(function () {

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -385,6 +385,25 @@ describe("The SaveToCase module", function() {
             assert.notOk(mug.p.case_type, "case_type cleared again");
         });
 
+        it("should switch to dropdown when Create is deselected while in xpath mode", function () {
+            util.loadXML(XPATH_CASE_TYPE_XML);
+            util.clickQuestion("question1");
+            var $dropdownRow = $("[name=property-case_type]").closest(".widget"),
+                $xpathRow = $("[name=property-caseTypeXPath]").closest(".widget"),
+                mug = util.getMug("question1");
+
+            // Starts in xpath mode
+            assert.ok(mug.p.caseTypeXPath);
+            assert.ok($xpathRow.is(":visible"), "xpath visible");
+            assert.notOk($dropdownRow.is(":visible"), "dropdown hidden");
+
+            // Deselect Create
+            mug.p.useCreate = false;
+            assert.notOk(mug.p.caseTypeXPath, "xpath cleared");
+            assert.ok($dropdownRow.is(":visible"), "dropdown visible after deselecting Create");
+            assert.notOk($xpathRow.is(":visible"), "xpath hidden after deselecting Create");
+        });
+
         it("should not let empty create/case_type bind override vellum:case_type", function () {
             util.loadXML(
                 LEGACY_CASE_TYPE_BIND_XML

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -300,9 +300,9 @@ describe("The SaveToCase module", function() {
                     "create": true,
                     "properties": [
                         "case_name",
-                        "case_type",
                         "p1",
-                        "p2"
+                        "p2",
+                        "case_type",
                     ]
                 },
                 "/data/save_to_case_close": {

--- a/tests/static/saveToCase/create_2_property.xml
+++ b/tests/static/saveToCase/create_2_property.xml
@@ -27,12 +27,12 @@
 				</data>
 			</instance>
 			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
-			<bind nodeset="/data/create1/case/create/case_type" calculate="caseType" />
+			<bind nodeset="/data/create1/case/create/case_type" calculate="'caseType'" />
 			<bind nodeset="/data/create1/case/create/case_name" vellum:calculate="#form/name" calculate="/data/name" />
 			<bind nodeset="/data/create1/case/create/owner_id" calculate="/data/meta/userID" />
 			<bind nodeset="/data/create1/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />
 			<bind nodeset="/data/create1/case/@user_id" calculate="/data/meta/userID" />
-			<bind nodeset="/data/create2/case/create/case_type" calculate="caseType" />
+			<bind nodeset="/data/create2/case/create/case_type" calculate="'caseType'" />
 			<bind nodeset="/data/create2/case/create/case_name" vellum:calculate="#form/name" calculate="/data/name" />
 			<bind nodeset="/data/create2/case/create/owner_id" calculate="/data/meta/userID" />
 			<bind nodeset="/data/create2/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />

--- a/tests/static/saveToCase/create_2_property.xml
+++ b/tests/static/saveToCase/create_2_property.xml
@@ -6,7 +6,7 @@
 			<instance>
 				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/E1B03643-109D-4DC6-9737-815E4401DE79" uiVersion="1" version="1" name="Untitled Form">
 					<name />
-					<create1 vellum:role="SaveToCase" vellum:case_type="" >
+					<create1 vellum:role="SaveToCase" vellum:case_type="caseType" >
 						<case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id="">
 							<create>
 								<case_type />
@@ -15,7 +15,7 @@
 							</create>
 						</case>
 					</create1>
-					<create2 vellum:role="SaveToCase" vellum:case_type="" >
+					<create2 vellum:role="SaveToCase" vellum:case_type="caseType" >
 						<case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id="">
 							<create>
 								<case_type />

--- a/tests/static/saveToCase/create_property.xml
+++ b/tests/static/saveToCase/create_property.xml
@@ -18,7 +18,7 @@
 				</data>
 			</instance>
 			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
-			<bind nodeset="/data/save_to_case/case/create/case_type" calculate="caseType" />
+			<bind nodeset="/data/save_to_case/case/create/case_type" calculate="'caseType'" />
 			<bind nodeset="/data/save_to_case/case/create/case_name" vellum:calculate="#form/name" calculate="/data/name" />
 			<bind nodeset="/data/save_to_case/case/create/owner_id" calculate="/data/meta/userID" />
 			<bind nodeset="/data/save_to_case/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />

--- a/tests/static/saveToCase/create_property.xml
+++ b/tests/static/saveToCase/create_property.xml
@@ -6,7 +6,7 @@
 			<instance>
 				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/E1B03643-109D-4DC6-9737-815E4401DE79" uiVersion="1" version="1" name="Untitled Form">
 					<name />
-					<save_to_case vellum:role="SaveToCase" vellum:case_type="" >
+					<save_to_case vellum:role="SaveToCase" vellum:case_type="caseType" >
 						<case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id="">
 							<create>
 								<case_type />

--- a/tests/static/saveToCase/legacy_case_type_bind.xml
+++ b/tests/static/saveToCase/legacy_case_type_bind.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Survey</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/480B3F3D-82BD-4320-9FAF-705F453D1828" uiVersion="1" version="1" name="Survey">
+					<name />
+					<question1 vellum:case_type="" vellum:role="SaveToCase">
+						<case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id="">
+							<create>
+								<case_type />
+								<case_name />
+							</create>
+						</case>
+					</question1>
+				</data>
+			</instance>
+			<instance src="jr://instance/session" id="commcaresession" />
+			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
+			<bind nodeset="/data/question1/case/create/case_name" vellum:calculate="#form/name" calculate="/data/name" />
+			<bind nodeset="/data/question1/case/create/case_type" calculate="'legacy_case_type_input'" />
+			<bind nodeset="/data/question1/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />
+			<bind nodeset="/data/question1/case/@user_id" calculate="instance('commcaresession')/session/context/userid" />
+			<setvalue event="xforms-ready" ref="/data/question1/case/@case_id" value="uuid()" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="name-label">
+						<value>Name</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input vellum:ref="#form/name" ref="/data/name">
+			<label ref="jr:itext('name-label')" />
+		</input>
+	</h:body>
+</h:html>

--- a/tests/static/saveToCase/xpath_case_type.xml
+++ b/tests/static/saveToCase/xpath_case_type.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/480B3F3D-82BD-4320-9FAF-705F453D1828" uiVersion="1" version="1" name="Untitled Form">
+					<name />
+					<case_type_val />
+					<question1 vellum:role="SaveToCase" vellum:case_type="" >
+						<case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id="">
+							<create>
+								<case_name />
+								<case_type />
+							</create>
+						</case>
+					</question1>
+				</data>
+			</instance>
+			<instance src="jr://instance/session" id="commcaresession" />
+			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
+			<bind vellum:nodeset="#form/case_type_val" nodeset="/data/case_type_val" calculate="'household'" />
+			<bind nodeset="/data/question1/case/create/case_name" vellum:calculate="#form/name" calculate="/data/name" />
+			<bind nodeset="/data/question1/case/create/case_type" calculate="/data/case_type_val" />
+			<bind nodeset="/data/question1/case/@date_modified" calculate="/data/meta/timeEnd" type="xsd:dateTime" />
+			<bind nodeset="/data/question1/case/@user_id" calculate="instance('commcaresession')/session/context/userid" />
+			<setvalue event="xforms-ready" ref="/data/question1/case/@case_id" value="uuid()" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="name-label">
+						<value>Name</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input vellum:ref="#form/name" ref="/data/name">
+			<label ref="jr:itext('name-label')" />
+		</input>
+	</h:body>
+</h:html>


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
The Case Type field is now a dual-mode widget: a dropdown for static case types, or an XPath field for dynamic case type expressions.

- Dropdown mode (default): Populated with existing case types from the data dictionary. Create actions allow typing new case types (spaces auto-converted to underscores). Input is validated, and reserved case types (`commcare-user` for non-update actions, `user-owner-mapping-case`) are rejected.

- XPath mode: A xpath widget supports dynamic expressions like `cond()` that compute case types at runtime. 

Toggle between modes via "Use an xpath expression" / "Use a dropdown" links below the field.

Behavior on load:

| create/case_type bind value | Mode shown | Bind on save |
|--------|--------|--------|
| 'household' (quoted literal) | Dropdown: household | 'household' |
| "household" (double-quoted) | Dropdown: household | 'household' |
| /data/case_type_val (xpath) | XPath: /data/case_type_val | /data/case_type_val |
| cond(...) (dynamic xpath) | XPath: cond(...) | cond(...) |
| worker_role (bare word) | XPath: worker_role (prompt user to fix) | worker_role | 
| empty | Dropdown: falls back to vellum:case_type | from dropdown

Mode switching:
- Switching saves the current value and restores it when switching back
- XPath mode is only available when Create action is active
- Custom case types created via tags are removed from dropdown options when Create is deselected

Before
<img width="1612" height="833" alt="Screenshot 2026-03-27 at 11 55 08 AM" src="https://github.com/user-attachments/assets/4235b10e-a2cc-42be-aec2-9651f764d7e3" />


After
https://github.com/user-attachments/assets/53e219f8-f8cc-42fe-85e6-4820c8be102d


The generated XML remains identical to before — no changes to the form structure.
 
## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19459

Upon investigation, ~137 out of 15,309 create action save to case questions with `create/case_type` use xpath expressions (not literals). These include dynamic patterns like `cond()` that compute case types based on form data. See https://docs.google.com/spreadsheets/d/1_8fXNNN1L9dda5PnugTwNC40ZpjTgq1MhoPYNGk1ceI/edit?gid=1491268561#gid=1491268561

Architecture — two spec properties, one UI slot:
- `case_type` (dropdown) — static case type string, stored in `vellum:case_type` and `create/case_type` bind as a quoted literal
- `caseTypeXPath` (xpath widget) — dynamic xpath expression, stored directly in `create/case_type` bind
- Only one is visible at a time; toggle links switch between them
- Validation is cross-linked: each field passes when the other has a value

Key changes:
- `parseBindElement`: Quoted literals (`'household'`) → `case_type` (dropdown). Non-quoted expressions → `caseTypeXPath` (xpath field), clears `case_type`
- `caseTypeDropdownWidget`: select2 dropdown with tags for Create, "Use an xpath expression" toggle link, removes custom tags when Create is deselected
- `caseTypeXpathWidget`: wraps widgets.xPath, "Use a dropdown" toggle link, validates bare words as likely literals
- `switchToXpathMode` / `switchToDropdownMode`: save/restore values when toggling, cross-validate both fields
- `getBindList` / `dataChildFilter` / `getCaseSaveData`: generate case_type from whichever field is active
- Case type validation: [\w-]+ regex, `commcare-user` restricted to update-only, `user-owner-mapping-case` fully reserved

[HQ change ](https://github.com/dimagi/commcare-hq/pull/37533) that passes `existingCaseTypes` to the `saveToCase` plugin options will be deployed independently before this — sending extra options that Vellum doesn't consume yet is harmless.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`VELLUM_SAVE_TO_CASE`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
- The generated XML is identical to before — only the UI for entering `case_type` changed
- Existing forms with literal case types load and save identically
- Existing forms with xpath expressions now display in the xpath field instead of being dropped — strictly better backward compatibility
- If an old form has different values for the top section's Case Type field and the Create section's Case Type property, the new form's top section's Case Type field will use the bind value from `/create/case_type` 
  
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->
 - Existing round-trip tests (create_property.xml, create_2_property.xml, logic_test.xml) verify XML is unchanged
 - New tests "create/case_type backward compatibility" added
### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->

- Load form with literal `create/case_type` → dropdown shown with value
- Load form with xpath `create/case_type` → xpath field shown with expression
- Toggle between modes → values saved and restored
- Create new case type, deselect Create → custom type removed from dropdown
- Type bare word in xpath field → validation warning about literal value
- Save in each mode → correct XML output
- `commcare-user` with Create → error; with Update only → allowed

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change