### PR TITLE
Fix false uuid() warning when copy-pasting SaveToCase

### DIFF
--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -434,6 +434,11 @@ var slugToProp = {
             useCreate: {
                 visibility: 'hidden',
                 presence: 'optional',
+                validationFunc: function (mug) {
+                    // case_id validation depends on useCreate
+                    mug.validate('case_id');
+                    return 'pass';
+                },
             },
             createProperty: {
                 lstring: gettext("Case Properties To Create"),

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -509,6 +509,14 @@ describe("The SaveToCase module", function() {
             mug.p.case_id = "/data/meta/caseID";
             assert.strictEqual(mug.spec.case_id.validationFunc(mug), "pass");
         });
+
+        it("should clear uuid() warning when useCreate is set after case_id", function () {
+            mug.p.case_id = "uuid()";
+            assert.deepEqual(mug.messages.get("case_id"),
+                ["Case ID cannot be uuid() without a Create action. It must reference an existing case."]);
+            mug.p.useCreate = true;
+            assert.deepEqual(mug.messages.get("case_id"), []);
+        });
     });
 
     it("should provide case references to the logic manager", function () {


### PR DESCRIPTION
## Product Description
When copy-pasting a SaveToCase question with `case_id = uuid()` and Create action selected, a false warning appeared: "Case ID cannot be uuid() without a Create action." This was confusing since Create was indeed selected.

Before
<img width="883" height="450" alt="Screenshot 2026-04-10 at 6 50 15 PM" src="https://github.com/user-attachments/assets/95ab8f77-d5d5-40b6-8c2b-9f8e7222a41f" />

After
<img width="1214" height="556" alt="Screenshot 2026-04-10 at 10 07 03 PM" src="https://github.com/user-attachments/assets/e5148dc3-3d0e-4c84-9605-d20232e14cf3" />

## Technical Summary
During paste, properties are deserialized in spec order. `case_id` comes before `useCreate`, so `case_id` validation fires while `useCreate` is still false. When `useCreate` is later set to true, it only re-validated itself — never clearing the stale `case_id` error.

Fix: add a `validationFunc` on `useCreate` that re-validates `case_id`, so the error is cleared once `useCreate` is set.

## Feature Flag
`VELLUM_SAVE_TO_CASE`

## Safety Assurance

### Safety story
Safe. The change only adds cross-property revalidation.

### Automated test coverage
New test "should clear uuid() warning when useCreate is set after case_id" added

### QA Plan
- Copy-paste a SaveToCase question with `uuid()` case ID and Create action → verify no false warning
- Toggle Create on/off → verify warning appears/disappears correctly

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change