### PR TITLE
Add "locked" widget to lock question properties

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -12,7 +12,6 @@ var corePlugins = [
         'core',
         'intents',
         'javaRosa',
-        'lock',
         'ignore',
         'uploader',
         'windowManager',

--- a/src/core.js
+++ b/src/core.js
@@ -1179,7 +1179,7 @@ fn.checkMove = function (srcId, srcType, dstId, dstType, position) {
     }
     if (position === 'inside') { position = 'into'; } // normalize for Vellum
 
-    var locked = !this.isMugPathMoveable(sourceMug.hashtagPath);
+    var locked = !this.isMugPathMoveable(sourceMug, sourceMug.hashtagPath);
     if (locked) {
         if (position === 'into' || position === 'last' || position === 'first') {
             return sourceMug.parentMug === targetMug;
@@ -2486,11 +2486,11 @@ fn.isMugRemoveable = function (mug, path) {
     return mug.options.isRemoveable;
 };
 
-fn.isPropertyLocked = function (mugPath, propertyPath) {
+fn.isPropertyLocked = function (mug, mugPath, propertyPath) {
     return false;
 };
 
-fn.isMugPathMoveable = function (mugPath) {
+fn.isMugPathMoveable = function (mug, mugPath) {
     return true;
 };
 

--- a/src/core.js
+++ b/src/core.js
@@ -1172,23 +1172,15 @@ fn.getRelativePosition = function (mug, position) {
 
 fn.checkMove = function (srcId, srcType, dstId, dstType, position) {
     var form = this.data.core.form,
-        targetMug = form.getMugByUFID(dstId),
         sourceMug = form.getMugByUFID(srcId);
     if (!sourceMug) {
         return false;
     }
-    if (position === 'inside') { position = 'into'; } // normalize for Vellum
-
-    var locked = !this.isMugPathMoveable(sourceMug);
-    if (locked) {
-        if (position === 'into' || position === 'last' || position === 'first') {
-            return sourceMug.parentMug === targetMug;
-        } else {
-            return sourceMug.parentMug === targetMug.parentMug;
-        }
+    if (this.isMugPathMoveable(sourceMug)) {
+        return true;
     }
 
-    return true;
+    return srcId === dstId;
 };
 
 fn.onFormChange = function (mug) {

--- a/src/core.js
+++ b/src/core.js
@@ -1179,7 +1179,7 @@ fn.checkMove = function (srcId, srcType, dstId, dstType, position) {
     }
     if (position === 'inside') { position = 'into'; } // normalize for Vellum
 
-    var locked = !this.isMugPathMoveable(sourceMug, sourceMug.hashtagPath);
+    var locked = !this.isMugPathMoveable(sourceMug);
     if (locked) {
         if (position === 'into' || position === 'last' || position === 'first') {
             return sourceMug.parentMug === targetMug;
@@ -2069,7 +2069,7 @@ fn.getMugToolbar = function (mug, multiselect) {
         $baseToolbar = $(question_toolbar({
             comment: multiselect ? '' : richText.sanitizeInput(mug.p.comment),
             isDeleteable: mugs && mugs.length && _.every(mugs, function (mug) {
-                return _this.isMugRemoveable(mug, mug.hashtagPath);
+                return _this.isMugRemoveable(mug);
             }),
             isCopyable: !multiselect && mug.options.isCopyable,
             sections: multiselect ? [] : _.chain(_this.getSections(mug))
@@ -2128,7 +2128,7 @@ fn.getQuestionTypeChanger = function (mug) {
         }
         return ret;
     };
-    var changeable = this.isMugTypeChangeable(mug, mug.hashtagPath);
+    var changeable = this.isMugTypeChangeable(mug);
 
     var $questionTypeChanger = $(question_type_changer({
         currentQuestionIcon: mug.getIcon(),
@@ -2482,19 +2482,19 @@ fn.getMugSpec = function () {
     return mugs.baseSpecs;
 };
 
-fn.isMugRemoveable = function (mug, path) {
+fn.isMugRemoveable = function (mug) {
     return mug.options.isRemoveable;
 };
 
-fn.isPropertyLocked = function (mug, mugPath, propertyPath) {
+fn.isPropertyLocked = function (mug, propertyPath) {
     return false;
 };
 
-fn.isMugPathMoveable = function (mug, mugPath) {
+fn.isMugPathMoveable = function (mug) {
     return true;
 };
 
-fn.isMugTypeChangeable = function (mug, mugPath) {
+fn.isMugTypeChangeable = function (mug) {
     return mug.options.isTypeChangeable;
 };
 

--- a/src/core.js
+++ b/src/core.js
@@ -1177,7 +1177,7 @@ fn.checkMove = function (srcId, srcType, dstId, dstType, position) {
         return false;
     }
     if (!this.isMugPathMoveable(sourceMug)) {
-        var srcParentId = sourceMug.parentMug ? sourceMug.parentMug.ufid : '#';
+        var srcParentId = sourceMug.parentMug?.ufid || '#';
         return srcParentId === dstId;
     }
     return true;

--- a/src/core.js
+++ b/src/core.js
@@ -1176,11 +1176,11 @@ fn.checkMove = function (srcId, srcType, dstId, dstType, position) {
     if (!sourceMug) {
         return false;
     }
-    if (this.isMugPathMoveable(sourceMug)) {
-        return true;
+    if (!this.isMugPathMoveable(sourceMug)) {
+        var srcParentId = sourceMug.parentMug ? sourceMug.parentMug.ufid : '#';
+        return srcParentId === dstId;
     }
-
-    return srcId === dstId;
+    return true;
 };
 
 fn.onFormChange = function (mug) {

--- a/src/javaRosa/itextBlock.js
+++ b/src/javaRosa/itextBlock.js
@@ -294,6 +294,12 @@ var itextConfigurableBlock = function (mug, options) {
             $(this).before(block.getDeleteFormButton($(this).data('formtype')));
         });
 
+        // these buttons don't have a widget to check isDisabled()
+        // instead, directly check if this property should be locked
+        if (mug.form.vellum.isPropertyLocked(mug, options.path)) {
+            $blockUI.find('.btn').addClass('disabled').css('pointerEvents', 'none');
+        }
+
         return $blockUI;
     };
 

--- a/src/javaRosa/itextWidget.js
+++ b/src/javaRosa/itextWidget.js
@@ -85,6 +85,10 @@ var iTextIDWidget = function (mug, options) {
             .addClass("col-sm-8")
             .after($autoBoxContainer);
 
+        if (widget.isDisabled()) {
+            $autoBoxContainer.find('input').prop('disabled', true);
+        }
+
         return $uiElem;
     };
 

--- a/src/lock.js
+++ b/src/lock.js
@@ -10,9 +10,9 @@ import "vellum/core";
 import _ from "underscore";
 import widgets from "vellum/widgets";
 
-const LOCKED_BIND_ATTR = "vellum:lock"
-const LOCKED_UNEDITABLE_MSG_KEY = "mug-locked-cannot-edit"
-const LOCKED_CHILDREN_MSG_KEY = "mug-has-locked-children"
+const LOCKED_BIND_ATTR = "vellum:lock";
+const LOCKED_UNEDITABLE_MSG_KEY = "mug-locked-cannot-edit";
+const LOCKED_CHILDREN_MSG_KEY = "mug-has-locked-children";
 
 $.vellum.plugin("lock", {}, {
     parseBindElement: function (form, el, path) {
@@ -26,8 +26,8 @@ $.vellum.plugin("lock", {}, {
                 const message = {
                     key: LOCKED_UNEDITABLE_MSG_KEY,
                     message: gettext(
-                            "This question is locked and can only be edited by a user with the locked "
-                            + "questions permission."
+                            "This question is locked and can only be edited by a user with the locked " +
+                            "questions permission."
                         ),
                     level: mug.INFO,
                 };
@@ -37,9 +37,7 @@ $.vellum.plugin("lock", {}, {
     },
     handleMugParseFinish: function (mug) {
         this.__callOld();
-        if (mug.parentMug
-            && mug.options.isControlOnly
-        ) {
+        if (mug.parentMug && mug.options.isControlOnly) {
             mug.p.set('locked', mug.parentMug.p.locked);
         }
     },
@@ -64,7 +62,7 @@ $.vellum.plugin("lock", {}, {
             visibility: isEditable ? 'visible' : 'visible_if_present',
             presence: 'optional',
             widget: widgets.checkbox,
-            enabled: function (mug) { return isEditable },
+            enabled: () => isEditable,
             help: gettext("A locked question cannot be edited, moved, or deleted from the form."),
             helpURL: "https://www.example.com",  // placeholder for public documentation
             serialize: () => {},

--- a/src/lock.js
+++ b/src/lock.js
@@ -38,9 +38,7 @@ $.vellum.plugin("lock", {}, {
     },
     handleMugParseFinish: function (mug) {
         this.__callOld();
-        if (mug.parentMug && mug.options.isControlOnly) {
-            mug.p.set('locked', mug.parentMug.p.locked);
-        }
+        this._setLockedFromParent(mug);
     },
     setTreeActions: function (mug) {
         if (mug.p.locked) {
@@ -75,7 +73,7 @@ $.vellum.plugin("lock", {}, {
                     delete mug.p.rawBindAttributes[LOCKED_BIND_ATTR];
                 }
                 mug.p.set(attr, value);
-                mug.form.getChildren(mug).forEach(child => _this.handleMugParseFinish(child));
+                mug.form.getChildren(mug).forEach(child => _this._setLockedFromParent(child));
             },
         };
         return spec;
@@ -107,6 +105,11 @@ $.vellum.plugin("lock", {}, {
         return mug.form.getChildren(mug).some(child =>
             child.p.locked || this._hasLockedChildren(child)
         );
+    },
+    _setLockedFromParent: function (mug) {
+        if (mug.parentMug && mug.options.isControlOnly) {
+            mug.p.set('locked', mug.parentMug.p.locked);
+        }
     },
     isPropertyLocked: function (mug, propertyPath) {
         const locked = this.__callOld();

--- a/src/lock.js
+++ b/src/lock.js
@@ -13,6 +13,7 @@ import widgets from "vellum/widgets";
 const LOCKED_BIND_ATTR = "vellum:lock";
 const LOCKED_UNEDITABLE_MSG_KEY = "mug-locked-cannot-edit";
 const LOCKED_CHILDREN_MSG_KEY = "mug-has-locked-children";
+const SELECT_CLASSES = ["Select", "MSelect", "Choice"];
 
 $.vellum.plugin("lock", {}, {
     parseBindElement: function (form, el, path) {
@@ -90,11 +91,17 @@ $.vellum.plugin("lock", {}, {
         if (canMove) {
             const destinationMug = form.getMugByUFID(dstId);
             if (destinationMug) {
-                return !(destinationMug.p.locked && _.contains(['Select', 'MSelect'], dstType));
+                return !(destinationMug.p.locked && _.contains(SELECT_CLASSES, dstType));
             }
             return true;
         }
         return false;
+    },
+    getInsertTargetAndPosition: function (refMug, qType, after) {
+        if (refMug && refMug.p.locked && _.contains(SELECT_CLASSES, refMug.__className)) {
+            return null;
+        }
+        return this.__callOld();
     },
     _hasLockedChildren: function (mug) {
         return mug.form.getChildren(mug).some(child =>

--- a/src/lock.js
+++ b/src/lock.js
@@ -63,16 +63,16 @@ $.vellum.plugin("lock", {}, {
         };
         return spec;
     },
-    isPropertyLocked: function (mug, mugPath, propertyPath) {
+    isPropertyLocked: function (mug, propertyPath) {
         return this.__callOld() || mug.p.locked;
     },
-    isMugPathMoveable: function (mug, mugPath) {
+    isMugPathMoveable: function (mug) {
         return this.__callOld() && !mug.p.locked;
     },
-    isMugRemoveable: function (mug, mugPath) {
+    isMugRemoveable: function (mug) {
         return this.__callOld() && !mug.p.locked;
     },
-    isMugTypeChangeable: function (mug, mugPath) {
+    isMugTypeChangeable: function (mug) {
         return this.__callOld() && !mug.p.locked;
     },
 });

--- a/src/lock.js
+++ b/src/lock.js
@@ -7,6 +7,7 @@
  */
 import $ from "jquery";
 import "vellum/core";
+import _ from "underscore";
 import widgets from "vellum/widgets";
 
 const LOCKED_BIND_ATTR = "vellum:lock"
@@ -33,12 +34,27 @@ $.vellum.plugin("lock", {}, {
             }
         }
     },
+    handleMugParseFinish: function (mug) {
+        this.__callOld();
+        if (mug.parentMug
+            && mug.options.isControlOnly
+        ) {
+            mug.p.set('locked', mug.parentMug.p.locked);
+        }
+    },
+    setTreeActions: function (mug) {
+        if (mug.p.locked) {
+            mug.options.canAddChoices = false;
+        }
+        this.__callOld();
+    },
     getMainProperties: function () {
         const properties = this.__callOld();
         properties.splice(1 + properties.indexOf('requiredAttr'), 0, 'locked');
         return properties;
     },
     getMugSpec: function () {
+        const _this = this;
         const spec = this.__callOld();
         const isEditable = this.opts().features.edit_locked_questions;
 
@@ -59,9 +75,22 @@ $.vellum.plugin("lock", {}, {
                     delete mug.p.rawBindAttributes[LOCKED_BIND_ATTR];
                 }
                 mug.p.set(attr, value);
+                mug.form.getChildren(mug).forEach(child => _this.handleMugParseFinish(child));
             },
         };
         return spec;
+    },
+    checkMove: function (srcId, srcType, dstId, dstType, position) {
+        const canMove = this.__callOld();
+
+        if (canMove) {
+            const form = this.data.core.form;
+            const destinationMug = form.getMugByUFID(dstId);
+            if (destinationMug) {
+            return !(destinationMug.p.locked && _.contains(['Select', 'MSelect'], dstType));
+            }
+        }
+        return false;
     },
     isPropertyLocked: function (mug, propertyPath) {
         return this.__callOld() || mug.p.locked;

--- a/src/lock.js
+++ b/src/lock.js
@@ -7,6 +7,7 @@
  */
 import $ from "jquery";
 import "vellum/core";
+import widgets from "vellum/widgets";
 
 const LOCKED_BIND_ATTR = "vellum:lock"
 
@@ -16,8 +17,38 @@ $.vellum.plugin("lock", {}, {
         const locked = el.xmlAttr(LOCKED_BIND_ATTR);
         if (locked && locked === 'all') {
             const mug = form.getMugByPath(path);
-            mug.p.set('locked', 'all');
+            mug.p.set('locked', true);
         }
+    },
+    getMainProperties: function () {
+        const properties = this.__callOld();
+        properties.splice(1 + properties.indexOf('requiredAttr'), 0, 'locked');
+        return properties;
+    },
+    getMugSpec: function () {
+        const spec = this.__callOld();
+        const isEditable = this.opts().features.edit_locked_questions;
+
+        spec.databind.locked = {
+            lstring: gettext("Locked"),
+            visibility: isEditable ? 'visible' : 'visible_if_present',
+            presence: 'optional',
+            widget: widgets.checkbox,
+            enabled: function (mug) { return isEditable },
+            help: gettext("A locked question cannot be edited, moved, or deleted from the form."),
+            helpURL: "https://www.example.com",  // placeholder for public documentation
+            serialize: () => {},
+            deserialize: () => {},
+            setter: function (mug, attr, value) {
+                if (value === true) {
+                    mug.p.rawBindAttributes[LOCKED_BIND_ATTR] = 'all';
+                } else {
+                    delete mug.p.rawBindAttributes[LOCKED_BIND_ATTR];
+                }
+                mug.p.set(attr, value);
+            },
+        };
+        return spec;
     },
     isPropertyLocked: function (mug, mugPath, propertyPath) {
         return this.__callOld() || mug.p.locked;

--- a/src/lock.js
+++ b/src/lock.js
@@ -96,7 +96,7 @@ $.vellum.plugin("lock", {}, {
         return false;
     },
     getInsertTargetAndPosition: function (refMug, qType, after) {
-        if (refMug && refMug.p.locked && _.contains(SELECT_CLASSES, refMug.__className)) {
+        if (refMug?.p.locked && _.contains(SELECT_CLASSES, refMug.__className)) {
             return null;
         }
         return this.__callOld();

--- a/src/lock.js
+++ b/src/lock.js
@@ -10,6 +10,7 @@ import "vellum/core";
 import widgets from "vellum/widgets";
 
 const LOCKED_BIND_ATTR = "vellum:lock"
+const LOCKED_UNEDITABLE_MSG_KEY = "mug-locked-cannot-edit"
 
 $.vellum.plugin("lock", {}, {
     parseBindElement: function (form, el, path) {
@@ -18,6 +19,18 @@ $.vellum.plugin("lock", {}, {
         if (locked && locked === 'all') {
             const mug = form.getMugByPath(path);
             mug.p.set('locked', true);
+
+            if (!this.opts().features.edit_locked_questions) {
+                const message = {
+                    key: LOCKED_UNEDITABLE_MSG_KEY,
+                    message: gettext(
+                            "This question is locked and can only be edited by a user with the locked "
+                            + "questions permission."
+                        ),
+                    level: mug.INFO,
+                };
+                mug.addMessage('locked', message);
+            }
         }
     },
     getMainProperties: function () {

--- a/src/lock.js
+++ b/src/lock.js
@@ -3,58 +3,32 @@
  *
  * Lets you lock questions by setting vellum:lock on their bind.
  *
- *    'node':  The question can't be deleted or renamed, or moved to a different
- *         parent.  Everything else can be changed.
- *    'value': The only thing that can be changed is itext IDs and itext values.
- *    'none': same as nothing
- *
- * Locking is not recursive; you must lock a node's entire hierarchy if you
- * really don't want it to be moved.
- *
- * Spec:
- * https://docs.google.com/document/d/1g4o3_OQfAYHjHdw7m7WcIAIRTomRV48yRQayL31jvIc
+ *    'all': Nothing about this question can be changed.
  */
 import $ from "jquery";
 import "vellum/core";
 
+const LOCKED_BIND_ATTR = "vellum:lock"
+
 $.vellum.plugin("lock", {}, {
-    loadXML: function (xml) {
-        this.data.lock.locks = {};
-        this.__callOld();
-    },
     parseBindElement: function (form, el, path) {
         this.__callOld();
-        var locked = el.xmlAttr('vellum:lock');
-        if (locked && locked !== 'none') {
-            this.data.lock.locks[path] = locked;
+        const locked = el.xmlAttr(LOCKED_BIND_ATTR);
+        if (locked && locked === 'all') {
+            const mug = form.getMugByPath(path);
+            mug.p.set('locked', 'all');
         }
     },
-    isPropertyLocked: function (mugPath, propertyPath) {
-        if (this.__callOld()) {
-            return true;
-        }
-        var lock = this.data.lock.locks[mugPath];
-        if (!lock) { 
-            return false; 
-        }
-
-        if ((lock === 'node' || lock === 'value') && 
-            propertyPath === 'nodeID') 
-        {
-            return true;
-        } else if (lock === 'value' && propertyPath.indexOf('Itext') === -1) {
-            return true;
-        }
-
-        return false;
+    isPropertyLocked: function (mug, mugPath, propertyPath) {
+        return this.__callOld() || mug.p.locked;
     },
-    isMugPathMoveable: function (mugPath) {
-        return this.__callOld() && !this.data.lock.locks[mugPath];
+    isMugPathMoveable: function (mug, mugPath) {
+        return this.__callOld() && !mug.p.locked;
     },
     isMugRemoveable: function (mug, mugPath) {
-        return this.__callOld() && !this.data.lock.locks[mugPath];
+        return this.__callOld() && !mug.p.locked;
     },
     isMugTypeChangeable: function (mug, mugPath) {
-        return this.__callOld() && this.data.lock.locks[mugPath] !== 'value';
-    }
+        return this.__callOld() && !mug.p.locked;
+    },
 });

--- a/src/lock.js
+++ b/src/lock.js
@@ -80,14 +80,19 @@ $.vellum.plugin("lock", {}, {
         return spec;
     },
     checkMove: function (srcId, srcType, dstId, dstType, position) {
-        const canMove = this.__callOld();
+        const form = this.data.core.form;
+        const sourceMug = form.getMugByUFID(srcId);
+        if (sourceMug.p.locked) {
+            return false;
+        }
 
+        const canMove = this.__callOld();
         if (canMove) {
-            const form = this.data.core.form;
             const destinationMug = form.getMugByUFID(dstId);
             if (destinationMug) {
                 return !(destinationMug.p.locked && _.contains(['Select', 'MSelect'], dstType));
             }
+            return true;
         }
         return false;
     },

--- a/src/lock.js
+++ b/src/lock.js
@@ -68,6 +68,7 @@ $.vellum.plugin("lock", {}, {
             deserialize: () => {},
             setter: function (mug, attr, value) {
                 if (value === true) {
+                    mug.p.rawBindAttributes = mug.p.rawBindAttributes || {};
                     mug.p.rawBindAttributes[LOCKED_BIND_ATTR] = 'all';
                 } else {
                     delete mug.p.rawBindAttributes[LOCKED_BIND_ATTR];

--- a/src/lock.js
+++ b/src/lock.js
@@ -12,6 +12,7 @@ import widgets from "vellum/widgets";
 
 const LOCKED_BIND_ATTR = "vellum:lock"
 const LOCKED_UNEDITABLE_MSG_KEY = "mug-locked-cannot-edit"
+const LOCKED_CHILDREN_MSG_KEY = "mug-has-locked-children"
 
 $.vellum.plugin("lock", {}, {
     parseBindElement: function (form, el, path) {
@@ -87,19 +88,40 @@ $.vellum.plugin("lock", {}, {
             const form = this.data.core.form;
             const destinationMug = form.getMugByUFID(dstId);
             if (destinationMug) {
-            return !(destinationMug.p.locked && _.contains(['Select', 'MSelect'], dstType));
+                return !(destinationMug.p.locked && _.contains(['Select', 'MSelect'], dstType));
             }
         }
         return false;
     },
+    _hasLockedChildren: function (mug) {
+        return mug.form.getChildren(mug).some(child =>
+            child.p.locked || this._hasLockedChildren(child)
+        );
+    },
     isPropertyLocked: function (mug, propertyPath) {
-        return this.__callOld() || mug.p.locked;
+        const locked = this.__callOld();
+        if (locked || mug.p.locked) {
+            return true;
+        }
+
+        if (propertyPath === 'nodeID' && !this.isMugPathMoveable(mug)) {
+            const message = {
+                key: LOCKED_CHILDREN_MSG_KEY,
+                message: gettext(
+                        "This group contains locked questions and cannot be moved or deleted from the form."
+                    ),
+                level: mug.INFO,
+            };
+            mug.addMessage('nodeID', message);
+            return true;
+        }
+        return false;
     },
     isMugPathMoveable: function (mug) {
-        return this.__callOld() && !mug.p.locked;
+        return this.__callOld() && !mug.p.locked && !this._hasLockedChildren(mug);
     },
     isMugRemoveable: function (mug) {
-        return this.__callOld() && !mug.p.locked;
+        return this.__callOld() && !mug.p.locked && !this._hasLockedChildren(mug);
     },
     isMugTypeChangeable: function (mug) {
         return this.__callOld() && !mug.p.locked;

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -29,11 +29,7 @@ var base = function(mug, options) {
             return !mug.spec[widget.path].enabled(mug);
         }
 
-        return mug.form.vellum.isPropertyLocked(
-            mug, 
-            mug.hashtagPath,
-            widget.path,
-        );
+        return mug.form.vellum.isPropertyLocked(mug, widget.path);
     };
 
     widget.getDisplayName = function () {

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -29,8 +29,11 @@ var base = function(mug, options) {
             return !mug.spec[widget.path].enabled(mug);
         }
 
-        return mug.form.vellum.isPropertyLocked(mug.hashtagPath,
-                                                widget.path);
+        return mug.form.vellum.isPropertyLocked(
+            mug, 
+            mug.hashtagPath,
+            widget.path,
+        );
     };
 
     widget.getDisplayName = function () {

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -783,8 +783,14 @@ var getUIElement = function($input, labelText, isDisabled, help) {
         help: help,
     }));
 
-    // Disable anything that can be disabled
-    $input.find("*").addBack().prop('disabled', !!isDisabled);
+    if (isDisabled) {
+        // Disable anything that can be disabled
+        $input.find("*").addBack().prop('disabled', true);
+        $input.filter('[contenteditable]').attr({
+            'contenteditable': false,
+            'disabled': true,
+        });
+    }
 
     $uiElem.find(".controls").prepend($input);
 

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -60,16 +60,22 @@ describe("The Lock plugin", function() {
 
     it("sets vellum:lock='all' on rawBindAttributes when locked", function () {
         const mug = getMug('/data/unlocked');
-        mug.p.locked = true;
-        assert.equal(mug.p.rawBindAttributes['vellum:lock'], 'all');
-        mug.p.locked = false;
+        try {
+            mug.p.locked = true;
+            assert.equal(mug.p.rawBindAttributes['vellum:lock'], 'all');
+        } finally {
+            mug.p.locked = false;
+        }
     });
 
     it("removes vellum:lock from rawBindAttributes when unlocked", function () {
         const mug = getMug('/data/locked');
-        mug.p.locked = false;
-        assert.notProperty(mug.p.rawBindAttributes, 'vellum:lock');
-        mug.p.locked = true;
+        try {
+            mug.p.locked = false;
+            assert.notProperty(mug.p.rawBindAttributes, 'vellum:lock');
+        } finally {
+            mug.p.locked = true;
+        }
     });
 
     it("disallows moving a locked node", function () {

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -18,6 +18,7 @@ var assert = chai.assert,
 function beforeFn(done) {
     util.init({
         javaRosa: {langs: ['en']},
+        plugins: ['lock'],
         core: {
             onReady: function () {
                 call('loadXFormOrError', TEST_XML, done);

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -123,6 +123,12 @@ describe("The Lock plugin", function() {
                 });
             });
 
+            it("does not add the 'cannot edit' message to locked questions", function () {
+                const mug = getMug('/data/locked');
+                const msg = mug.messages.get('locked', 'mug-locked-cannot-edit');
+                assert.isNull(msg);
+            });
+
             it("makes the locked property visible for all questions", function () {
                 const mug = getMug('/data/unlocked');
                 const spec = mug.spec.locked;
@@ -138,6 +144,12 @@ describe("The Lock plugin", function() {
 
         describe("without the feature enabled", function () {
             before(beforeFn);
+
+            it("adds the 'cannot edit' message to locked questions", function () {
+                const mug = getMug('/data/locked');
+                const msg = mug.messages.get('locked', 'mug-locked-cannot-edit');
+                assert(msg, "expected 'cannot edit' message on locked mug");
+            });
 
             it("makes the locked property visible only if present", function () {
                 const mug = getMug('/data/unlocked');

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -204,6 +204,22 @@ describe("The Lock plugin", function() {
                 0));
         });
 
+        it("prevents pasting a choice into a locked select", function () {
+            clickQuestion('/data/unlocked_select/choice1');
+            const serialized = copyPaste.copy();
+            clickQuestion('/data/locked_select/choice1');
+            const errors = copyPaste.paste(serialized);
+            assert(errors.length > 0, "expected paste errors");
+        });
+
+        it("allows pasting a choice into an unlocked select", function () {
+            clickQuestion('/data/locked_select/choice1');
+            const serialized = copyPaste.copy();
+            clickQuestion('/data/unlocked_select/choice1');
+            const errors = copyPaste.paste(serialized);
+            assert.equal(errors.length, 0, "expected no paste errors");
+        });
+
         it("removes the 'Add Choice' action for a locked select", function () {
             const lockedSelect = getMug('/data/locked_select');
             assert.isFalse(lockedSelect.options.canAddChoices);

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -108,6 +108,32 @@ describe("The Lock plugin", function() {
         assert(!getMug('/data/unsupported_lock').p.locked);
     });
 
+    describe("locked select questions", function () {
+        it("propagates locked to control-only children when set", function () {
+            const mug = getMug('/data/unlocked_select');
+            const choice = getMug('/data/unlocked_select/choice1');
+
+            mug.p.locked = true;
+            assert(choice.p.locked);
+            mug.p.locked = false;
+            assert(!choice.p.locked);
+        });
+
+        it("prevents moving choices into a locked select", function () {
+            const src = getMug('/data/unlocked_select/choice1'),
+                dst = getMug('/data/locked_select');
+            assert.isFalse(call('checkMove',
+                src.ufid, src.__className,
+                dst.ufid, dst.__className,
+                'inside'));
+        });
+
+        it("removes the 'Add Choice' action for a locked select", function () {
+            const lockedSelect = getMug('/data/locked_select');
+            assert.isFalse(lockedSelect.options.canAddChoices);
+        });
+    });
+
     describe("edit_locked_questions feature", function () {
         describe("with the feature enabled", function () {
             before(function (done) {

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -12,6 +12,7 @@ import TEST_XML from "tests/static/lock/test.xml";
 
 var assert = chai.assert,
     clickQuestion = util.clickQuestion,
+    getMug = util.getMug,
     call = util.call,
     getInput = util.getInput;
 
@@ -30,17 +31,17 @@ function beforeFn(done) {
 describe("The Lock plugin", function() {
     before(beforeFn);
 
-    function locked(mugPath, property) {
-        return call('isPropertyLocked', mugPath, property);
+    function locked(path, propertyPath) {
+        return call('isPropertyLocked', getMug(path), propertyPath);
     }
-    function moveable(mugPath) {
-        return call('isMugPathMoveable', mugPath);
+    function moveable(path) {
+        return call('isMugPathMoveable', getMug(path));
     }
-    function deleteable(mugPath) {
-        return call('isMugRemoveable', call('getMugByPath', mugPath), mugPath);
+    function deleteable(path) {
+        return call('isMugRemoveable', getMug(path));
     }
-    function changeable(mugPath) {
-        return call('isMugTypeChangeable', call('getMugByPath', mugPath), mugPath);
+    function changeable(path) {
+        return call('isMugTypeChangeable', getMug(path));
     }
 
     it("preserves XML with vellum:lock attributes", function () {

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -149,7 +149,32 @@ describe("The Lock plugin", function() {
             assert(call('checkMove',
                 src.ufid, src.__className,
                 dst.ufid, dst.__className,
-                'inside'));
+                0));
+        });
+
+        it("allows reordering a group with locked children within its parent", function () {
+            const src = getMug('/data/group_with_nested_lock');
+            assert(call('checkMove',
+                src.ufid, src.__className,
+                '#', '#',
+                0));
+        });
+
+        it("prevents moving a group with locked children to a new parent", function () {
+            const src = getMug('/data/group_with_nested_lock');
+            const newParent = getMug('/data/group_no_lock');
+            assert.isFalse(call('checkMove',
+                src.ufid, src.__className,
+                newParent.ufid, newParent.__className,
+                0));
+        });
+
+        it("prevents a locked question from being reordered", function () {
+            const src = getMug('/data/locked');
+            assert.isFalse(call('checkMove',
+                src.ufid, src.__className,
+                '#', '#',
+                0));
         });
     });
 
@@ -170,7 +195,7 @@ describe("The Lock plugin", function() {
             assert.isFalse(call('checkMove',
                 src.ufid, src.__className,
                 dst.ufid, dst.__className,
-                'inside'));
+                0));
         });
 
         it("removes the 'Add Choice' action for a locked select", function () {

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -108,6 +108,51 @@ describe("The Lock plugin", function() {
         assert(!getMug('/data/unsupported_lock').p.locked);
     });
 
+    describe("groups", function () {
+        it("disallows moving a group that contains a locked question", function () {
+            assert.isFalse(moveable('/data/group_with_nested_lock'));
+            assert(moveable('/data/group_no_lock'));
+        });
+
+        it("disallows deleting a group that contains a locked question", function () {
+            assert.isFalse(deleteable('/data/group_with_nested_lock'));
+            assert(deleteable('/data/group_no_lock'));
+        });
+
+        it("disallows changing ID of a group that contains a locked question", function () {
+            assert(locked('/data/group_with_nested_lock', 'nodeID'));
+            assert.isFalse(locked('/data/group_no_lock', 'nodeID'));
+        });
+
+        it("detects locked children recursively", function () {
+            const groupWithNestedLock = getMug('/data/group_with_nested_lock');
+            assert(call('_hasLockedChildren', groupWithNestedLock),
+                "group with deeply nested locked question should have locked children");
+            const subgroup = getMug('/data/group_with_nested_lock/subgroup');
+            assert(call('_hasLockedChildren', subgroup),
+                "subgroup directly containing locked question should have locked children");
+            const groupNoLock = getMug('/data/group_no_lock');
+            assert.isFalse(call('_hasLockedChildren', groupNoLock),
+                "group without locked children should return false");
+        });
+
+        it("adds a 'locked children' message to a group that contains a locked question", function () {
+            locked('/data/group_with_nested_lock', 'nodeID');
+            const mug = getMug('/data/group_with_nested_lock');
+            const msg = mug.messages.get('nodeID', 'mug-has-locked-children');
+            assert(msg, "expected locked children message on group");
+        });
+
+        it("allows moving a question into a locked group", function () {
+            const src = getMug('/data/unlocked');
+            const dst = getMug('/data/locked_group');
+            assert(call('checkMove',
+                src.ufid, src.__className,
+                dst.ufid, dst.__className,
+                'inside'));
+        });
+    });
+
     describe("locked select questions", function () {
         it("propagates locked to control-only children when set", function () {
             const mug = getMug('/data/unlocked_select');

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -3,6 +3,7 @@ import chai from "chai";
 import util from "tests/utils";
 import $ from "jquery";
 import TEST_XML from "tests/static/lock/test.xml";
+import copyPaste from "vellum/copy-paste";
 
 // NOTE: timer mocking here doesn't actually work, it only handles timeouts,
 // doesn't actually implement sleep-like functionality.
@@ -10,7 +11,7 @@ import TEST_XML from "tests/static/lock/test.xml";
 // finished before testing something (or make things under test not use
 // setTimeout/Interval.  Use callbacks or https://github.com/cujojs/when.
 
-var assert = chai.assert,
+const assert = chai.assert,
     clickQuestion = util.clickQuestion,
     getMug = util.getMug,
     call = util.call,
@@ -44,47 +45,112 @@ describe("The Lock plugin", function() {
         return call('isMugTypeChangeable', getMug(path));
     }
 
+    it("includes 'locked' in the main properties after 'requiredAttr'", function () {
+        const props = call('getMainProperties');
+        const requiredIdx = props.indexOf('requiredAttr');
+        const lockedIdx = props.indexOf('locked');
+        assert(lockedIdx !== -1, "'locked' should be in main properties");
+        assert.equal(lockedIdx, requiredIdx + 1,
+            "'locked' should be immediately after 'requiredAttr'");
+    });
+
     it("preserves XML with vellum:lock attributes", function () {
         util.assertXmlEqual(TEST_XML, call('createXML'));
     });
 
-    it("disallows renaming a locked node", function () {
-        assert(locked('#form/node_locked', 'nodeID'));
-        assert(locked('#form/value_locked', 'nodeID'));
-        assert.isFalse(locked('#form/none_locked', 'nodeID'));
-        assert.isFalse(locked('#form/normal', 'nodeID'));
+    it("sets vellum:lock='all' on rawBindAttributes when locked", function () {
+        const mug = getMug('/data/unlocked');
+        mug.p.locked = true;
+        assert.equal(mug.p.rawBindAttributes['vellum:lock'], 'all');
+        mug.p.locked = false;
     });
 
-    it("disallows moving a locked node to a different parent", function () {
-        assert.isFalse(moveable('#form/node_locked'));
-        assert.isFalse(moveable('#form/value_locked'));
-        assert(moveable('#form/none_locked'));
-        assert(moveable('#form/normal'));
+    it("removes vellum:lock from rawBindAttributes when unlocked", function () {
+        const mug = getMug('/data/locked');
+        mug.p.locked = false;
+        assert.notProperty(mug.p.rawBindAttributes, 'vellum:lock');
+        mug.p.locked = true;
+    });
+
+    it("disallows moving a locked node", function () {
+        assert.isFalse(moveable('/data/locked'));
+        assert(moveable('/data/unlocked'));
     });
 
     it("disallows deleting a locked node", function () {
-        assert.isFalse(deleteable('#form/node_locked'));
-        assert.isFalse(deleteable('#form/value_locked'));
-        assert(deleteable('#form/none_locked'));
-        assert(deleteable('#form/normal'));
+        assert.isFalse(deleteable('/data/locked'));
+        assert(deleteable('/data/unlocked'));
     });
 
-    it("disallows changing the type only of a 'value' locked node", function () {
-        assert.isFalse(changeable('#form/value_locked'));
-        assert(changeable('#form/node_locked'));
-        assert(changeable('#form/none_locked'));
-        assert(changeable('#form/normal'));
+    it("disallows changing the type of a locked node", function () {
+        assert.isFalse(changeable('/data/locked'));
+        assert(changeable('/data/unlocked'));
     });
 
-    it("allows changing only the Itext IDs of a 'value' locked node", function () {
-        assert.isFalse(locked('#form/value_locked', 'constraintMsgItext'));
-        assert(locked('#form/value_locked', 'constraintAttr'));
+    it("disallows changing all properties of a locked node", function () {
+        assert(locked('/data/locked'));
+        assert(locked('/data/locked', 'constraintAttr'));
+        assert(locked('/data/locked', 'relevantAttr'));
+        assert(locked('/data/locked', 'requiredAttr'));
     });
 
-    it("allows changing any property of a non-locked node", function () {
-        assert.isFalse(locked('#form/node_locked'));
-        assert.isFalse(locked('#form/none_locked'));
-        assert.isFalse(locked('#form/normal'));
+    it("copies a locked question as unlocked", function () {
+        clickQuestion('locked');
+        const serialized = copyPaste.copy();
+        copyPaste.paste(serialized);
+        const pasted = getMug('/data/copy-1-of-locked');
+        assert(pasted, "pasted mug should exist");
+        assert(!pasted.p.locked);
+        call('getData').core.form.removeMugsFromForm([pasted]);
+    });
+
+    it("does not lock based on unsupported vellum:lock values", function () {
+        assert(!getMug('/data/unsupported_lock').p.locked);
+    });
+
+    describe("edit_locked_questions feature", function () {
+        describe("with the feature enabled", function () {
+            before(function (done) {
+                util.init({
+                    javaRosa: {langs: ['en']},
+                    plugins: ['lock'],
+                    features: {edit_locked_questions: true},
+                    core: {
+                        onReady: function () {
+                            call('loadXFormOrError', TEST_XML, done);
+                        }
+                    }
+                });
+            });
+
+            it("makes the locked property visible for all questions", function () {
+                const mug = getMug('/data/unlocked');
+                const spec = mug.spec.locked;
+                assert.equal(spec.visibility, 'visible');
+            });
+
+            it("makes the locked property editable", function () {
+                const mug = getMug('/data/locked');
+                const spec = mug.spec.locked;
+                assert(spec.enabled(mug));
+            });
+        });
+
+        describe("without the feature enabled", function () {
+            before(beforeFn);
+
+            it("makes the locked property visible only if present", function () {
+                const mug = getMug('/data/unlocked');
+                const spec = mug.spec.locked;
+                assert.equal(spec.visibility, 'visible_if_present');
+            });
+
+            it("makes the locked property not editable", function () {
+                const mug = getMug('/data/locked');
+                const spec = mug.spec.locked;
+                assert(!spec.enabled(mug));
+            });
+        });
     });
 });
 
@@ -94,57 +160,60 @@ describe("The question locking functionality in the core and UI", function () {
 
     describe("The edit locking", function () {
         it("shows the delete button for deleteable questions", function () {
-            clickQuestion('normal');
+            clickQuestion('unlocked');
             assert($("button:contains(Delete)").length === 1);
         });
-        
+
         it("hides the delete button for non-deletable questions", function () {
-            clickQuestion('node_locked');
+            clickQuestion('locked');
             assert($("button:contains(Delete)").length === 0);
         });
 
         function testTypeChangeable(bool) {
-            clickQuestion(bool ? "normal" : "value_locked");
-            var btn = $(".btn.current-question");
+            clickQuestion(bool ? "unlocked" : "locked");
+            const btn = $(".btn.current-question");
             assert(btn.length === 1);
             btn.click();
-            var menu = btn.closest('.question-type-changer');
+            const menu = btn.closest('.question-type-changer');
             assert.equal(!!menu.find('li:not(.dropdown-header)').length, bool);
         }
+
         it("shows the type changer for type-changeable questions", function () {
             testTypeChangeable(true);
         });
+
         it("hides the type changer for non-type-changeable questions", function () {
             testTypeChangeable(false);
         });
 
-        it("disables the checkbox (only) for a locked boolean property", function () {
-            clickQuestion("value_locked");
+        it("disables the checkbox for a locked boolean property", function () {
+            clickQuestion("locked");
             assert(getInput('requiredAttr').prop('disabled'));
 
-            clickQuestion("normal");
-            var $r = getInput('requiredAttr');
+            clickQuestion("unlocked");
+            const $r = getInput('requiredAttr');
             assert.isFalse($r.prop('disabled'));
         });
 
-        it("disables the text input (only) for a locked text property", function () {
-            clickQuestion("normal");
+        it("disables the text input for a locked text property", function () {
+            clickQuestion("unlocked");
             assert.isFalse(getInput('nodeID').prop('disabled'));
 
-            clickQuestion("value_locked");
+            clickQuestion("locked");
             assert(getInput("nodeID").prop('disabled'));
         });
 
         function testEditButton(bool) {
-            clickQuestion(bool ? "value_locked" : "normal");
-            var $but = getInput('relevantAttr').parents('.form-group').find('button.fd-edit-button');
+            clickQuestion(bool ? "locked" : "unlocked");
+            const $but = getInput('relevantAttr').parents('.form-group').find('button.fd-edit-button');
             assert.equal(1, $but.length);
             assert.equal(bool, $but.prop('disabled'));
         }
+
         it("enables the edit button for non-locked logic properties", function () {
             testEditButton(false);
         });
-       
+
         it("disables the edit button for locked logic properties", function () {
             testEditButton(true);
         });

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -196,8 +196,8 @@ describe("The Lock plugin", function() {
         });
 
         it("prevents moving choices into a locked select", function () {
-            const src = getMug('/data/unlocked_select/choice1'),
-                dst = getMug('/data/locked_select');
+            const src = getMug('/data/unlocked_select/choice1');
+            const dst = getMug('/data/locked_select');
             assert.isFalse(call('checkMove',
                 src.ufid, src.__className,
                 dst.ufid, dst.__className,

--- a/tests/static/lock/test.xml
+++ b/tests/static/lock/test.xml
@@ -15,11 +15,15 @@
 					<locked />
 					<unsupported_lock />
 					<unlocked />
+					<locked_select />
+					<unlocked_select />
 				</data>
 			</instance>
 			<bind vellum:nodeset="#form/locked" nodeset="/data/locked" type="xsd:string" vellum:lock="all" />
 			<bind vellum:nodeset="#form/unsupported_lock" nodeset="/data/unsupported_lock" type="xsd:string" vellum:lock="other" />
 			<bind vellum:nodeset="#form/unlocked" nodeset="/data/unlocked" type="xsd:string" />
+			<bind vellum:nodeset="#form/locked_select" nodeset="/data/locked_select" vellum:lock="all" />
+			<bind vellum:nodeset="#form/unlocked_select" nodeset="/data/unlocked_select" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="locked-label">
@@ -30,6 +34,18 @@
 					</text>
 					<text id="unlocked-label">
 						<value>unlocked</value>
+					</text>
+					<text id="locked_select-label">
+						<value>locked_select</value>
+					</text>
+					<text id="locked_select-choice1-label">
+						<value>choice1</value>
+					</text>
+					<text id="unlocked_select-label">
+						<value>unlocked_select</value>
+					</text>
+					<text id="unlocked_select-choice1-label">
+						<value>choice1</value>
 					</text>
 				</translation>
 			</itext>
@@ -45,5 +61,19 @@
 		<input vellum:ref="#form/unlocked" ref="/data/unlocked">
 			<label ref="jr:itext('unlocked-label')" />
 		</input>
+		<select1 vellum:ref="#form/locked_select" ref="/data/locked_select">
+			<label ref="jr:itext('locked_select-label')" />
+			<item>
+				<label ref="jr:itext('locked_select-choice1-label')" />
+				<value>choice1</value>
+			</item>
+		</select1>
+		<select1 vellum:ref="#form/unlocked_select" ref="/data/unlocked_select">
+			<label ref="jr:itext('unlocked_select-label')" />
+			<item>
+				<label ref="jr:itext('unlocked_select-choice1-label')" />
+				<value>choice1</value>
+			</item>
+		</select1>
 	</h:body>
 </h:html>

--- a/tests/static/lock/test.xml
+++ b/tests/static/lock/test.xml
@@ -12,49 +12,38 @@
 				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" 
 					xmlns="http://openrosa.org/formdesigner/4BE1309B-ABCF-4184-8175-9E381F3E0DD7"
 					uiVersion="1" version="1" name="Untitled Form">
-					<node_locked />
-					<value_locked />
-					<none_locked />
-					<normal />
-					<group />
+					<locked />
+					<unsupported_lock />
+					<unlocked />
 				</data>
 			</instance>
-			<bind vellum:nodeset="#form/node_locked" nodeset="/data/node_locked" type="xsd:string" vellum:lock="node" />
-			<bind vellum:nodeset="#form/value_locked" nodeset="/data/value_locked" type="xsd:string" vellum:lock="value"/>
-			<bind vellum:nodeset="#form/none_locked" nodeset="/data/none_locked" type="xsd:string" vellum:lock="none" />
-			<bind vellum:nodeset="#form/normal" nodeset="/data/normal" type="xsd:string" />
-			<bind vellum:nodeset="#form/group" nodeset="/data/group" />
+			<bind vellum:nodeset="#form/locked" nodeset="/data/locked" type="xsd:string" vellum:lock="all" />
+			<bind vellum:nodeset="#form/unsupported_lock" nodeset="/data/unsupported_lock" type="xsd:string" vellum:lock="other" />
+			<bind vellum:nodeset="#form/unlocked" nodeset="/data/unlocked" type="xsd:string" />
 			<itext>
 				<translation lang="en" default="">
-					<text id="node_locked-label">
-						<value>node_locked</value>
+					<text id="locked-label">
+						<value>locked</value>
 					</text>
-					<text id="value_locked-label">
-						<value>value_locked</value>
+					<text id="unsupported_lock-label">
+						<value>unsupported_lock</value>
 					</text>
-					<text id="none_locked-label">
-						<value>none_locked</value>
-					</text>
-					<text id="normal-label">
-						<value>normal</value>
+					<text id="unlocked-label">
+						<value>unlocked</value>
 					</text>
 				</translation>
 			</itext>
 		</model>
 	</h:head>
 	<h:body>
-		<input vellum:ref="#form/node_locked" ref="/data/node_locked">
-			<label ref="jr:itext('node_locked-label')" />
+		<input vellum:ref="#form/locked" ref="/data/locked">
+			<label ref="jr:itext('locked-label')" />
 		</input>
-		<input vellum:ref="#form/value_locked" ref="/data/value_locked">
-			<label ref="jr:itext('value_locked-label')" />
+		<input vellum:ref="#form/unsupported_lock" ref="/data/unsupported_lock">
+			<label ref="jr:itext('unsupported_lock-label')" />
 		</input>
-		<input vellum:ref="#form/none_locked" ref="/data/none_locked">
-			<label ref="jr:itext('none_locked-label')" />
+		<input vellum:ref="#form/unlocked" ref="/data/unlocked">
+			<label ref="jr:itext('unlocked-label')" />
 		</input>
-		<input vellum:ref="#form/normal" ref="/data/normal">
-			<label ref="jr:itext('normal-label')" />
-		</input>
-		<group vellum:ref="#form/group" ref="/data/group"></group>
 	</h:body>
 </h:html>

--- a/tests/static/lock/test.xml
+++ b/tests/static/lock/test.xml
@@ -15,6 +15,15 @@
 					<locked />
 					<unsupported_lock />
 					<unlocked />
+					<group_with_nested_lock>
+						<subgroup>
+							<nested_locked />
+						</subgroup>
+					</group_with_nested_lock>
+					<group_no_lock>
+						<nested_unlocked />
+					</group_no_lock>
+					<locked_group />
 					<locked_select />
 					<unlocked_select />
 				</data>
@@ -22,6 +31,12 @@
 			<bind vellum:nodeset="#form/locked" nodeset="/data/locked" type="xsd:string" vellum:lock="all" />
 			<bind vellum:nodeset="#form/unsupported_lock" nodeset="/data/unsupported_lock" type="xsd:string" vellum:lock="other" />
 			<bind vellum:nodeset="#form/unlocked" nodeset="/data/unlocked" type="xsd:string" />
+			<bind vellum:nodeset="#form/group_with_nested_lock" nodeset="/data/group_with_nested_lock" />
+			<bind vellum:nodeset="#form/group_with_nested_lock/subgroup" nodeset="/data/group_with_nested_lock/subgroup" />
+			<bind vellum:nodeset="#form/group_with_nested_lock/subgroup/nested_locked" nodeset="/data/group_with_nested_lock/subgroup/nested_locked" type="xsd:string" vellum:lock="all" />
+			<bind vellum:nodeset="#form/group_no_lock" nodeset="/data/group_no_lock" />
+			<bind vellum:nodeset="#form/group_no_lock/nested_unlocked" nodeset="/data/group_no_lock/nested_unlocked" type="xsd:string" />
+			<bind vellum:nodeset="#form/locked_group" nodeset="/data/locked_group" vellum:lock="all" />
 			<bind vellum:nodeset="#form/locked_select" nodeset="/data/locked_select" vellum:lock="all" />
 			<bind vellum:nodeset="#form/unlocked_select" nodeset="/data/unlocked_select" />
 			<itext>
@@ -34,6 +49,12 @@
 					</text>
 					<text id="unlocked-label">
 						<value>unlocked</value>
+					</text>
+					<text id="nested_locked-label">
+						<value>nested_locked</value>
+					</text>
+					<text id="nested_unlocked-label">
+						<value>nested_unlocked</value>
 					</text>
 					<text id="locked_select-label">
 						<value>locked_select</value>
@@ -61,6 +82,19 @@
 		<input vellum:ref="#form/unlocked" ref="/data/unlocked">
 			<label ref="jr:itext('unlocked-label')" />
 		</input>
+		<group vellum:ref="#form/group_with_nested_lock" ref="/data/group_with_nested_lock">
+			<group vellum:ref="#form/group_with_nested_lock/subgroup" ref="/data/group_with_nested_lock/subgroup">
+				<input vellum:ref="#form/group_with_nested_lock/subgroup/nested_locked" ref="/data/group_with_nested_lock/subgroup/nested_locked">
+					<label ref="jr:itext('nested_locked-label')" />
+				</input>
+			</group>
+		</group>
+		<group vellum:ref="#form/group_no_lock" ref="/data/group_no_lock">
+			<input vellum:ref="#form/group_no_lock/nested_unlocked" ref="/data/group_no_lock/nested_unlocked">
+				<label ref="jr:itext('nested_unlocked-label')" />
+			</input>
+		</group>
+		<group vellum:ref="#form/locked_group" ref="/data/locked_group"></group>
 		<select1 vellum:ref="#form/locked_select" ref="/data/locked_select">
 			<label ref="jr:itext('locked_select-label')" />
 			<item>


### PR DESCRIPTION
## Product Description
Adds a "Locked" checkbox, which disables all properties on a question from being edited. Also adds messages when a question is locked and uneditable or a group contains any locked questions.
<img width="187" height="63" alt="image" src="https://github.com/user-attachments/assets/4cbfeca9-b5bd-4213-a422-cbfc79dbe390" />

<img width="579" height="113" alt="image" src="https://github.com/user-attachments/assets/af2a73de-dc15-473c-a5ec-7a0b65caba61" />

<img width="594" height="186" alt="image" src="https://github.com/user-attachments/assets/87332404-fec1-43a3-9465-d3c9569ce111" />


## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19544
This is the initial set of changes for Locked Admin questions, essentially an MVP. Specifically, this:
- Removes access to previous vellum:lock functionality. This was never UI-accessible and only partially functional, and deemed OK to remove by product leadership
- Adds the locked widget to all questions & groups, reading from and writing to the question's `<bind>` XML node
- Uses the added locked property to determine which question widgets should be locked. In this iteration it is all of them, though in the future we may add more selective options, which informed the use of "all" on the XML attribute rather than a boolean
- Makes sure locked questions cannot be re-ordered or deleted from the form
- Handles Select questions by applying the locked property to any of their children and removing the "Add Choice" button
- Handles groups by checking whether a group contains any locked child questions, and if so:
  - Locks the question ID and position of the group
  - Ensures the group cannot be deleted

AI (@claude Opus 4.6) was used to plan, debug, and write tests included in this pull request.

## Feature Flag
Not explicitly feature flagged but will be when HQ development begins. For now, the main changes here are not accessible without manually enabling the "lock" plugin.

## Safety Assurance

### Safety story
Developing as a plugin means core code is relatively unaffected, so blast radius would be limited to those with the plugin enabled. Tested locally and (soon) on staging. Added/updated automated tests for all key functionality here.

### Automated test coverage
Added/updated automated testing in formdesigner.lock.js

### QA Plan
This will get QA holistically with the other elements of Locked Admin questions.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
