### PR TITLE
Return standard CommCare HQ case_mapping_diff format

### DIFF
--- a/src/caseDiff.js
+++ b/src/caseDiff.js
@@ -88,3 +88,63 @@ function countExactMatches(item, baseline, incoming, cache) {
     }
     return num;
 }
+
+/**
+ * Convert combined mapping diff to case_mapping_diff format accepted by HQ
+ *
+ * NOTE: the provided `diff` object may be mutated, and future mutations
+ * to it or the returned object may mutually affect each other.
+ *
+ * Combined format: all properties grouped under 'add' and 'delete' keys:
+ *   {
+ *     "add": {
+ *       "name": [{"question_path": ...}, ...]
+ *       "case-property": [{"question_path": ...}, ...]
+ *       ...
+ *     },
+ *     "delete": {
+ *       "name": [{"question_path": ...}, ...]
+ *       "case-property": [{"question_path": ...}, ...]
+ *       ...
+ *     },
+ *   }
+ *
+ * Standard HQ "case_mapping_diff" format for registration forms:
+ *   {
+ *     "open_case": {
+ *       // "name" diffs
+ *       "add": [{"question_path": ...}, ...],
+ *       "delete": [{"question_path": ...}, ...],
+ *     },
+ *     "update_case": {
+ *       "add": {
+ *         "case-property": [{"question_path": ...}, ...]
+ *         ...
+ *       },
+ *       "delete": {
+ *         "case-property": [{"question_path": ...}, ...]
+ *         ...
+ *       },
+ *     },
+ *   }
+ * 
+ * Non-registration forms do not produce an "open_case" item, and
+ * instead all diffs are included under "update_case".
+ *
+ * @param {Object} diff Diff object created by compareCaseMappings.
+ */
+export function formatCaseMappingDiff(diff, is_registration_form) {
+    const result = {"update_case": diff};
+    if (is_registration_form) {
+        result.open_case = {};
+        if (diff.add?.name) {
+            result.open_case.add = diff.add.name;
+            delete diff.add.name;
+        }
+        if (diff.delete?.name) {
+            result.open_case.delete = diff.delete.name;
+            delete diff.delete.name;
+        }
+    }
+    return result;
+}

--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -7,7 +7,7 @@ import tmpAutoAssign from "vellum/templates/case_management_auto_assign_name.htm
 import tplAutoAssignedName from "vellum/templates/case_management_auto_assigned_name.html";
 import util from "vellum/util";
 import widgets from "vellum/widgets";
