### PR TITLE
Fix case management diff to handle duplicate and modified mappings

### DIFF
--- a/src/caseDiff.js
+++ b/src/caseDiff.js
@@ -6,7 +6,6 @@ export function compareCaseMappings (baseline, incoming) {
     // the original with the incoming mappings to produce a diff.
     const additions = {};
     const deletions = {};
-    const updates = {};
     const allKeys = new Set([...Object.keys(baseline), ...Object.keys(incoming)]);
 
     allKeys.forEach(key => {
@@ -16,7 +15,8 @@ export function compareCaseMappings (baseline, incoming) {
                 if (!match) {
                     push(key, item, additions);
                 } else if (!_.isEqual(match, item)) {
-                    push(key, item, updates);
+                    push(key, match, deletions);
+                    push(key, item, additions);
                 }
             });
             baseline[key].forEach(item => {
@@ -41,9 +41,6 @@ export function compareCaseMappings (baseline, incoming) {
     }
     if (Object.keys(deletions).length) {
         diff.delete = deletions;
-    }
-    if (Object.keys(updates).length) {
-        diff.update = updates;
     }
     return diff;
 }

--- a/src/caseDiff.js
+++ b/src/caseDiff.js
@@ -12,7 +12,7 @@ export function compareCaseMappings (baseline, incoming) {
         if (Object.hasOwn(baseline, key) && Object.hasOwn(incoming, key)) {
             const cache = {};
             incoming[key].forEach(item => {
-                const num = countExactMataches(item, baseline[key], incoming[key], cache);
+                const num = countExactMatches(item, baseline[key], incoming[key], cache);
                 if (num === null || num > 0) {
                     push(key, item, additions);
                 } else if (num < 0) {
@@ -20,7 +20,7 @@ export function compareCaseMappings (baseline, incoming) {
                 }
             });
             baseline[key].forEach(item => {
-                const num = countExactMataches(item, baseline[key], incoming[key], cache);
+                const num = countExactMatches(item, baseline[key], incoming[key], cache);
                 if (num === null || num < 0) {
                     push(key, item, deletions);
                 }
@@ -61,8 +61,14 @@ function push(key, item, mapping) {
  * time this function is called. Once cached, the cached difference
  * (which remains zero once zero) is returned.
  */
-function countExactMataches(item, baseline, incoming, cache) {
-    const key = Object.keys(item).sort().map(k => `${k}=${item[k]}`).join(' ');
+function countExactMatches(item, baseline, incoming, cache) {
+    const key = Object.keys(item)
+        .sort()
+        .map(k => {
+            const v = item[k];
+            return `${k}:${typeof v}=${String(v)}`;
+        })
+        .join(' ');
     let num = cache[key];
     if (num === undefined) {
         const nBaseline = baseline.filter(q => _.isEqual(q, item)).length;

--- a/src/caseDiff.js
+++ b/src/caseDiff.js
@@ -10,17 +10,18 @@ export function compareCaseMappings (baseline, incoming) {
 
     allKeys.forEach(key => {
         if (Object.hasOwn(baseline, key) && Object.hasOwn(incoming, key)) {
+            const cache = {};
             incoming[key].forEach(item => {
-                const match = baseline[key].find(q => q.question_path === item.question_path);
-                if (!match) {
+                const num = countExactMataches(item, baseline[key], incoming[key], cache);
+                if (num === null || num > 0) {
                     push(key, item, additions);
-                } else if (!_.isEqual(match, item)) {
-                    push(key, match, deletions);
-                    push(key, item, additions);
+                } else if (num < 0) {
+                    push(key, item, deletions);
                 }
             });
             baseline[key].forEach(item => {
-                if (!incoming[key].find(q => q.question_path === item.question_path)) {
+                const num = countExactMataches(item, baseline[key], incoming[key], cache);
+                if (num === null || num < 0) {
                     push(key, item, deletions);
                 }
             });
@@ -48,4 +49,36 @@ export function compareCaseMappings (baseline, incoming) {
 function push(key, item, mapping) {
     mapping[key] = mapping[key] || [];
     mapping[key].push(item);
+}
+
+/**
+ * Count exact matches of item in baseline and incoming
+ *
+ * Returns null if there are no other exact matches.
+ * Returns a positive number if incoming has more exact matches.
+ * Returns a negative number if baseline has more exact matches.
+ * If not null, the difference is moved toward zero and cached each
+ * time this function is called. Once cached, the cached difference
+ * (which remains zero once zero) is returned.
+ */
+function countExactMataches(item, baseline, incoming, cache) {
+    const key = Object.keys(item).sort().map(k => `${k}=${item[k]}`).join(' ');
+    let num = cache[key];
+    if (num === undefined) {
+        const nBaseline = baseline.filter(q => _.isEqual(q, item)).length;
+        const nIncoming = incoming.filter(q => _.isEqual(q, item)).length;
+        if (nIncoming + nBaseline === 1) {
+            cache[key] = null;
+            return null;
+        }
+        num = cache[key] = nIncoming - nBaseline;
+    } else if (num === null) {
+        return null;
+    }
+    if (num > 0) {
+        cache[key]--;
+    } else if (num < 0) {
+        cache[key]++;
+    }
+    return num;
 }

--- a/tests/caseDiff.js
+++ b/tests/caseDiff.js
@@ -30,7 +30,8 @@ describe("The Case Management diff tool", function () {
         const baseline = {one: [{question_path: "/data/first"}]};
         const incoming = {one: [{question_path: "/data/first", update_mode: "edit"}]};
         assert.deepEqual(compareCaseMappings(baseline, incoming), {
-            update: {one: [{question_path: "/data/first", update_mode: "edit"}]}
+            delete: {one: [{question_path: "/data/first"}]},
+            add: {one: [{question_path: "/data/first", update_mode: "edit"}]},
         });
     });
 
@@ -38,7 +39,8 @@ describe("The Case Management diff tool", function () {
         const baseline = {one: [{question_path: "/data/first", update_mode: "edit"}]};
         const incoming = {one: [{question_path: "/data/first", update_mode: "always"}]};
         assert.deepEqual(compareCaseMappings(baseline, incoming), {
-            update: {one: [{question_path: "/data/first", update_mode: "always"}]}
+            delete: {one: [{question_path: "/data/first", update_mode: "edit"}]},
+            add: {one: [{question_path: "/data/first", update_mode: "always"}]},
         });
     });
 
@@ -46,7 +48,8 @@ describe("The Case Management diff tool", function () {
         const baseline = {one: [{question_path: "/data/first", update_mode: "edit"}]};
         const incoming = {one: [{question_path: "/data/first"}]};
         assert.deepEqual(compareCaseMappings(baseline, incoming), {
-            update: {one: [{question_path: "/data/first"}]}
+            delete: {one: [{question_path: "/data/first", update_mode: "edit"}]},
+            add: {one: [{question_path: "/data/first"}]},
         });
     });
 

--- a/tests/caseDiff.js
+++ b/tests/caseDiff.js
@@ -69,6 +69,125 @@ describe("The Case Management diff tool", function () {
         });
     });
 
+    it("should add duplicate question mapping", function () {
+        const baseline = {one: [{question_path: "/data/first"}]};
+        const incoming = {one: [{question_path: "/data/first"}, {question_path: "/data/first"}]};
+        assert.deepEqual(compareCaseMappings(baseline, incoming), {
+            add: {one: [{question_path: "/data/first"}]}
+        });
+    });
+
+    it("should delete duplicate question mapping", function () {
+        const baseline = {one: [{question_path: "/data/first"}, {question_path: "/data/first"}]};
+        const incoming = {one: [{question_path: "/data/first"}]};
+        assert.deepEqual(compareCaseMappings(baseline, incoming), {
+            delete: {one: [{question_path: "/data/first"}]}
+        });
+    });
+
+    it("should delete duplicate question mapping with differing update_modes", function () {
+        const baseline = {one: [
+            {question_path: "/data/first", update_mode: "always"},
+            {question_path: "/data/first", update_mode: "edit"},
+        ]};
+        const incoming = {one: [
+            {question_path: "/data/first", update_mode: "always"},
+        ]};
+        assert.deepEqual(compareCaseMappings(baseline, incoming), {
+            delete: {one: [{question_path: "/data/first", update_mode: "edit"}]}
+        });
+    });
+
+    it("should add duplicate question mapping with differing update_modes", function () {
+        const baseline = {one: [
+            {question_path: "/data/first", update_mode: "always"},
+        ]};
+        const incoming = {one: [
+            {question_path: "/data/first", update_mode: "always"},
+            {question_path: "/data/first", update_mode: "edit"},
+        ]};
+        assert.deepEqual(compareCaseMappings(baseline, incoming), {
+            add: {one: [{question_path: "/data/first", update_mode: "edit"}]}
+        });
+    });
+
+    it("should add triplicate question mapping", function () {
+        const baseline = {one: [{question_path: "/data/first"}]};
+        const incoming = {one: [
+            {question_path: "/data/first"},
+            {question_path: "/data/first"},
+            {question_path: "/data/first"},
+        ]};
+        assert.deepEqual(compareCaseMappings(baseline, incoming), {
+            add: {one: [{question_path: "/data/first"}, {question_path: "/data/first"}]}
+        });
+    });
+
+    it("should delete triplicate question mapping", function () {
+        const baseline = {one: [
+            {question_path: "/data/first"},
+            {question_path: "/data/first"},
+            {question_path: "/data/first"},
+        ]};
+        const incoming = {one: [{question_path: "/data/first"}]};
+        assert.deepEqual(compareCaseMappings(baseline, incoming), {
+            delete: {one: [{question_path: "/data/first"}, {question_path: "/data/first"}]}
+        });
+    });
+
+    it("should add triplicate question mapping v2", function () {
+        const baseline = {one: [
+            {question_path: "/data/first"},
+            {question_path: "/data/first"},
+        ]};
+        const incoming = {one: [
+            {question_path: "/data/first"},
+            {question_path: "/data/first"},
+            {question_path: "/data/first"},
+        ]};
+        assert.deepEqual(compareCaseMappings(baseline, incoming), {
+            add: {one: [{question_path: "/data/first"}]}
+        });
+    });
+
+    it("should delete triplicate question mapping v2", function () {
+        const baseline = {one: [
+            {question_path: "/data/first"},
+            {question_path: "/data/first"},
+            {question_path: "/data/first"},
+        ]};
+        const incoming = {one: [
+            {question_path: "/data/first"},
+            {question_path: "/data/first"},
+        ]};
+        assert.deepEqual(compareCaseMappings(baseline, incoming), {
+            delete: {one: [{question_path: "/data/first"}]}
+        });
+    });
+
+    it("should handle duplicate question mappings for different case properties", function () {
+        const baseline = {
+            one: [
+                {question_path: "/data/first"},
+                {question_path: "/data/first"},
+            ],
+            two: [
+                {question_path: "/data/first"},
+                {question_path: "/data/first"},
+            ],
+        };
+        const incoming = {
+            one: [{question_path: "/data/first"}],
+            two: [{question_path: "/data/first"}],
+        };
+        assert.deepEqual(compareCaseMappings(baseline, incoming), {
+            delete: {
+                one: [{question_path: "/data/first"}],
+                two: [{question_path: "/data/first"}],
+            }
+        });
+    });
+
     it("should return empty diff when mappings are identical", function () {
         const baseline = {one: [{question_path: "/data/first", update_mode: "edit"}]};
         const incoming = {one: [{question_path: "/data/first", update_mode: "edit"}]};


### PR DESCRIPTION
## Product Description
Fixes the case management diff algorithm to correctly handle duplicate question mappings and modified mappings. Previously, modifying a mapping (e.g., changing `update_mode`) produced an "update" operation that downstream consumers may not handle. Now, modifications are represented as a delete + add pair, which is more explicit and consistent. Additionally, duplicate mappings (the same question path mapped multiple times) are now diffed correctly, only adding or removing the exact surplus or deficit rather than misidentifying them.

## Technical Summary
- Removed the "updates" concept from the diff schema; modified mappings are now expressed as delete + add pairs. This change requires [dm/form-action-diff](https://github.com/dimagi/commcare-hq/pull/37543), specifically https://github.com/dimagi/commcare-hq/pull/37543/commits/4eda9cff6696f8e4887acd2abb6b2a7a0aced2f4, for proper interoperability with HQ. However, it will have no adverse affects on user who do not have the `FORMBUILDER_SAVE_TO_CASE` feature flag enabled if this is merged before the HQ branch. Update: the HQ branch has been merged.
- Replaced the `question_path`-based matching logic with an exact-match counting algorithm that correctly handles duplicates and tracks how many copies of each item exist in baseline vs. incoming. The new diff algorithm is also [used in HQ](https://github.com/dimagi/commcare-hq/pull/37543/commits/fd9fa9b6d1ecb4a5e97041527b84f44b61ca7236).

:blowfish: Review by commit.

## Feature Flag
`FORMBUILDER_SAVE_TO_CASE`

## Safety Assurance

### Safety story
The diff algorithm is purely functional with no side effects. The change is well-covered by new tests exercising duplicate, triplicate, and cross-property duplicate scenarios. All changed functionality is behind the feature flag.

### Automated test coverage
New test cases added covering: duplicate mappings, triplicate mappings, duplicates with differing `update_mode`, and duplicates across different case properties. Existing tests updated to reflect the new delete + add representation of modifications.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations
