### PR TITLE
Hide Date Modified and User ID in collapsible advanced section

### DIFF
--- a/src/less-style/question-props.less
+++ b/src/less-style/question-props.less
@@ -121,6 +121,34 @@
                 }
             }
         }
+
+        .fd-question-fieldset[data-slug='advanced'] {
+            legend {
+                display: none;
+            }
+        }
+
+        .fd-collapse-toggle {
+            padding: 10px 0;
+            &:has(button.collapsed) {
+                margin-bottom: 20px;
+            }
+            button {
+                background: none;
+                border: none;
+                padding: 0;
+                color: @cc-brand-mid;
+                &:hover {
+                    color: darken(@cc-brand-mid, 10%);
+                }
+                &.collapsed .fd-collapse-hide {
+                    display: none;
+                }
+                &:not(.collapsed) .fd-collapse-show {
+                    display: none;
+                }
+            }
+        }
     }
 
     .fd-chips {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -499,12 +499,19 @@ var slugToProp = {
                 displayName: gettext("Basic"),
                 properties: [
                     "nodeID",
-                    "date_modified",
-                    "user_id",
                     "case_type",
                     "case_id",
                     "caseActions",
                 ],
+            },
+            {
+                slug: "advanced",
+                displayName: gettext("Advanced"),
+                properties: [
+                    "date_modified",
+                    "user_id",
+                ],
+                isCollapsed: true,
             },
             {
                 slug: "create",
@@ -582,6 +589,16 @@ $.vellum.plugin("saveToCase", {}, {
         types.normal.SaveToCase = util.extend(
             mugs.defaultOptions, saveToCaseMugOptions);
         return types;
+    },
+    displayMugProperties: function (mug) {
+        this.__callOld();
+        if (mug.__className !== "SaveToCase") {
+            return;
+        }
+        widgets.util.addCollapseToggle('advanced', {
+            showText: gettext("View Advanced"),
+            hideText: gettext("Hide Advanced"),
+        });
     },
     getSections: function (mug) {
         if (sectionData.hasOwnProperty(mug.__className)) {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -598,6 +598,7 @@ $.vellum.plugin("saveToCase", {}, {
         widgets.util.addCollapseToggle('advanced', {
             showText: gettext("View Advanced"),
             hideText: gettext("Hide Advanced"),
+            mug: mug,
         });
     },
     getSections: function (mug) {

--- a/src/templates/collapse_toggle.html
+++ b/src/templates/collapse_toggle.html
@@ -1,0 +1,7 @@
+<div class="fd-collapse-toggle">
+    <button type="button" class="collapsed" data-toggle="collapse" data-target="#<%-collapseId%>"
+            aria-expanded="false" aria-controls="<%-collapseId%>">
+        <span class="fd-collapse-show"><%-showText%> <i class="fa fa-chevron-down"></i></span>
+        <span class="fd-collapse-hide"><%-hideText%> <i class="fa fa-chevron-up"></i></span>
+    </button>
+</div>

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -1,3 +1,4 @@
+import collapse_toggle from "vellum/templates/collapse_toggle.html";
 import ui_element from "vellum/templates/ui_element.html";
 import widget_chips_template from "vellum/templates/widget_chips.html";
 import widget_control_keyvalue from "vellum/templates/widget_control_keyvalue.html";
@@ -932,6 +933,17 @@ function getWidget(input, vellum) {
     return null;
 }
 
+function addCollapseToggle(slug, options) {
+    var $section = $(".fd-question-fieldset[data-slug='" + slug + "']"),
+        collapseId = 'fd-collapse-' + slug;
+    $section.find('legend').hide();
+    $section.removeClass('hide');
+    $section.find('.fd-fieldset-content')
+        .attr('id', collapseId)
+        .addClass('collapse');
+    $section.before(collapse_toggle($.extend({collapseId: collapseId}, options)));
+}
+
 function setWidget($el, widget) {
     $el.data("vellum_widget", widget);
     return $el;
@@ -958,6 +970,7 @@ export default {
         setWidget: setWidget,
         getMessages: getMessages,
         getUIElementWithEditButton: getUIElementWithEditButton,
-        getUIElement: getUIElement
+        getUIElement: getUIElement,
+        addCollapseToggle: addCollapseToggle
     }
 };

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -935,13 +935,22 @@ function getWidget(input, vellum) {
 
 function addCollapseToggle(slug, options) {
     var $section = $(".fd-question-fieldset[data-slug='" + slug + "']"),
-        collapseId = 'fd-collapse-' + slug;
+        collapseId = 'fd-collapse-' + slug,
+        $content = $section.find('.fd-fieldset-content');
     $section.find('legend').hide();
     $section.removeClass('hide');
-    $section.find('.fd-fieldset-content')
-        .attr('id', collapseId)
-        .addClass('collapse');
+    $content.attr('id', collapseId).addClass('collapse');
     $section.before(collapse_toggle($.extend({collapseId: collapseId}, options)));
+
+    if (options.mug) {
+        var expandIfMessages = function () {
+            if ($content.find('.messages').children().length) {
+                $content.collapse('show');
+            }
+        };
+        options.mug.on("messages-changed", expandIfMessages, null, "teardown-mug-properties");
+        expandIfMessages();
+    }
 }
 
 function setWidget($el, widget) {

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -943,11 +943,11 @@ function addCollapseToggle(slug, options) {
     $section.before(collapse_toggle($.extend({collapseId: collapseId}, options)));
 
     if (options.mug) {
-        var expandIfMessages = function () {
+        function expandIfMessages() {
             if ($content.find('.messages').children().length) {
                 $content.collapse('show');
             }
-        };
+        }
         options.mug.on("messages-changed", expandIfMessages, null, "teardown-mug-properties");
         expandIfMessages();
     }


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
Move Date Modified and User ID fields into a collapsible "Advanced" section in the Save to Case question type.
- Fields are hidden by default behind a "View Advanced" / "Hide Advanced" toggle
- Section auto-expands if any field has a warning message
 
<img width="1001" height="707" alt="Screenshot 2026-03-28 at 10 55 42 PM" src="https://github.com/user-attachments/assets/1602f42d-5ed5-412d-ae52-e0ad5b601b65" />

<img width="1001" height="651" alt="Screenshot 2026-03-28 at 10 56 41 PM" src="https://github.com/user-attachments/assets/fe32e948-cf56-48ff-902f-8fa44e2206f2" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Ticket: https://dimagi.atlassian.net/browse/SAAS-19463

- Added a reusable `collapse_toggle.html` template using Bootstrap 3's native collapse component
- Added `widgets.util.addCollapseToggle(slug, options)` helper in `widgets.js` for wiring up any section as a B3 collapsible
- CSS uses B3's `.collapsed` class to toggle label/icon visibility — no JS event handlers needed
- Moved `date_modified` and `user_id` into a new "advanced" section in `sectionData`
## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`VELLUM_SAVE_TO_CASE`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Only affects the Save to Case question type UI layout — no data model changes.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->
- Manually verify the toggle shows/hides Date Modified and User ID
- Verify auto-expand when a validation message exists on either field

### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
