### PR TITLE
Fix: Create chip deselected when selecting Close or Index chips

### DIFF
--- a/src/widgets.js
+++ b/src/widgets.js
@@ -620,11 +620,13 @@ var chips = function (mug, options) {
             if (isActive) {
                 onDeselect(slug, mug);
             } else {
-                exclusiveChips.forEach(function (s) {
-                    if (s !== slug && getState(s, mug)) {
-                        onDeselect(s, mug);
-                    }
-                });
+                if (exclusiveSet.has(slug)) {
+                    exclusiveChips.forEach(function (s) {
+                        if (s !== slug && getState(s, mug)) {
+                            onDeselect(s, mug);
+                        }
+                    });
+                }
                 onSelect(slug, mug);
             }
             render();

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -119,6 +119,36 @@ describe("The SaveToCase module", function() {
         assert.strictEqual($("[name=property-case_type]").data('select2').options.options.tags, true);
     });
 
+    it("should not deselect Create when selecting Close or Index", function () {
+        util.loadXML("");
+        util.addQuestion("SaveToCase", "stc", {
+            case_id: 'uuid()',
+            case_type: 'my_custom_type',
+            useCreate: true,
+            createProperty: {
+                'case_name': { 'calculate': '/data/name' },
+            }
+        });
+        util.clickQuestion("stc");
+        var mug = util.getMug("stc");
+
+        // Verify initial state
+        assert.equal(mug.p.useCreate, true);
+        assert.equal(mug.p.case_type, 'my_custom_type');
+
+        // Click Close chip
+        $(".fd-chip[data-slug='close']").trigger('click');
+        assert.equal(mug.p.useCreate, true, "Create should still be active after clicking Close");
+        assert.equal(mug.p.useClose, true, "Close should be active");
+        assert.equal(mug.p.case_type, 'my_custom_type', "case_type should be preserved after clicking Close");
+
+        // Click Index chip
+        $(".fd-chip[data-slug='index']").trigger('click');
+        assert.equal(mug.p.useCreate, true, "Create should still be active after clicking Index");
+        assert.equal(mug.p.useIndex, true, "Index should be active");
+        assert.equal(mug.p.case_type, 'my_custom_type', "case_type should be preserved after clicking Index");
+    });
+
     it("should support two questions with same name", function () {
         util.loadXML(TWO_SAME_NAME_XML);
         var one = util.getMug("one/save"),


### PR DESCRIPTION
## Product Description

When "Create" chip is selected, clicking "Close" or "Index" chips would deselect the "Create" action. This PR is to fix it.

https://github.com/user-attachments/assets/7ca7a851-37b0-4c89-b500-a5f14f1c21f1


## Technical Summary

Cause: The chips widget's exclusive deselection logic was running whenever *any* chip was selected, not just when an exclusive chip was selected. Clicking "Close" (non-exclusive) would iterate over the exclusive set `["create", "update"]` and deselect "Create" if active.

The fix wraps the exclusive deselection in `if (exclusiveSet.has(slug))` so it only fires when the newly selected chip is itself in the exclusive group.

## Feature Flag

`VELLUM_SAVE_TO_CASE`

## Safety Assurance

### Safety story

Safe. The change is minimal (one guard condition).

### Automated test coverage

Added test: "should not deselect Create when selecting Close or Index"

### QA Plan

1. Open a form with an Advanced Case Actions mug
2. Select "Create" and set a case type
3. Click "Close" — verify Create stays selected and case type is preserved
4. Click "Index" — same verification
5. Verify Create/Update mutual exclusion still works (Update is disabled when Create is active)

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change