### PR TITLE
Detect broken XML paths and offer to fix on form load

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -531,6 +531,9 @@ fn.showPathCorrectionModal = function (corrections, formXML, options) {
         ),
         buildCorrectionList()
     );
+    $modal.on('shown.bs.modal', function () {
+        $modal.find(':focus').blur();
+    });
     $modal.modal('show');
 };
 

--- a/src/core.js
+++ b/src/core.js
@@ -473,6 +473,67 @@ fn.showConfirmBulkActionModal = function (confirmMessage, confirmActionFn) {
     $modal.modal('show');
 };
 
+fn.showPathCorrectionModal = function (corrections, formXML, options) {
+    var _this = this,
+        $modal;
+
+    function toAbsolutePath(path) {
+        return path.replace(/^#form/, '/data');
+    }
+
+    function applyCorrections() {
+        var fixedXML = formXML;
+        _.each(corrections, function (c) {
+            fixedXML = fixedXML.split(toAbsolutePath(c.wrongPath))
+                               .join(toAbsolutePath(c.correctPath));
+        });
+        _this.closeModal();
+        _this.data.core.parseWarnings = [];
+        _this.loadXML(fixedXML, options);
+        delete _this.data.core.parseWarnings;
+    }
+
+    function buildCorrectionList() {
+        var $list = $('<ul></ul>');
+        _.each(corrections, function (c) {
+            var wrong = toAbsolutePath(c.wrongPath),
+                correct = toAbsolutePath(c.correctPath),
+                leafName = wrong.split('/').pop();
+            $list.append(
+                $('<li></li>').append(
+                    document.createTextNode(gettext("Path ")),
+                    $('<code></code>').text(wrong),
+                    document.createTextNode(util.format(
+                        gettext(" was not found. A data node named " +
+                                "\"{name}\" exists at "),
+                        {name: leafName})),
+                    $('<code></code>').text(correct),
+                    document.createTextNode(".")
+                )
+            );
+        });
+        return $list;
+    }
+
+    $modal = this.generateNewModal(gettext("Broken Paths Detected"), [
+        {
+            title: gettext('Fix and Reload'),
+            cssClasses: "btn-primary",
+            action: applyCorrections
+        }
+    ], gettext("Ignore"));
+
+    var $body = $modal.find('.modal-body');
+    $body.append(
+        $('<p></p>').text(
+            gettext("The following paths in this form's XML do not match " +
+                    "any data nodes. Saving without fixing may result in data loss.")
+        ),
+        buildCorrectionList()
+    );
+    $modal.modal('show');
+};
+
 fn._init_extra_tools = function () {
     var _this = this,
         menuItems = this.getToolsMenuItems();
@@ -1409,6 +1470,10 @@ fn.loadXML = function (formXML, options) {
     if (formXML) {
         _this._resetMessages(_this.data.core.form.errors);
         _this._populateTree(selectedHashtag);
+    }
+
+    if (form.pathCorrections && form.pathCorrections.length) {
+        _this.showPathCorrectionModal(form.pathCorrections, formXML, options);
     }
 
     form.on('question-type-change', function (e) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -708,12 +708,24 @@ function parseBindElement (form, el, path) {
     var mug = form.getMugByPath(path);
 
     if(!mug){
-        form.parseWarnings.push(util.format(
-            gettext("Bind Node [{path}] found but has no associated " +
-                    "Data node. This bind node will be discarded!"),
-            {path: path}
-        ));
-        return;
+        var match = findDataNodeByLeafName(form, path);
+        if (match) {
+            mug = match;
+            if (!form.pathCorrections) {
+                form.pathCorrections = [];
+            }
+            form.pathCorrections.push({
+                wrongPath: path,
+                correctPath: match.absolutePath
+            });
+        } else {
+            form.parseWarnings.push(util.format(
+                gettext("Bind Node [{path}] found but has no associated " +
+                        "Data node. This bind node will be discarded!"),
+                {path: path}
+            ));
+            return;
+        }
     }
 
     var required = el.popAttr('required');

--- a/src/parser.js
+++ b/src/parser.js
@@ -297,6 +297,18 @@ function parseControlElement(form, $cEl, parentMug) {
             path = getPathFromControlElement($cEl, form, parentMug);
         }
         mug = form.getMugByPath(path);
+        if (!mug && path) {
+            var match = findDataNodeByLeafName(form, path);
+            if (match) {
+                if (!form.pathCorrections) {
+                    form.pathCorrections = [];
+                }
+                form.pathCorrections.push({
+                    wrongPath: path,
+                    correctPath: match.absolutePath
+                });
+            }
+        }
     }
     mug = adapt(mug, form);
     var node = form.tree.getNodeFromMug(mug);
@@ -529,6 +541,27 @@ function parseBoolAttributeValue (attrString, undefined) {
     } else {
         return undefined;
     }
+}
+
+/**
+ * Search for an unclaimed data node whose nodeID matches the last
+ * segment of the given path. Used to recover from hand-edited XML
+ * where a control element's ref/nodeset has the wrong path.
+ *
+ * @param form - the form object
+ * @param path - the broken path (e.g., "/data/members_repeat")
+ * @returns - the matching DataBindOnly mug, or null
+ */
+function findDataNodeByLeafName(form, path) {
+    var leafName = path.replace(/^#form\//, '').split('/').pop();
+    var match = null;
+    _.each(form.mugMap, function (mug) {
+        if (mug.p.nodeID === leafName &&
+            mug.__className === 'DataBindOnly') {
+            match = mug;
+        }
+    });
+    return match;
 }
 
 /**


### PR DESCRIPTION
## Product Description
When a form has hand-edited XML with wrong paths (e.g., a repeat group referencing `/data/members_repeat` instead of `/data/sec_members/members_repeat`), the form silently breaks — Question ID becomes blank and uneditable, and saving the form causes data loss. User is confused and don't know how to fix it, fill in a Question ID won't work.

After this change, a modal appears on form load showing the broken paths and their corrections (e.g., `/data/members_repeat` → `/data/sec_members/members_repeat`), with a "Fix and Reload" button that corrects the XML automatically.

<img width="615" height="244" alt="Screenshot 2026-04-07 at 11 23 42 PM" src="https://github.com/user-attachments/assets/73874557-b0bd-477c-89a0-23aaa5d36894" />

I then realized I can apply same logic to broken path in bind node.
<img width="730" height="103" alt="Screenshot 2026-04-07 at 11 33 23 PM" src="https://github.com/user-attachments/assets/0f0faba5-242c-4386-b3d7-13e0e9999b8e" />
Thus the modal will become the following:
<img width="624" height="292" alt="Screenshot 2026-04-07 at 11 34 17 PM" src="https://github.com/user-attachments/assets/e41129e5-e567-47d1-969c-13030d8a3620" />


## Technical Summary
Ticket: https://dimagi.atlassian.net/browse/SAAS-19569

### Why Question ID breaks
When a control element's path doesn't resolve via `getMugByPath`, the parser creates an orphaned "control-only" mug with no data node. This causes a chain of failures:

1. `isControlOnly = true` → `absolutePath` returns null ([code](https://github.com/dimagi/Vellum/blob/72e82a5a7c3560137ffe6fda59491aea9c6fc88f/src/form.js#L1053-L1057))
2. `absolutePath` null → `hashtagPath` null
3. The `nodeID` setter calls `moveMug("rename", value)` which [skips the entire rename block for control-only mugs](https://github.com/dimagi/Vellum/blob/72e82a5a7c3560137ffe6fda59491aea9c6fc88f/src/form.js#L758)
4. Result: Question ID stays blank and can't be set through the UI

### How this PR fixes it
During parsing, when `getMugByPath` fails, `findDataNodeByLeafName` searches for an unclaimed DataBindOnly mug with the same node name (e.g., finds `members_repeat` at `/data/sec_members/members_repeat`). If found, the correction is stored on `form.pathCorrections`. After parsing, `showPathCorrectionModal` displays the corrections. "Fix and Reload" does a find-and-replace on the raw XML and reloads the form, which resolves the control to the correct data node and restores Question ID.

## Feature Flag
N/A

## Safety Assurance

### Safety story
This only activates when `getMugByPath` returns null for a control element's path — a case that previously resulted in silent data loss. Normal forms with valid paths are unaffected. The fix is opt-in via the modal (user can click "Ignore" to skip).

### Automated test coverage
No existing tests cover malformed XML path handling. Manual testing with broken XML files confirms the modal appears and fix works correctly.

### QA Plan
- Load a form with a wrong repeat path — modal should appear showing `/data/members_repeat` → `/data/sec_members/members_repeat`
- Click "Fix and Reload" — form reloads with corrected paths, Question ID works
- Click "Ignore" — form loads as before (broken), no crash
- Load a normal form — no modal, no change in behavior

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)