### PR TITLE
Improve Create Section: add open case condition and dedicated fields

### DIFF
--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -486,23 +486,17 @@ var slugToProp = {
                 validationFunc: function (mug) {
                     if (mug.p.useCreate) {
                         var props = _.without(_.keys(mug.p.createProperty), ""),
-                            required = ["case_name"],
-                            optional = ["owner_id"],
-                            legal = _.union(required, optional),
-                            illegalProps = _.difference(props, legal),
-                            requiredProps = _.intersection(props, required),
+                            reserved = ["case_type", "case_name", "owner_id"],
+                            reservedUsed = _.intersection(props, reserved),
                             invalidProps = _.filter(props, function(p) {
                                 return !VALID_PROP_REGEX.test(p);
                             });
 
-                        if (requiredProps.length !== required.length) {
+                        if (reservedUsed.length > 0) {
                             return util.format(
-                                gettext("You must include {columns} columns to create a case"),
-                                {columns: required.join(", ")}
+                                gettext("{props} cannot be added here. Use the dedicated fields above."),
+                                {props: reservedUsed.join(", ")}
                             );
-                        } else if (illegalProps.length > 0) {
-                            return gettext("You can only use the following properties:") +
-                                " " + legal.join(', ');
                         } else if (invalidProps.length > 0) {
                             return util.format(
                                 gettext("{props} are invalid properties"),
@@ -632,8 +626,16 @@ var slugToProp = {
                 actions.push(simpleNode('create', makeColumns(createProps)));
             }
 
-            if (updatesCase(mug)) {
-                actions.push(simpleNode('update', makeColumns(mug.p.updateProperty)));
+            // <update> from extra create properties or standalone update action
+            var updateProps = {};
+            if (createsCase(mug) && mug.p.createProperty) {
+                _.extend(updateProps, _.omit(mug.p.createProperty, ""));
+            }
+            if (updatesCase(mug) && mug.p.updateProperty) {
+                _.extend(updateProps, _.omit(mug.p.updateProperty, ""));
+            }
+            if (!_.isEmpty(updateProps)) {
+                actions.push(simpleNode('update', makeColumns(updateProps)));
             }
 
             if (closesCase(mug)) {
@@ -711,7 +713,7 @@ var slugToProp = {
                     }
                     ret.push(ownerBind);
                 }
-                ret = ret.concat(generateBinds('create', mug.p.createProperty));
+                ret = ret.concat(generateBinds('update', mug.p.createProperty));
             }
             if (updatesCase(mug)) {
                 ret = ret.concat(generateBinds('update', mug.p.updateProperty));

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -901,6 +901,45 @@ var slugToProp = {
         ]
     };
 
+function promoteStashedCreateBindRelevants(mug) {
+    var caseTypeRelevant = mug.p._caseTypeRelevant,
+        caseNameRelevant = mug.p._caseNameRelevant,
+        ownerIdRelevant = mug.p._ownerIdRelevant;
+    delete mug.p._caseTypeRelevant;
+    delete mug.p._caseNameRelevant;
+    delete mug.p._ownerIdRelevant;
+
+    var caseTypeAndNameRelevants = _.compact(
+        _.uniq([caseTypeRelevant, caseNameRelevant])
+    );
+    if (caseTypeAndNameRelevants.length && !mug.p.openCaseCondition) {
+        mug.p.openCaseCondition = caseTypeAndNameRelevants.join(" and ");
+    }
+
+    if (ownerIdRelevant) {
+        var redundantWithCaseTypeOrName = _.contains(
+            caseTypeAndNameRelevants,
+            ownerIdRelevant
+        );
+        var redundantWithOpenCase = ownerIdRelevant === mug.p.openCaseCondition;
+        if (!redundantWithCaseTypeOrName && !redundantWithOpenCase) {
+            mug.p.ownerIdCondition = ownerIdRelevant;
+        }
+    }
+}
+
+function mergeUpdatePropertiesIntoCreateAfterParse(mug) {
+    if (!updatesCase(mug)) {
+        return;
+    }
+    if (!mug.p.createProperty) {
+        mug.p.createProperty = {};
+    }
+    _.extend(mug.p.createProperty, mug.p.updateProperty);
+    mug.p.updateProperty = {};
+    mug.p.useUpdate = false;
+}
+
 $.vellum.plugin("saveToCase", {}, {
     init: function () {
         var opts = this.opts().saveToCase || {};
@@ -927,41 +966,8 @@ $.vellum.plugin("saveToCase", {}, {
                 return value === inner;
             });
         }
-
-        var caseTypeRelevant = mug.p._caseTypeRelevant,
-            caseNameRelevant = mug.p._caseNameRelevant,
-            ownerIdRelevant = mug.p._ownerIdRelevant;
-        delete mug.p._caseTypeRelevant;
-        delete mug.p._caseNameRelevant;
-        delete mug.p._ownerIdRelevant;
-
-        var caseTypeAndNameRelevants = _.compact(
-            _.uniq([caseTypeRelevant, caseNameRelevant])
-        );
-        if (caseTypeAndNameRelevants.length && !mug.p.openCaseCondition) {
-            mug.p.openCaseCondition = caseTypeAndNameRelevants.join(" and ");
-        }
-
-        if (ownerIdRelevant) {
-            var redundantWithCaseTypeOrName = _.contains(
-                caseTypeAndNameRelevants,
-                ownerIdRelevant
-            );
-            var redundantWithOpenCase = ownerIdRelevant === mug.p.openCaseCondition;
-            if (!redundantWithCaseTypeOrName && !redundantWithOpenCase) {
-                mug.p.ownerIdCondition = ownerIdRelevant;
-            }
-        }
-        // When both Create and Update exist in parsed XML, merge update
-        // properties into createProperty so they appear in the Create section.
-        if (updatesCase(mug)) {
-            if (!mug.p.createProperty) {
-                mug.p.createProperty = {};
-            }
-            _.extend(mug.p.createProperty, mug.p.updateProperty);
-            mug.p.updateProperty = {};
-            mug.p.useUpdate = false;
-        }
+        promoteStashedCreateBindRelevants(mug);
+        mergeUpdatePropertiesIntoCreateAfterParse(mug);
     },
     getMugToolbar: function (mug, multiselect) {
         var $toolbar = this.__callOld();

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -375,6 +375,44 @@ var slugToProp = {
                     return 'pass';
                 },
             },
+            "openCaseCondition": {
+                lstring: gettext("Open Case Condition"),
+                visibility: 'visible',
+                presence: 'optional',
+                widget: widgets.xPath,
+                serialize: mugs.serializeXPath,
+                deserialize: mugs.deserializeXPath,
+            },
+            "caseName": {
+                lstring: gettext("Case Name"),
+                visibility: 'visible',
+                presence: 'optional',
+                widget: widgets.xPath,
+                serialize: mugs.serializeXPath,
+                deserialize: mugs.deserializeXPath,
+                validationFunc: function (mug) {
+                    if (mug.p.useCreate && !mug.p.caseName) {
+                        return gettext("Case Name is required");
+                    }
+                    return 'pass';
+                },
+            },
+            "ownerId": {
+                lstring: gettext("Owner ID"),
+                visibility: 'visible',
+                presence: 'optional',
+                widget: widgets.xPath,
+                serialize: mugs.serializeXPath,
+                deserialize: mugs.deserializeXPath,
+            },
+            "ownerIdCondition": {
+                lstring: gettext("Owner ID Condition"),
+                visibility: 'visible',
+                presence: 'optional',
+                widget: widgets.xPath,
+                serialize: mugs.serializeXPath,
+                deserialize: mugs.deserializeXPath,
+            },
             "case_id": {
                 lstring: gettext("Case ID"),
                 visibility: 'visible',
@@ -582,12 +620,15 @@ var slugToProp = {
 
             var actions = [];
             if (createsCase(mug)) {
-                // Include a case_type column in the create action subtree when mug.p.case_type
-                // is set so that the tree shape matches legacy forms that has case_type
-                // under create section alongside other properties.
                 var createProps = {};
                 if (mug.p.case_type || mug.p.caseTypeXPath) {
                     createProps.case_type = {};
+                }
+                if (mug.p.caseName) {
+                    createProps.case_name = {};
+                }
+                if (mug.p.ownerId) {
+                    createProps.owner_id = {};
                 }
                 _.extend(createProps, mug.p.createProperty);
                 actions.push(simpleNode('create', makeColumns(createProps)));
@@ -641,6 +682,12 @@ var slugToProp = {
                         calculate: mug.p.case_id
                     });
                 }
+                if (mug.p.openCaseCondition) {
+                    ret.push({
+                        nodeset: mug.absolutePath + "/case",
+                        relevant: mug.p.openCaseCondition
+                    });
+                }
                 // Emit /case/create/case_type bind.
                 // Use the original xpath reference if available,
                 // otherwise wrap the literal in single quotes.
@@ -649,6 +696,22 @@ var slugToProp = {
                         nodeset: mug.absolutePath + "/case/create/case_type",
                         calculate: mug.p.caseTypeXPath || "'" + mug.p.case_type + "'"
                     });
+                }
+                if (mug.p.caseName) {
+                    ret.push({
+                        nodeset: mug.absolutePath + "/case/create/case_name",
+                        calculate: mug.p.caseName
+                    });
+                }
+                if (mug.p.ownerId) {
+                    var ownerBind = {
+                        nodeset: mug.absolutePath + "/case/create/owner_id",
+                        calculate: mug.p.ownerId
+                    };
+                    if (mug.p.ownerIdCondition) {
+                        ownerBind.relevant = mug.p.ownerIdCondition;
+                    }
+                    ret.push(ownerBind);
                 }
                 ret = ret.concat(generateBinds('create', mug.p.createProperty));
             }
@@ -731,11 +794,17 @@ var slugToProp = {
                 _.keys(mug.p.createProperty || {}),
                 _.keys(mug.p.updateProperty || {})
             );
-            // case_type is now a dedicated field rather than a createProperty entry,
+            // case_type, case_name and owner_id are now a dedicated field rather than a createProperty entry,
             // but we still include it in the properties list to keep the data
             // structure sent to HQ consistent with what it was before.
             if (mug.p.useCreate && (mug.p.case_type || mug.p.caseTypeXPath)) {
                 propertyNames.push("case_type");
+            }
+            if (mug.p.useCreate && mug.p.caseName) {
+                propertyNames.push("case_name");
+            }
+            if (mug.p.useCreate && mug.p.ownerId) {
+                propertyNames.push("owner_id");
             }
             return {
                 case_type: mug.p.case_type || '',
@@ -771,6 +840,10 @@ var slugToProp = {
                 slug: "create",
                 displayName: gettext("Create"),
                 properties: [
+                    "openCaseCondition",
+                    "caseName",
+                    "ownerId",
+                    "ownerIdCondition",
                     "createProperty",
                 ],
                 isCollapsed: function (mug) {
@@ -876,6 +949,18 @@ $.vellum.plugin("saveToCase", {}, {
     parseBindElement: function (form, el, path) {
         var mug = form.getMugByPath(path);
         if (!mug) {
+            var CASE_NODE_BIND_PATTERN = /\/case$/;
+            if (CASE_NODE_BIND_PATTERN.test(path)) {
+                var caseBasePath = path.replace(CASE_NODE_BIND_PATTERN, "");
+                mug = form.getMugByPath(caseBasePath);
+                if (mug && mug.__className === "SaveToCase") {
+                    if (el.xmlAttr('relevant')) {
+                        mug.p.openCaseCondition = el.xmlAttr("relevant");
+                    }
+                    return;
+                }
+                mug = null;
+            }
             var casePathRegex = /\/case\/(?:(create|update|index)\/([\w-]+)|(close|@date_modified|@user_id|@case_id))$/,
                 matchRet = path.match(casePathRegex),
                 basePath;
@@ -898,6 +983,19 @@ $.vellum.plugin("saveToCase", {}, {
                             } else if (stripped) {
                                 // Route create/case_type to the Case Type dropdown.
                                 mug.p.case_type = stripped;
+                            }
+                            return;
+                        }
+
+                        if (action === "create" && prop === "case_name") {
+                            mug.p.caseName = el.xmlAttr("calculate");
+                            return;
+                        }
+
+                        if (action === "create" && prop === "owner_id") {
+                            mug.p.ownerId = el.xmlAttr("calculate");
+                            if (el.xmlAttr('relevant')) {
+                                mug.p.ownerIdCondition = el.xmlAttr("relevant");
                             }
                             return;
                         }

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -10,6 +10,18 @@ import widget_index_case from "vellum/templates/widget_index_case.html";
 import widget_save_to_case from "vellum/templates/widget_save_to_case.html";
 import "vellum/core";
 
+
+function validateXPath(mug, value) {
+    if (value) {
+        try {
+            mug.form.xpath.parse(value);
+        } catch (err) {
+            return gettext("Invalid XPath expression.");
+        }
+    }
+    return 'pass';
+}
+
 function createsCase(mug) {
     return mug ? mug.p.useCreate : false;
 }
@@ -382,6 +394,9 @@ var slugToProp = {
                 widget: widgets.xPath,
                 serialize: mugs.serializeXPath,
                 deserialize: mugs.deserializeXPath,
+                validationFunc: function (mug) {
+                    return validateXPath(mug, mug.p.openCaseCondition);
+                },
             },
             "caseName": {
                 lstring: gettext("Case Name"),
@@ -412,6 +427,9 @@ var slugToProp = {
                 widget: widgets.xPath,
                 serialize: mugs.serializeXPath,
                 deserialize: mugs.deserializeXPath,
+                validationFunc: function (mug) {
+                    return validateXPath(mug, mug.p.ownerIdCondition);
+                },
             },
             "case_id": {
                 lstring: gettext("Case ID"),

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -902,12 +902,11 @@ var slugToProp = {
     };
 
 function promoteStashedCreateBindRelevants(mug) {
-    var caseTypeRelevant = mug.p._caseTypeRelevant,
-        caseNameRelevant = mug.p._caseNameRelevant,
-        ownerIdRelevant = mug.p._ownerIdRelevant;
-    delete mug.p._caseTypeRelevant;
-    delete mug.p._caseNameRelevant;
-    delete mug.p._ownerIdRelevant;
+    var stashed = mug._stashedCreateBindRelevants || {},
+        caseTypeRelevant = stashed.case_type,
+        caseNameRelevant = stashed.case_name,
+        ownerIdRelevant = stashed.owner_id;
+    delete mug._stashedCreateBindRelevants;
 
     var caseTypeAndNameRelevants = _.compact(
         _.uniq([caseTypeRelevant, caseNameRelevant])
@@ -1031,6 +1030,14 @@ $.vellum.plugin("saveToCase", {}, {
                         var prop = matchRet[2],
                             action = matchRet[1];
 
+                        function stashRelevant(key) {
+                            var relevant = el.xmlAttr('relevant');
+                            if (relevant) {
+                                mug._stashedCreateBindRelevants = mug._stashedCreateBindRelevants || {};
+                                mug._stashedCreateBindRelevants[key] = relevant;
+                            }
+                        }
+
                         if (action === "create" && prop === "case_type") {
                             var caseTypeBindValue = el.xmlAttr("calculate") || '',
                                 stripped = caseTypeBindValue.replace(/^(['"])(.*)\1$/, '$2');
@@ -1043,19 +1050,19 @@ $.vellum.plugin("saveToCase", {}, {
                                 // Route create/case_type to the Case Type dropdown.
                                 mug.p.case_type = stripped;
                             }
-                            mug.p._caseTypeRelevant = el.xmlAttr('relevant');
+                            stashRelevant('case_type');
                             return;
                         }
 
                         if (action === "create" && prop === "case_name") {
                             mug.p.caseName = el.xmlAttr("calculate");
-                            mug.p._caseNameRelevant = el.xmlAttr('relevant');
+                            stashRelevant('case_name');
                             return;
                         }
 
                         if (action === "create" && prop === "owner_id") {
                             mug.p.ownerId = el.xmlAttr("calculate");
-                            mug.p._ownerIdRelevant = el.xmlAttr('relevant');
+                            stashRelevant('owner_id');
                             return;
                         }
 

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -1030,13 +1030,13 @@ $.vellum.plugin("saveToCase", {}, {
                         var prop = matchRet[2],
                             action = matchRet[1];
 
-                        function stashRelevant(key) {
+                        var stashRelevant = function (key) {
                             var relevant = el.xmlAttr('relevant');
                             if (relevant) {
                                 mug._stashedCreateBindRelevants = mug._stashedCreateBindRelevants || {};
                                 mug._stashedCreateBindRelevants[key] = relevant;
                             }
-                        }
+                        };
 
                         if (action === "create" && prop === "case_type") {
                             var caseTypeBindValue = el.xmlAttr("calculate") || '',

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -621,16 +621,14 @@ var slugToProp = {
             var actions = [];
             if (createsCase(mug)) {
                 var createProps = {};
-                if (mug.p.case_type || mug.p.caseTypeXPath) {
-                    createProps.case_type = {};
-                }
-                if (mug.p.caseName) {
-                    createProps.case_name = {};
-                }
-                if (mug.p.ownerId) {
-                    createProps.owner_id = {};
-                }
-                _.extend(createProps, mug.p.createProperty);
+                var addCreateProp = function (key, value) {
+                    if (value) {
+                        createProps[key] = {};
+                    }
+                };
+                addCreateProp('case_type', mug.p.case_type || mug.p.caseTypeXPath);
+                addCreateProp('case_name', mug.p.caseName);
+                addCreateProp('owner_id', mug.p.ownerId);
                 actions.push(simpleNode('create', makeColumns(createProps)));
             }
 

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -934,6 +934,16 @@ $.vellum.plugin("saveToCase", {}, {
                 mug.p.ownerIdCondition = ownerIdRelevant;
             }
         }
+        // When both Create and Update exist in parsed XML, merge update
+        // properties into createProperty so they appear in the Create section.
+        if (updatesCase(mug)) {
+            if (!mug.p.createProperty) {
+                mug.p.createProperty = {};
+            }
+            _.extend(mug.p.createProperty, mug.p.updateProperty);
+            mug.p.updateProperty = {};
+            mug.p.useUpdate = false;
+        }
     },
     getMugToolbar: function (mug, multiselect) {
         var $toolbar = this.__callOld();

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -907,6 +907,31 @@ $.vellum.plugin("saveToCase", {}, {
                 return value === inner;
             });
         }
+
+        var caseTypeRelevant = mug.p._caseTypeRelevant,
+            caseNameRelevant = mug.p._caseNameRelevant,
+            ownerIdRelevant = mug.p._ownerIdRelevant;
+        delete mug.p._caseTypeRelevant;
+        delete mug.p._caseNameRelevant;
+        delete mug.p._ownerIdRelevant;
+
+        var caseTypeAndNameRelevants = _.compact(
+            _.uniq([caseTypeRelevant, caseNameRelevant])
+        );
+        if (caseTypeAndNameRelevants.length && !mug.p.openCaseCondition) {
+            mug.p.openCaseCondition = caseTypeAndNameRelevants.join(" and ");
+        }
+
+        if (ownerIdRelevant) {
+            var redundantWithCaseTypeOrName = _.contains(
+                caseTypeAndNameRelevants,
+                ownerIdRelevant
+            );
+            var redundantWithOpenCase = ownerIdRelevant === mug.p.openCaseCondition;
+            if (!redundantWithCaseTypeOrName && !redundantWithOpenCase) {
+                mug.p.ownerIdCondition = ownerIdRelevant;
+            }
+        }
     },
     getMugToolbar: function (mug, multiselect) {
         var $toolbar = this.__callOld();
@@ -982,19 +1007,19 @@ $.vellum.plugin("saveToCase", {}, {
                                 // Route create/case_type to the Case Type dropdown.
                                 mug.p.case_type = stripped;
                             }
+                            mug.p._caseTypeRelevant = el.xmlAttr('relevant');
                             return;
                         }
 
                         if (action === "create" && prop === "case_name") {
                             mug.p.caseName = el.xmlAttr("calculate");
+                            mug.p._caseNameRelevant = el.xmlAttr('relevant');
                             return;
                         }
 
                         if (action === "create" && prop === "owner_id") {
                             mug.p.ownerId = el.xmlAttr("calculate");
-                            if (el.xmlAttr('relevant')) {
-                                mug.p.ownerIdCondition = el.xmlAttr("relevant");
-                            }
+                            mug.p._ownerIdRelevant = el.xmlAttr('relevant');
                             return;
                         }
 

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -26,12 +26,11 @@ describe("The SaveToCase module", function() {
 
     it("should load and save a create property", function () {
         util.loadXML(CREATE_PROPERTY_XML);
-        var create = util.getMug("save_to_case"),
-            props = create.p.createProperty;
+        var create = util.getMug("save_to_case");
         assert.equal(create.p.case_type, "caseType");
-        assert.equal(props.case_name.calculate, "/data/name");
+        assert.equal(create.p.caseName, "/data/name");
         assert.equal(create.p.useCreate, true);
-        assert.equal(props.owner_id.calculate, '/data/meta/userID');
+        assert.equal(create.p.ownerId, '/data/meta/userID');
         assert.equal(create.p.date_modified, '/data/meta/timeEnd');
         assert.equal(create.p.user_id, "/data/meta/userID");
         util.assertXmlEqual(call("createXML"), CREATE_PROPERTY_XML);
@@ -569,10 +568,10 @@ describe("The SaveToCase module", function() {
                     "close": false,
                     "create": true,
                     "properties": [
-                        "case_name",
                         "p1",
                         "p2",
                         "case_type",
+                        "case_name",
                     ]
                 },
                 "/data/save_to_case_close": {

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -583,4 +583,198 @@ describe("The SaveToCase module", function() {
             }
         });
     });
+
+    describe("dedicated create fields", function () {
+        it("should validate caseName is required for create", function () {
+            util.loadXML("");
+            var mug = util.addQuestion("SaveToCase", "mug");
+            mug.p.useCreate = true;
+            assert.notEqual(mug.spec.caseName.validationFunc(mug), "pass");
+            mug.p.caseName = "/data/name";
+            assert.strictEqual(mug.spec.caseName.validationFunc(mug), "pass");
+        });
+
+        it("should reject reserved properties in createProperty", function () {
+            util.loadXML("");
+            var mug = util.addQuestion("SaveToCase", "mug");
+            mug.p.useCreate = true;
+            mug.p.caseName = "/data/name";
+            mug.p.createProperty = {
+                case_name: { calculate: "/data/name" },
+            };
+            assert.notEqual(mug.spec.createProperty.validationFunc(mug), "pass");
+        });
+
+        it("should emit extra create properties under <update>", function () {
+            util.loadXML("");
+            var mug = util.addQuestion("SaveToCase", "stc", {
+                case_id: 'uuid()',
+                useCreate: true,
+                case_type: 'household',
+                caseName: '/data/name',
+            });
+            mug.p.createProperty = {
+                'favorite_color': { calculate: "'blue'" },
+            };
+            var xml = call("createXML"),
+                $xml = $(xml);
+            assert.equal($xml.find('create case_name').length, 1);
+            assert.equal($xml.find('update favorite_color').length, 1);
+            assert.equal($xml.find('create favorite_color').length, 0);
+        });
+
+        it("should merge update into createProperty on parse when both create property and update property exist", function () {
+            util.loadXML(LOGIC_TEST_XML);
+            var mug = util.getMug("save_to_case_create");
+            assert.equal(mug.p.caseName, "'name'");
+            assert.equal(mug.p.useCreate, true);
+            assert.equal(mug.p.useUpdate, false);
+            assert.deepEqual(_.without(_.keys(mug.p.createProperty), ""), ["p1", "p2"]);
+        });
+
+        it("should preserve user-provided ownerIdCondition even when openCaseCondition has same condition", function () {
+            util.loadXML("");
+            util.addQuestion("SaveToCase", "stc", {
+                case_id: 'uuid()',
+                useCreate: true,
+                case_type: 'household',
+                caseName: '/data/name',
+                ownerId: '/data/loc',
+                ownerIdCondition: "/data/set_owner = 'yes'",
+                openCaseCondition: "/data/set_owner = 'yes'",
+            });
+            var xml = call("createXML"),
+                $xml = $(xml);
+            assert.equal(
+                $xml.find('bind[nodeset="/data/stc/case"]').attr('relevant'),
+                "/data/set_owner = 'yes'"
+            );
+            assert.equal(
+                $xml.find('bind[nodeset="/data/stc/case/create/owner_id"]').attr('relevant'),
+                "/data/set_owner = 'yes'"
+            );
+        });
+    });
+
+    describe("create section backward compatibility", function () {
+        function withRelevants(caseTypeRel, caseNameRel, ownerIdRel) {
+            var xml = CREATE_PROPERTY_XML;
+            if (caseTypeRel) {
+                xml = xml.replace(
+                    'nodeset="/data/save_to_case/case/create/case_type"',
+                    'nodeset="/data/save_to_case/case/create/case_type" relevant="' + caseTypeRel + '"'
+                );
+            }
+            if (caseNameRel) {
+                xml = xml.replace(
+                    'nodeset="/data/save_to_case/case/create/case_name"',
+                    'nodeset="/data/save_to_case/case/create/case_name" relevant="' + caseNameRel + '"'
+                );
+            }
+            if (ownerIdRel) {
+                xml = xml.replace(
+                    'nodeset="/data/save_to_case/case/create/owner_id"',
+                    'nodeset="/data/save_to_case/case/create/owner_id" relevant="' + ownerIdRel + '"'
+                );
+            }
+            return xml;
+        }
+
+        it("should have no openCaseCondition when no per-property relevant exists", function () {
+            util.loadXML(CREATE_PROPERTY_XML);
+            var mug = util.getMug("save_to_case");
+            assert.notOk(mug.p.openCaseCondition);
+            assert.notOk(mug.p.ownerIdCondition);
+        });
+
+        it("should promote all-same relevant to openCaseCondition and absorb owner_id", function () {
+            var cond = "/data/name != ''";
+            util.loadXML(withRelevants(cond, cond, cond));
+            var mug = util.getMug("save_to_case");
+            assert.equal(mug.p.openCaseCondition, cond);
+            assert.notOk(mug.p.ownerIdCondition);
+        });
+
+        it("should keep owner_id-only relevant as ownerIdCondition", function () {
+            util.loadXML(withRelevants(null, null, "/data/name != ''"));
+            var mug = util.getMug("save_to_case");
+            assert.notOk(mug.p.openCaseCondition);
+            assert.equal(mug.p.ownerIdCondition, "/data/name != ''");
+        });
+
+        it("should promote case_name-only relevant to openCaseCondition", function () {
+            util.loadXML(withRelevants(null, "/data/name != ''", null));
+            var mug = util.getMug("save_to_case");
+            assert.equal(mug.p.openCaseCondition, "/data/name != ''");
+            assert.notOk(mug.p.ownerIdCondition);
+        });
+
+        it("should combine different case_name and case_type relevants with 'and'", function () {
+            util.loadXML(withRelevants("1 = 1", "/data/name != ''", null));
+            var mug = util.getMug("save_to_case");
+            assert.include(mug.p.openCaseCondition, "1 = 1");
+            assert.include(mug.p.openCaseCondition, "/data/name != ''");
+            assert.include(mug.p.openCaseCondition, " and ");
+        });
+
+        it("should promote case_type relevant and keep different owner_id as ownerIdCondition", function () {
+            util.loadXML(withRelevants("1 = 1", null, "/data/name != ''"));
+            var mug = util.getMug("save_to_case");
+            assert.equal(mug.p.openCaseCondition, "1 = 1");
+            assert.equal(mug.p.ownerIdCondition, "/data/name != ''");
+        });
+
+        it("should promote shared case_name+owner_id relevant and absorb owner_id", function () {
+            var cond = "/data/name != ''";
+            util.loadXML(withRelevants(null, cond, cond));
+            var mug = util.getMug("save_to_case");
+            assert.equal(mug.p.openCaseCondition, cond);
+            assert.notOk(mug.p.ownerIdCondition);
+        });
+
+        it("should output case-level relevant instead of per-property relevant after loading legacy form", function () {
+            var cond = "/data/name != ''";
+            util.loadXML(withRelevants(cond, cond, cond));
+            var xml = call("createXML"),
+                $xml = $(xml);
+            assert.equal(
+                $xml.find('bind[nodeset="/data/save_to_case/case"]').attr('relevant'),
+                cond
+            );
+            assert.notOk(
+                $xml.find('bind[nodeset="/data/save_to_case/case/create/case_type"]').attr('relevant')
+            );
+            assert.notOk(
+                $xml.find('bind[nodeset="/data/save_to_case/case/create/case_name"]').attr('relevant')
+            );
+            assert.notOk(
+                $xml.find('bind[nodeset="/data/save_to_case/case/create/owner_id"]').attr('relevant')
+            );
+        });
+    });
+
+    describe("openCaseCondition promotion", function () {
+        it("should preserve user-provided ownerIdCondition even when openCaseCondition has same condition", function () {
+            util.loadXML("");
+            util.addQuestion("SaveToCase", "stc", {
+                case_id: 'uuid()',
+                useCreate: true,
+                case_type: 'household',
+                caseName: '/data/name',
+                ownerId: '/data/loc',
+                ownerIdCondition: "/data/set_owner = 'yes'",
+                openCaseCondition: "/data/set_owner = 'yes'",
+            });
+            var xml = call("createXML"),
+                $xml = $(xml);
+            assert.equal(
+                $xml.find('bind[nodeset="/data/stc/case"]').attr('relevant'),
+                "/data/set_owner = 'yes'"
+            );
+            assert.equal(
+                $xml.find('bind[nodeset="/data/stc/case/create/owner_id"]').attr('relevant'),
+                "/data/set_owner = 'yes'"
+            );
+        });
+    });
 });


### PR DESCRIPTION
## Product Description

The old Create section required users to manually enter case_name, case_type, and owner_id as generic key-value properties, each with a Property Name, Calculation, and an optional Relevant (update condition) field. We’ve already reconciled case_type with a top-level dropdown. This PR is to:
- make case_name and owner_id dedicated single fields that only require dragging and dropping a question reference - removing the need to type property names manually.
- when the action is create, user no longer needs to select update action as well to put other case properties, user can add other case properties in "Case Properties To Create"

Before
<img width="502" height="479" alt="Screenshot 2026-04-16 at 10 22 08 AM" src="https://github.com/user-attachments/assets/29993cda-4576-40de-adf2-d6019ee26f22" />

After
<img width="671" height="525" alt="Screenshot 2026-04-16 at 10 18 52 AM" src="https://github.com/user-attachments/assets/0e7cb870-a7ff-4caf-a9ca-176b32ae4c7b" />

### Backward compatibility

Legacy forms that used per-property `relevant` on `case_type`, `case_name`, or `owner_id` create binds are automatically migrated:
- `case_type` and `case_name` relevants are promoted to **Open Case Condition** (combined with `and` if they differ).
- `owner_id` relevant is absorbed if it matches the promoted condition, otherwise kept as **Owner ID Condition**.
- Legacy forms with both `<create>` and `<update>` sections merge update properties into the Create section.

See the [design decision document](https://docs.google.com/document/d/1a2S1b1spUumzGV82FrrloZ01GER5qkAnwtjg12JhAto/edit?tab=t.2g3s56t3ix7z#bookmark=id.dfsjehh4860) for the full rationale on how `relevant` fields are handled.

## Technical Summary

Ticket: https://dimagi.atlassian.net/browse/SAAS-19457

### Why `aec64e3` (XPath validation) is needed

The xPath widget's built-in logic reference tracking (via the logic manager) validates expressions during interactive editing — but it does NOT validate on form load. When a legacy form with an invalid XPath in a promoted `relevant` is loaded, the logic manager silently fails to track references without producing an error. The `validationFunc` in `aec64e3` catches this by running `form.xpath.parse()` during `mug.validate()`, which fires when the mug is displayed. The message text matches the logic manager's message (`"Invalid XPath expression."` with period) so `getMessages` deduplicates them during interactive editing.

## Feature Flag

`VELLUM_SAVE_TO_CASE`

## Safety Assurance

### Safety story

Tested locally multiple times. I also test on [production forms that has per-property relevant](https://docs.google.com/spreadsheets/d/1R5zTAz36bLehx-p35k3OFRqK9TI2By_mjSSPKYIAGHw/edit?gid=0#gid=0) to make sure them will load as expected so user's workflow won't be disrupted. 

### Automated test coverage

New test suites:
- **"dedicated create fields"**
- **"create section backward compatibility"**

### QA Plan

- Load existing production forms with per-property relevant → verify Open Case Condition is populated, no per-property relevant in output
- Create new form with Open Case Condition → verify case-level bind in XML
- Verify bubbles display correctly for promoted conditions
- Verify invalid XPath shows exactly one warning message

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change