-import { compareCaseMappings } from "vellum/caseDiff";
+import { compareCaseMappings, formatCaseMappingDiff } from "vellum/caseDiff";
 
 
 function casePropertyDropdownWidget (mug, opts) {
@@ -689,8 +689,9 @@ $.vellum.plugin('caseManagement', {}, {
     augmentSentData: function (sentData, saveType) {
         const result = this.__callOld();
         const data = this.data.caseManagement;
+        const is_reg = this.data.caseManagement.is_registration_form;
         const diff = compareCaseMappings(data.baseline, data.caseMappings);
-        result.mapping_diff = JSON.stringify(diff);
+        result.case_mapping_diff = JSON.stringify(formatCaseMappingDiff(diff, is_reg));
         return result;
     }
 

--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -159,6 +159,44 @@ function addMultipleAssignmentsMessageToMug(mug, url) {
     mug.addMessage('caseProperty', message);
 }
 
+/**
+ * Add case mappings to plugin data
+ *
+ * Mappings for unknown questions are not added to the plugin data.
+ *
+ * @param {Object} caseMappings - {"caseProperty": [{"question_path": ...}, ...], ...}
+ * @param {Object} data - plugin data to which caseMappings and
+ *                        caseMappingsByQuestion will be assigned.
+ * @param {Form} form
+ */
+function addCaseMappingsToPlugin(caseMappings, data, form) {
+    function isKnownQuestion(question) {
+        const path = question.question_path;
+        if (!path) {
+            return false;
+        } else if (!Object.hasOwn(cache, path)) {
+            cache[path] = !!form.getMugByPath(path);
+        }
+        return cache[path];
+    }
+    const cache = {};
+    const mappings = {};
+    const byQuestion = {};
+    Object.entries(caseMappings).forEach(([property, questions]) => {
+        questions = questions.filter(isKnownQuestion);
+        if (questions.length) {
+            mappings[property] = questions;
+            questions.forEach(question => {
+                const path = question.question_path;
+                byQuestion[path] = byQuestion[path] || [];
+                byQuestion[path].push(property);
+            });
+        }
+    });
+    data.caseMappings = mappings;
+    data.caseMappingsByQuestion = byQuestion;
+}
+
 class XMLCaseMappingsBuilder {
     getMappings (xml) {
         if (!xml) {
@@ -197,44 +235,6 @@ class XMLCaseMappingsBuilder {
 
         return question;
     }
-}
-
-/**
- * Add case mappings to plugin data
- *
- * Mappings for unknown questions are not added to the plugin data.
- *
- * @param {Object} caseMappings - {"caseProperty": [{"question_path": ...}, ...], ...}
- * @param {Object} data - plugin data to which caseMappings and
- *                        caseMappingsByQuestion will be assigned.
- * @param {Form} form
- */
-function addCaseMappingsToPlugin(caseMappings, data, form) {
-    function isKnownQuestion(question) {
-        const path = question.question_path;
-        if (!path) {
-            return false;
-        } else if (!Object.hasOwn(cache, path)) {
-            cache[path] = !!form.getMugByPath(path);
-        }
-        return cache[path];
-    }
-    const cache = {};
-    const mappings = {};
-    const byQuestion = {};
-    Object.entries(caseMappings).forEach(([property, questions]) => {
-        questions = questions.filter(isKnownQuestion);
-        if (questions.length) {
-            mappings[property] = questions;
-            questions.forEach(question => {
-                const path = question.question_path;
-                byQuestion[path] = byQuestion[path] || [];
-                byQuestion[path].push(property);
-            });
-        }
-    });
-    data.caseMappings = mappings;
-    data.caseMappingsByQuestion = byQuestion;
 }
 
 class XMLCaseMappingWriter {

--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -159,8 +159,8 @@ function addMultipleAssignmentsMessageToMug(mug, url) {
     mug.addMessage('caseProperty', message);
 }
 
-class CaseMappingsBuilder {
-    getMappingsFromXML (xml) {
+class XMLCaseMappingsBuilder {
+    getMappings (xml) {
         if (!xml) {
             return;
         }
@@ -486,8 +486,8 @@ $.vellum.plugin('caseManagement', {}, {
             const mappings = JSON.parse(JSON.stringify(data.baseline));
             addCaseMappingsToPlugin(mappings, data, form);
         } else {
-            const builder = new CaseMappingsBuilder();
-            const mappings = builder.getMappingsFromXML(xml);
+            const builder = new XMLCaseMappingsBuilder();
+            const mappings = builder.getMappings(xml);
             if (mappings) {
                 addCaseMappingsToPlugin(mappings, data, form);
             }

--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -303,7 +303,8 @@ class CaseMapMaintainer {
     }
 
     replaceFormPropertyMappings (questionPath, prev, current) {
-        let questions = prev ? this.data.caseMappings[prev] || [] : [];
+        const mappings = this.data.caseMappings;
+        let questions = prev ? mappings[prev] || [] : [];
         let question = null;
 
         let prevIndex = questions.findIndex((question) => question.question_path === questionPath);
@@ -314,7 +315,7 @@ class CaseMapMaintainer {
             questions.splice(prevIndex, 1);
             if (questions.length === 0) {
                 // delete the old case property questions
-                delete this.data.caseMappings[prev];
+                delete mappings[prev];
             } else if (questions.length === 1) {
                 // this case property is now unique, so we can remove conflict warnings from the remaining mug
                 const remainingMug = this.form.getMugByPath(questions[0].question_path);
@@ -329,7 +330,7 @@ class CaseMapMaintainer {
         }
 
         if (current) {
-            this.data.caseMappings[current] = this.data.caseMappings[current] || [];
+            mappings[current] = mappings[current] || [];
             if (!question) {
                 const originals = this.data.baseline[current];
                 question = originals?.find(q => q.question_path === questionPath);
@@ -337,13 +338,13 @@ class CaseMapMaintainer {
                     question = {'question_path': questionPath};
                 }
             }
-            this.data.caseMappings[current].push(question);
+            mappings[current].push(question);
 
-            if (this.data.caseMappings[current].length >= 2) {
+            if (mappings[current].length >= 2) {
                 // this new mapping creates a conflict, so add a warning to each assigned question
                 // these warnings will cause the save button to mention validation errors,
                 // but they do not prevent saving the form
-                this.data.caseMappings[current].forEach(question => {
+                mappings[current].forEach(question => {
                     const mugWithConflict = this.form.getMugByPath(question.question_path);
                     addConflictMessageToMug(mugWithConflict, current);
                 });

--- a/tests/caseDiff.js
+++ b/tests/caseDiff.js
@@ -1,5 +1,5 @@
 import chai from "chai";
-import { compareCaseMappings } from "vellum/caseDiff";
+import { compareCaseMappings, formatCaseMappingDiff } from "vellum/caseDiff";
 
 const assert = chai.assert;
 
@@ -192,5 +192,85 @@ describe("The Case Management diff tool", function () {
         const baseline = {one: [{question_path: "/data/first", update_mode: "edit"}]};
         const incoming = {one: [{question_path: "/data/first", update_mode: "edit"}]};
         assert.deepEqual(compareCaseMappings(baseline, incoming), {});
+    });
+});
+
+describe("The Case Management diff formatter", () => {
+    it("should keep all mappings in 'update_case' for non-registration form", () => {
+        const diff = {
+            add: {name: [{question_path: "/data/one"}]},
+            delete: {name: [{question_path: "/data/two"}]},
+        };
+        assert.deepEqual(formatCaseMappingDiff(diff), {
+            "update_case": {
+                add: {name: [{question_path: "/data/one"}]},
+                delete: {name: [{question_path: "/data/two"}]},
+            },
+        });
+    });
+
+    it("should put 'name' mappings in 'open_case' for registration form", () => {
+        const diff = {
+            add: {
+                name: [{question_path: "/data/one"}],
+                age: [{question_path: "/data/two"}],
+                dob: [{question_path: "/data/three"}],
+            },
+            delete: {
+                name: [{question_path: "/data/four"}],
+                age: [{question_path: "/data/five"}],
+                dob: [{question_path: "/data/six"}],
+            },
+        };
+        assert.deepEqual(formatCaseMappingDiff(diff, true), {
+            "open_case": {
+                add: [{question_path: "/data/one"}],
+                delete: [{question_path: "/data/four"}],
+            },
+            "update_case": {
+                add: {
+                    age: [{question_path: "/data/two"}],
+                    dob: [{question_path: "/data/three"}],
+                },
+                delete: {
+                    age: [{question_path: "/data/five"}],
+                    dob: [{question_path: "/data/six"}],
+                },
+            }
+        });
+    });
+
+    it("should handle missing 'delete' for registration form", () => {
+        const diff = {
+            add: {
+                name: [{question_path: "/data/one"}],
+                age: [{question_path: "/data/two"}],
+            },
+        };
+        assert.deepEqual(formatCaseMappingDiff(diff, true), {
+            "open_case": {
+                add: [{question_path: "/data/one"}],
+            },
+            "update_case": {
+                add: {age: [{question_path: "/data/two"}]},
+            }
+        });
+    });
+
+    it("should handle missing 'add' for registration form", () => {
+        const diff = {
+            delete: {
+                name: [{question_path: "/data/three"}],
+                age: [{question_path: "/data/four"}],
+            },
+        };
+        assert.deepEqual(formatCaseMappingDiff(diff, true), {
+            "open_case": {
+                delete: [{question_path: "/data/three"}],
+            },
+            "update_case": {
+                delete: {age: [{question_path: "/data/four"}]},
+            }
+        });
     });
 });

--- a/tests/static/caseManagement/invalid_mapping.xml
+++ b/tests/static/caseManagement/invalid_mapping.xml
@@ -22,15 +22,15 @@
 				</translation>
 			</itext>
 		</model>
+        <vellum:case_mappings>
+            <mapping property="one">
+                <question question_path="/data/question2" />
+            </mapping>
+        </vellum:case_mappings>
 	</h:head>
 	<h:body>
 		<input vellum:ref="#form/question1" ref="/data/question1">
 			<label ref="jr:itext('question1-label')" />
 		</input>
 	</h:body>
-	<vellum:case_mappings>
-		<mapping property="one">
-			<question question_path="/data/question2" />
-		</mapping>
-	</vellum:case_mappings>
 </h:html>


### PR DESCRIPTION
## Product Description

No user-facing changes.

## Technical Summary

- Replace the `mapping_diff` payload with a `case_mapping_diff` payload shaped to match [HQ's standard case-mapping-diff format](https://github.com/dimagi/commcare-hq/pull/37602/changes/70c346400eeb3778a77f0ca270ae702ae37f3f47). Add `formatCaseMappingDiff` in `caseDiff.js` with unit tests covering registration and non-registration forms and both add/delete branches.
- Fix a test fixture that had `vellum:case_mappings` placed outside of `h:head` (the real writer has always put it inside `h:head`, so the fixture was not representative).
- Small refactor in `replaceFormPropertyMappings` to alias `this.data.caseMappings` to a local variable.
- Rename `CaseMappingsBuilder` → `XMLCaseMappingsBuilder` and move it adjacent to `XMLCaseMappingWriter` so the XML read/write pair lives together. The `getMappingsFromXML` method is renamed to `getMappings` to avoid stuttering with the class name.

## Feature Flag

`FORMBUILDER_SAVE_TO_CASE`

## Safety Assurance

### Safety story

The payload key change (`mapping_diff` → `case_mapping_diff`) is already supported by HQ. The diff content itself is computed by the same `compareCaseMappings` function as before; only the surrounding envelope has changed, and the reshape is covered by unit tests. The class rename and file relocation are mechanical refactors with no behavioral change.

### Automated test coverage

Yes.


### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
