### PR TITLE
Light-weight nudge for Case Management adoption

### DIFF
--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -485,6 +485,35 @@ $.vellum.plugin('caseManagement', {}, {
         return sections;
     },
 
+    getSectionDisplay: function (mug, options) {
+        // can be removed when the Case Management nudge is no longer needed
+        const $sec = this.__callOld();
+        const NUDGE_KEY = 'nudge-caseManagement';
+        const DISMISS_ON = 3;
+        let useCount = parseInt(localStorage.getItem(NUDGE_KEY) || '0');
+        if (options.slug === 'caseManagement' && useCount < DISMISS_ON) {
+            const $nudge = $(
+                '<div class="alert alert-info fd-nudge">' +
+                    '<button type="button" class="close" ' +
+                        'data-dismiss="alert" aria-hidden="true">&times;</button>' +
+                    '<i class="fa fa-info-circle"></i> ' +
+                    gettext('Save this question as a case property to reuse its data across your application.') +
+                '</div>'
+            );
+            $nudge.on('close.bs.alert', () => localStorage.setItem(NUDGE_KEY, String(DISMISS_ON)));
+            $sec.find('.fd-fieldset-content').prepend($nudge);
+            mug.on('property-changed', event => {
+                if (event.property === 'caseProperty' && event.val) {
+                    localStorage.setItem(NUDGE_KEY, String(++useCount));
+                    if (useCount >= DISMISS_ON) {
+                        $nudge.fadeOut(300, function () { $(this).remove(); });
+                    }
+                }
+            }, null, 'teardown-mug-properties');
+        }
+        return $sec;
+    },
+
     getMugSpec: function () {
         const specs = this.__callOld();
         const that = this;

--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -495,7 +495,7 @@ $.vellum.plugin('caseManagement', {}, {
             const $nudge = $(
                 '<div class="alert alert-info fd-nudge">' +
                     '<button type="button" class="close" ' +
-                        'data-dismiss="alert" aria-hidden="true">&times;</button>' +
+                        'data-dismiss="alert" aria-label="' + gettext('Close') + '">&times;</button>' +
                     '<i class="fa fa-info-circle"></i> ' +
                     gettext('Save this question as a case property to reuse its data across your application.') +
                 '</div>'

--- a/src/less-style/question-props.less
+++ b/src/less-style/question-props.less
@@ -69,6 +69,18 @@
                 }
             }
 
+            // Inline nudge for feature adoption
+            .fd-nudge {
+                margin: 0 0 10px 0;
+                padding: 8px 12px;
+                font-size: 12px;
+                line-height: 1.4;
+
+                .fa-info-circle {
+                    margin-right: 4px;
+                }
+            }
+
             // Accordion content
             .fd-fieldset-content {
 


### PR DESCRIPTION
Adds a small inline hint inside the Case Management section of the question properties panel encouraging form builders to save questions as case properties so their data can be reused across the application.

<img width="752" height="129" alt="image" src="https://github.com/user-attachments/assets/d0f087f3-f338-41f1-9e0b-485ce6825ea8" />

The nudge:
- Appears above the Case Management section content as a dismissible info alert.
- Auto-dismisses permanently after the user has set a `caseProperty` value on 3 questions.
- Can be manually dismissed at any time via the close button (counted as "fully used" so it won't come back).
- Persists its state per-browser via `localStorage`, so it doesn't re-appear on reload once dismissed.

https://dimagi.atlassian.net/browse/SAAS-19557

## Feature Flag

`FORMBUILDER_SAVE_TO_CASE`

## Safety Assurance

### Safety story

- Purely additive UI change scoped to the Case Management section of the question editor; no data model, form schema, or save-path changes.
- Rendering logic is gated on `options.slug === 'caseManagement'`, so other question-property sections are unaffected.
- If `localStorage` is unavailable or throws, the worst case is the nudge never shows.
- The nudge uses existing Bootstrap alert markup and standard jQuery patterns already in use throughout Vellum.

### Automated test coverage

No new automated tests. The change is a small, transient UI nudge with no business logic worth locking in via tests.

### QA Plan

No QA

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

Reverting removes the nudge immediately on next deploy. Stale `nudge-caseManagement` keys left in users' `localStorage` are harmless.
