### PR TITLE
UI Improvements for Locked Admin Questions

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1966,6 +1966,12 @@ fn.setTreeValidationIcon = function (mug) {
     }
 };
 
+/**
+ * Extension point for plugins to add inline icons next to mug name in the form tree.
+ * Should populate a data.extraIcons object on the mug's corresponding jstree node.
+ * 
+ * @param mug - The mug to add icons for.
+ */
 fn.setTreeExtraIcons = function (mug) {};
 
 fn._resetMessages = function (errors) {

--- a/src/core.js
+++ b/src/core.js
@@ -1028,6 +1028,10 @@ fn._createJSTree = function () {
                 var args = Array.prototype.slice.call(arguments),
                     node = this.parent.redraw_node.apply(this.inst, args);
                 obj = this.inst.get_node(obj);
+                // add any extra icons if present
+                if (node && obj.data?.extraIcons) {
+                    $(node).find('a > i').first().after(Object.values(obj.data.extraIcons));
+                }
                 // decorate node with error indicator if present
                 if (node && obj.data && obj.data.errors) {
                     $(node).find('a > i').first().after(obj.data.errors);
@@ -1529,6 +1533,7 @@ fn._populateTree = function (selectedHashtag) {
             if (!changed && mug.hasErrors()) {
                 _this.setTreeValidationIcon(mug);
             }
+            _this.setTreeExtraIcons(mug);
             _this.setTreeActions(mug);
         }
     });
@@ -1960,6 +1965,8 @@ fn.setTreeValidationIcon = function (mug) {
         this.jstree("redraw_node", node);
     }
 };
+
+fn.setTreeExtraIcons = function (mug) {};
 
 fn._resetMessages = function (errors) {
     var error, messages_div = this.$f.find('.fd-messages');

--- a/src/dataSourceWidgets.js
+++ b/src/dataSourceWidgets.js
@@ -190,7 +190,12 @@ function fixtureWidget(mug, options, labelText) {
     if (options.hasAdvancedEditor) {
         widget.getUIElement = function () {
             var query = widgets.util.getUIElementWithEditButton(
-                    widgets.util.getUIElement(widget.input, labelText),
+                    widgets.util.getUIElement(
+                        widget.input,
+                        labelText,
+                        !!widget.isDisabled(),
+                        widget.getHelp(),
+                    ),
                     function () {
                         mug.form.vellum.displaySecondaryEditor({
                             source: getSource(mug),
@@ -206,7 +211,8 @@ function fixtureWidget(mug, options, labelText) {
                                 }
                             }
                         });
-                    }
+                    },
+                    !!widget.isDisabled(),
                 );
             query.find(".fd-edit-button").text("...");
             return $("<div></div>").append(query);

--- a/src/lock.js
+++ b/src/lock.js
@@ -98,7 +98,11 @@ $.vellum.plugin("lock", {}, {
             help: gettext("A locked question cannot be edited, moved, or deleted from the form."),
             helpURL: "https://www.example.com",  // placeholder for public documentation
             serialize: () => {},
-            deserialize: () => {},
+            deserialize: (data, key, mug, context) => {
+                if (mug.p.rawBindAttributes && mug.p.rawBindAttributes[LOCKED_BIND_ATTR]) {
+                    delete mug.p.rawBindAttributes[LOCKED_BIND_ATTR];
+                }
+            },
             setter: function (mug, attr, value) {
                 if (value === true) {
                     mug.p.rawBindAttributes = mug.p.rawBindAttributes || {};

--- a/src/lock.js
+++ b/src/lock.js
@@ -60,7 +60,7 @@ $.vellum.plugin("lock", {}, {
     handleMugParseFinish: function (mug) {
         this.__callOld();
         if (_.contains(SELECT_CLASSES, mug.__className)) {
-            setControlOnlyChildrenLocked(mug);
+            propagateLockToControlOnlyChildren(mug);
         }
     },
     setTreeActions: function (mug) {
@@ -122,21 +122,19 @@ $.vellum.plugin("lock", {}, {
                 _this.setTreeExtraIcons(mug);
 
                 if (_.contains(SELECT_CLASSES, mug.__className)) {
-                    setControlOnlyChildrenLocked(mug);
+                    propagateLockToControlOnlyChildren(mug);
                 }
 
                 if (!mug.form.isLoadingXForm) {
                     if (_.contains(GROUP_CLASSES, mug.__className)) {
-                        cascadeLockToChildren(mug, value);
+                        cascadeLockToDescendants(mug, value);
                     } else if (_.contains(STATIC_SELECT_CLASSES, mug.__className)) {
                         _this.setTreeActions(mug);
                     }
                     if (_this.getCurrentlySelectedMug() === mug) {
                         _this.displayMugProperties(mug);
                     }
-                    if (mug.parentMug) {
-                        updateParentTreeIcons(mug.parentMug);
-                    }
+                    updateAncestorTreeIcons(mug);
                 }
             },
         };
@@ -185,29 +183,29 @@ $.vellum.plugin("lock", {}, {
         return false;
     },
     isMugPathMoveable: function (mug) {
-        return this.__callOld() && !mug.p.locked && !hasLockedChildren(mug);
+        return this.__callOld() && !mug.p.locked && !hasLockedDescendants(mug);
     },
     isMugRemoveable: function (mug) {
-        return this.__callOld() && !mug.p.locked && !hasLockedChildren(mug);
+        return this.__callOld() && !mug.p.locked && !hasLockedDescendants(mug);
     },
     isMugTypeChangeable: function (mug) {
         return this.__callOld() && !mug.p.locked;
     },
 });
 
-function hasLockedChildren(mug) {
+function hasLockedDescendants(mug) {
     return mug.form.getChildren(mug).some(child =>
-        child.p.locked || hasLockedChildren(child)
+        child.p.locked || hasLockedDescendants(child)
     );
 }
 
-function hasUnlockedChildren(mug) {
+function hasUnlockedDescendants(mug) {
     return mug.form.getChildren(mug).some(child =>
-        !child.p.locked || hasUnlockedChildren(child)
+        !child.p.locked || hasUnlockedDescendants(child)
     );
 }
 
-function setControlOnlyChildrenLocked(mug) {
+function propagateLockToControlOnlyChildren(mug) {
     mug.form.getChildren(mug).forEach(child => {
         if (child.options.isControlOnly) {
             child.p.set('locked', mug.p.locked);
@@ -215,17 +213,18 @@ function setControlOnlyChildrenLocked(mug) {
     });
 }
 
-function cascadeLockToChildren(mug, value) {
+function cascadeLockToDescendants(mug, value) {
     mug.form.getChildren(mug).forEach(child => {
         if (child.p.locked !== value) {
             child.p.locked = value;
         } else if (_.contains(GROUP_CLASSES, child.__className)) {
-            cascadeLockToChildren(child, value);
+            cascadeLockToDescendants(child, value);
         }
     });
 }
 
-function updateParentTreeIcons(parent) {
+function updateAncestorTreeIcons(mug) {
+    let parent = mug.parentMug;
     while (parent) {
         if (parent.p.locked && _.contains(GROUP_CLASSES, parent.__className)) {
             parent.form.vellum.setTreeExtraIcons(parent);
@@ -242,7 +241,7 @@ function treeLockIcon(mug) {
     let iconClass = "fa-lock";
     let tooltipText = gettext("Only a user with permission can edit this question.");
     if (_.contains(GROUP_CLASSES, mug.__className)) {
-        if (hasUnlockedChildren(mug)) {
+        if (hasUnlockedDescendants(mug)) {
             iconClass = "fa-unlock";
             tooltipText = gettext(
                 "Only a user with permission can edit this group. " +

--- a/src/lock.js
+++ b/src/lock.js
@@ -54,7 +54,7 @@ $.vellum.plugin("lock", {}, {
     },
     handleMugParseFinish: function (mug) {
         this.__callOld();
-        setLockedFromParent(mug);
+        setControlOnlyChildrenLocked(mug);
     },
     setTreeActions: function (mug) {
         if (!mug.options.hasOwnProperty('_originalCanAddChoices')) {
@@ -113,7 +113,9 @@ $.vellum.plugin("lock", {}, {
                     delete _this.data.lock.locks[mug.ufid];
                 }
                 mug.p.set(attr, value);
-                mug.form.getChildren(mug).forEach(child => setLockedFromParent(child));
+                if (_.contains(["Select", "MSelect"], mug.__className)) {
+                    setControlOnlyChildrenLocked(mug);
+                }
                 _this.setTreeExtraIcons(mug);
 
                 if (!mug.form.isLoadingXForm) {
@@ -196,10 +198,12 @@ function hasUnlockedChildren(mug) {
     );
 }
 
-function setLockedFromParent(mug) {
-    if (mug.parentMug && mug.options.isControlOnly) {
-        mug.p.set('locked', mug.parentMug.p.locked);
-    }
+function setControlOnlyChildrenLocked(mug) {
+    mug.form.getChildren(mug).forEach(child => {
+        if (child.options.isControlOnly) {
+            child.p.set('locked', mug.p.locked);
+        }
+    });
 }
 
 function updateParentTreeIcons(parent) {

--- a/src/lock.js
+++ b/src/lock.js
@@ -113,13 +113,16 @@ $.vellum.plugin("lock", {}, {
                     delete _this.data.lock.locks[mug.ufid];
                 }
                 mug.p.set(attr, value);
+                _this.setTreeExtraIcons(mug);
+
                 if (_.contains(["Select", "MSelect"], mug.__className)) {
                     setControlOnlyChildrenLocked(mug);
                 }
-                _this.setTreeExtraIcons(mug);
 
                 if (!mug.form.isLoadingXForm) {
-                    if (_.contains(["Select", "MSelect"], mug.__className)) {
+                    if (mug.__className === "Group") {
+                        cascadeLockToChildren(mug, value);
+                    } else if (_.contains(["Select", "MSelect"], mug.__className)) {
                         _this.setTreeActions(mug);
                     }
                     if (_this.getCurrentlySelectedMug() === mug) {
@@ -202,6 +205,16 @@ function setControlOnlyChildrenLocked(mug) {
     mug.form.getChildren(mug).forEach(child => {
         if (child.options.isControlOnly) {
             child.p.set('locked', mug.p.locked);
+        }
+    });
+}
+
+function cascadeLockToChildren(mug, value) {
+    mug.form.getChildren(mug).forEach(child => {
+        if (child.p.locked !== value) {
+            child.p.locked = value;
+        } else if (child.__className === "Group") {
+            cascadeLockToChildren(child, value);
         }
     });
 }

--- a/src/lock.js
+++ b/src/lock.js
@@ -41,9 +41,10 @@ $.vellum.plugin("lock", {}, {
         setLockedFromParent(mug);
     },
     setTreeActions: function (mug) {
-        if (mug.p.locked) {
-            mug.options.canAddChoices = false;
+        if (!mug.options.hasOwnProperty('_originalCanAddChoices')) {
+            mug.options._originalCanAddChoices = mug.options.canAddChoices;
         }
+        mug.options.canAddChoices = mug.p.locked ? false : mug.options._originalCanAddChoices;
         this.__callOld();
     },
     setTreeExtraIcons: function (mug) {
@@ -94,6 +95,9 @@ $.vellum.plugin("lock", {}, {
                 _this.setTreeExtraIcons(mug);
 
                 if (!mug.form.isLoadingXForm) {
+                    if (_.contains(["Select", "MSelect"], mug.__className)) {
+                        _this.setTreeActions(mug);
+                    }
                     if (_this.getCurrentlySelectedMug() === mug) {
                         _this.displayMugProperties(mug);
                     }

--- a/src/lock.js
+++ b/src/lock.js
@@ -46,6 +46,22 @@ $.vellum.plugin("lock", {}, {
         }
         this.__callOld();
     },
+    setTreeExtraIcons: function (mug) {
+        this.__callOld();
+        const node = mug.ufid && this.jstree('get_node', mug.ufid);
+        if (!node) { return; }
+
+        let icon = null;
+        if (mug.p.locked) {
+            icon = treeLockIcon(mug);
+        }
+
+        if (node.data.extraIcons?.lock !== icon) {
+            node.data.extraIcons = node.data.extraIcons || {};
+            node.data.extraIcons.lock = icon;
+            this.jstree('redraw_node', node);
+        }
+    },
     getMainProperties: function () {
         const properties = this.__callOld();
         properties.splice(1 + properties.indexOf('requiredAttr'), 0, 'locked');
@@ -75,6 +91,7 @@ $.vellum.plugin("lock", {}, {
                 }
                 mug.p.set(attr, value);
                 mug.form.getChildren(mug).forEach(child => setLockedFromParent(child));
+                _this.setTreeExtraIcons(mug);
             },
         };
         return spec;
@@ -138,8 +155,38 @@ function hasLockedChildren(mug) {
     );
 }
 
+function hasUnlockedChildren(mug) {
+    return mug.form.getChildren(mug).some(child =>
+        !child.p.locked || hasUnlockedChildren(child)
+    );
+}
+
 function setLockedFromParent(mug) {
     if (mug.parentMug && mug.options.isControlOnly) {
         mug.p.set('locked', mug.parentMug.p.locked);
     }
+}
+
+function treeLockIcon(mug) {
+    if (mug.options.isControlOnly) {
+        return;
+    }
+
+    let iconClass = "fa-lock";
+    let tooltipText = gettext("Only a user with permission can edit this question.");
+    if (mug.__className === "Group") {
+        if (hasUnlockedChildren(mug)) {
+            iconClass = "fa-unlock";
+            tooltipText = gettext(
+                "Only a user with permission can edit this group. " +
+                "Some questions are unlocked."
+            );
+        } else {
+            tooltipText = gettext(
+                "Only a user with permission can edit this group. " +
+                "All questions are locked."
+            );
+        }
+    }
+    return `<i class="fa ${iconClass}" title="${tooltipText}"></i>&nbsp;`;
 }

--- a/src/lock.js
+++ b/src/lock.js
@@ -14,6 +14,7 @@ const LOCKED_BIND_ATTR = "vellum:lock";
 const LOCKED_UNEDITABLE_MSG_KEY = "mug-locked-cannot-edit";
 const LOCKED_CHILDREN_MSG_KEY = "mug-has-locked-children";
 const SELECT_CLASSES = ["Select", "MSelect", "Choice"];
+const GROUP_CLASSES = ["Group", "Repeat", "FieldList"];
 
 $.vellum.plugin("lock", {}, {
     init: function () {
@@ -120,7 +121,7 @@ $.vellum.plugin("lock", {}, {
                 }
 
                 if (!mug.form.isLoadingXForm) {
-                    if (mug.__className === "Group") {
+                    if (_.contains(GROUP_CLASSES, mug.__className)) {
                         cascadeLockToChildren(mug, value);
                     } else if (_.contains(["Select", "MSelect"], mug.__className)) {
                         _this.setTreeActions(mug);
@@ -213,7 +214,7 @@ function cascadeLockToChildren(mug, value) {
     mug.form.getChildren(mug).forEach(child => {
         if (child.p.locked !== value) {
             child.p.locked = value;
-        } else if (child.__className === "Group") {
+        } else if (_.contains(GROUP_CLASSES, child.__className)) {
             cascadeLockToChildren(child, value);
         }
     });
@@ -221,7 +222,7 @@ function cascadeLockToChildren(mug, value) {
 
 function updateParentTreeIcons(parent) {
     while (parent) {
-        if (parent.p.locked && parent.__className === "Group") {
+        if (parent.p.locked && _.contains(GROUP_CLASSES, parent.__className)) {
             parent.form.vellum.setTreeExtraIcons(parent);
         }
         parent = parent.parentMug;
@@ -235,7 +236,7 @@ function treeLockIcon(mug) {
 
     let iconClass = "fa-lock";
     let tooltipText = gettext("Only a user with permission can edit this question.");
-    if (mug.__className === "Group") {
+    if (_.contains(GROUP_CLASSES, mug.__className)) {
         if (hasUnlockedChildren(mug)) {
             iconClass = "fa-unlock";
             tooltipText = gettext(

--- a/src/lock.js
+++ b/src/lock.js
@@ -92,6 +92,12 @@ $.vellum.plugin("lock", {}, {
                 mug.p.set(attr, value);
                 mug.form.getChildren(mug).forEach(child => setLockedFromParent(child));
                 _this.setTreeExtraIcons(mug);
+
+                if (!mug.form.isLoadingXForm) {
+                    if (mug.parentMug) {
+                        updateParentTreeIcons(mug.parentMug);
+                    }
+                }
             },
         };
         return spec;
@@ -164,6 +170,15 @@ function hasUnlockedChildren(mug) {
 function setLockedFromParent(mug) {
     if (mug.parentMug && mug.options.isControlOnly) {
         mug.p.set('locked', mug.parentMug.p.locked);
+    }
+}
+
+function updateParentTreeIcons(parent) {
+    while (parent) {
+        if (parent.p.locked && parent.__className === "Group") {
+            parent.form.vellum.setTreeExtraIcons(parent);
+        }
+        parent = parent.parentMug;
     }
 }
 

--- a/src/lock.js
+++ b/src/lock.js
@@ -38,7 +38,7 @@ $.vellum.plugin("lock", {}, {
     },
     handleMugParseFinish: function (mug) {
         this.__callOld();
-        this._setLockedFromParent(mug);
+        setLockedFromParent(mug);
     },
     setTreeActions: function (mug) {
         if (mug.p.locked) {
@@ -74,7 +74,7 @@ $.vellum.plugin("lock", {}, {
                     delete mug.p.rawBindAttributes[LOCKED_BIND_ATTR];
                 }
                 mug.p.set(attr, value);
-                mug.form.getChildren(mug).forEach(child => _this._setLockedFromParent(child));
+                mug.form.getChildren(mug).forEach(child => setLockedFromParent(child));
             },
         };
         return spec;
@@ -102,16 +102,6 @@ $.vellum.plugin("lock", {}, {
         }
         return this.__callOld();
     },
-    _hasLockedChildren: function (mug) {
-        return mug.form.getChildren(mug).some(child =>
-            child.p.locked || this._hasLockedChildren(child)
-        );
-    },
-    _setLockedFromParent: function (mug) {
-        if (mug.parentMug && mug.options.isControlOnly) {
-            mug.p.set('locked', mug.parentMug.p.locked);
-        }
-    },
     isPropertyLocked: function (mug, propertyPath) {
         const locked = this.__callOld();
         if (locked || mug.p.locked) {
@@ -132,12 +122,24 @@ $.vellum.plugin("lock", {}, {
         return false;
     },
     isMugPathMoveable: function (mug) {
-        return this.__callOld() && !mug.p.locked && !this._hasLockedChildren(mug);
+        return this.__callOld() && !mug.p.locked && !hasLockedChildren(mug);
     },
     isMugRemoveable: function (mug) {
-        return this.__callOld() && !mug.p.locked && !this._hasLockedChildren(mug);
+        return this.__callOld() && !mug.p.locked && !hasLockedChildren(mug);
     },
     isMugTypeChangeable: function (mug) {
         return this.__callOld() && !mug.p.locked;
     },
 });
+
+function hasLockedChildren(mug) {
+    return mug.form.getChildren(mug).some(child =>
+        child.p.locked || hasLockedChildren(child)
+    );
+}
+
+function setLockedFromParent(mug) {
+    if (mug.parentMug && mug.options.isControlOnly) {
+        mug.p.set('locked', mug.parentMug.p.locked);
+    }
+}

--- a/src/lock.js
+++ b/src/lock.js
@@ -16,6 +16,22 @@ const LOCKED_CHILDREN_MSG_KEY = "mug-has-locked-children";
 const SELECT_CLASSES = ["Select", "MSelect", "Choice"];
 
 $.vellum.plugin("lock", {}, {
+    init: function () {
+        const data = this.data.lock;
+        data.locks = {};
+    },
+    loadXML: function () {
+        this.__callOld();
+
+        // we don't know whether there are any locks until XML is loaded
+        // tools menu items are already defined at this point, so target what we want and remove them here
+        if (_.some(this.data.lock.locks) && !this.opts().features.edit_locked_questions) {
+            const $menu = this.$f.find('.fd-tools-menu').parent();
+            $menu.find('a:contains("' + gettext("Edit Source XML") + '")').parent().remove();
+            $menu.find('a:contains("' + gettext("Edit Bulk Translations") + '")').parent().remove();
+        }
+
+    },
     parseBindElement: function (form, el, path) {
         this.__callOld();
         const locked = el.xmlAttr(LOCKED_BIND_ATTR);
@@ -87,8 +103,10 @@ $.vellum.plugin("lock", {}, {
                 if (value === true) {
                     mug.p.rawBindAttributes = mug.p.rawBindAttributes || {};
                     mug.p.rawBindAttributes[LOCKED_BIND_ATTR] = 'all';
+                    _this.data.lock.locks[mug.ufid] = 'all';
                 } else {
                     delete mug.p.rawBindAttributes[LOCKED_BIND_ATTR];
+                    delete _this.data.lock.locks[mug.ufid];
                 }
                 mug.p.set(attr, value);
                 mug.form.getChildren(mug).forEach(child => setLockedFromParent(child));

--- a/src/lock.js
+++ b/src/lock.js
@@ -94,6 +94,9 @@ $.vellum.plugin("lock", {}, {
                 _this.setTreeExtraIcons(mug);
 
                 if (!mug.form.isLoadingXForm) {
+                    if (_this.getCurrentlySelectedMug() === mug) {
+                        _this.displayMugProperties(mug);
+                    }
                     if (mug.parentMug) {
                         updateParentTreeIcons(mug.parentMug);
                     }

--- a/src/lock.js
+++ b/src/lock.js
@@ -13,7 +13,11 @@ import widgets from "vellum/widgets";
 const LOCKED_BIND_ATTR = "vellum:lock";
 const LOCKED_UNEDITABLE_MSG_KEY = "mug-locked-cannot-edit";
 const LOCKED_CHILDREN_MSG_KEY = "mug-has-locked-children";
-const SELECT_CLASSES = ["Select", "MSelect", "Choice"];
+
+const STATIC_SELECT_CLASSES = ["Select", "MSelect"];
+const SELECT_AND_CHOICE_CLASSES = [...STATIC_SELECT_CLASSES, "Choice"];
+const DYNAMIC_SELECT_CLASSES = ["SelectDynamic", "MSelectDynamic"];
+const SELECT_CLASSES = [...STATIC_SELECT_CLASSES, ...DYNAMIC_SELECT_CLASSES];
 const GROUP_CLASSES = ["Group", "Repeat", "FieldList"];
 
 $.vellum.plugin("lock", {}, {
@@ -55,13 +59,14 @@ $.vellum.plugin("lock", {}, {
     },
     handleMugParseFinish: function (mug) {
         this.__callOld();
-        setControlOnlyChildrenLocked(mug);
+        if (_.contains(SELECT_CLASSES, mug.__className)) {
+            setControlOnlyChildrenLocked(mug);
+        }
     },
     setTreeActions: function (mug) {
-        if (!mug.options.hasOwnProperty('_originalCanAddChoices')) {
-            mug.options._originalCanAddChoices = mug.options.canAddChoices;
+        if (_.contains(STATIC_SELECT_CLASSES, mug.__className)) {
+            mug.options.canAddChoices = !mug.p.locked;
         }
-        mug.options.canAddChoices = mug.p.locked ? false : mug.options._originalCanAddChoices;
         this.__callOld();
     },
     setTreeExtraIcons: function (mug) {
@@ -116,14 +121,14 @@ $.vellum.plugin("lock", {}, {
                 mug.p.set(attr, value);
                 _this.setTreeExtraIcons(mug);
 
-                if (_.contains(["Select", "MSelect"], mug.__className)) {
+                if (_.contains(SELECT_CLASSES, mug.__className)) {
                     setControlOnlyChildrenLocked(mug);
                 }
 
                 if (!mug.form.isLoadingXForm) {
                     if (_.contains(GROUP_CLASSES, mug.__className)) {
                         cascadeLockToChildren(mug, value);
-                    } else if (_.contains(["Select", "MSelect"], mug.__className)) {
+                    } else if (_.contains(STATIC_SELECT_CLASSES, mug.__className)) {
                         _this.setTreeActions(mug);
                     }
                     if (_this.getCurrentlySelectedMug() === mug) {
@@ -148,14 +153,14 @@ $.vellum.plugin("lock", {}, {
         if (canMove) {
             const destinationMug = form.getMugByUFID(dstId);
             if (destinationMug) {
-                return !(destinationMug.p.locked && _.contains(SELECT_CLASSES, dstType));
+                return !(destinationMug.p.locked && _.contains(SELECT_AND_CHOICE_CLASSES, dstType));
             }
             return true;
         }
         return false;
     },
     getInsertTargetAndPosition: function (refMug, qType, after) {
-        if (refMug?.p.locked && _.contains(SELECT_CLASSES, refMug.__className)) {
+        if (refMug?.p.locked && _.contains(SELECT_AND_CHOICE_CLASSES, refMug.__className)) {
             return null;
         }
         return this.__callOld();

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -320,33 +320,42 @@ describe("The Lock plugin", function() {
             }
         });
 
-        it("shows a lock icon on a locked group with no unlocked children", function () {
-            const icon = getLockIcon('/data/locked_group');
-            assert(icon, "expected icon on locked group");
-            assert.include(icon, 'fa-lock');
-            assert.notInclude(icon, 'fa-unlock');
-        });
+        [
+            {type: "Group", lockedPath: '/data/locked_group',
+             withUnlockedChildrenPath: '/data/locked_group_with_unlocked_children'},
+            {type: "Repeat", lockedPath: '/data/locked_repeat',
+             withUnlockedChildrenPath: '/data/locked_repeat_with_unlocked_children'},
+            {type: "FieldList", lockedPath: '/data/locked_fieldlist',
+             withUnlockedChildrenPath: '/data/locked_fieldlist_with_unlocked_children'},
+        ].forEach(function ({type, lockedPath, withUnlockedChildrenPath}) {
+            describe(`for a locked ${type}`, function () {
+                it("shows a lock icon when there are no unlocked children", function () {
+                    const icon = getLockIcon(lockedPath);
+                    assert(icon, `expected icon on locked ${type}`);
+                    assert.include(icon, 'fa-lock');
+                    assert.notInclude(icon, 'fa-unlock');
+                });
 
-        it("updates parent group icon when child lock state changes", function () {
-            const child = getMug('/data/locked_group_with_unlocked_children/nested_unlocked');
-            try {
-                // initially has unlocked children -> fa-unlock
-                assert.include(getLockIcon('/data/locked_group_with_unlocked_children'), 'fa-unlock');
-                // lock the child -> all children locked -> fa-lock
-                child.p.locked = true;
-                const icon = getLockIcon('/data/locked_group_with_unlocked_children');
-                assert.include(icon, 'fa-lock');
-                assert.notInclude(icon, 'fa-unlock');
-            } finally {
-                child.p.locked = false;
-            }
-        });
+                it("shows an unlock icon when there are unlocked children", function () {
+                    const icon = getLockIcon(withUnlockedChildrenPath);
+                    assert(icon, `expected icon on locked ${type}`);
+                    assert.include(icon, 'fa-unlock');
+                    assert.notInclude(icon, 'fa-lock');
+                });
 
-        it("shows an unlock icon on a locked group with unlocked children", function () {
-            const icon = getLockIcon('/data/locked_group_with_unlocked_children');
-            assert(icon, "expected lock icon on locked select");
-            assert.include(icon, 'fa-unlock');
-            assert.notInclude(icon, 'fa-lock');
+                it("updates the icon when a child's lock state changes", function () {
+                    const child = getMug(`${withUnlockedChildrenPath}/nested_unlocked`);
+                    try {
+                        assert.include(getLockIcon(withUnlockedChildrenPath), 'fa-unlock');
+                        child.p.locked = true;
+                        const icon = getLockIcon(withUnlockedChildrenPath);
+                        assert.include(icon, 'fa-lock');
+                        assert.notInclude(icon, 'fa-unlock');
+                    } finally {
+                        child.p.locked = false;
+                    }
+                });
+            });
         });
     });
 

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -171,6 +171,59 @@ describe("The Lock plugin", function() {
                 '#', '#',
                 0));
         });
+
+        it("locks all children when a group is locked", function () {
+            const group = getMug('/data/group_no_lock');
+            const child = getMug('/data/group_no_lock/nested_unlocked');
+            try {
+                group.p.locked = true;
+                assert(child.p.locked, "expected child to be locked");
+            } finally {
+                group.p.locked = false;
+            }
+        });
+
+        it("unlocks all children when a group is unlocked", function () {
+            const group = getMug('/data/group_no_lock');
+            const child = getMug('/data/group_no_lock/nested_unlocked');
+            try {
+                group.p.locked = true;
+                group.p.locked = false;
+                assert(!child.p.locked, "expected child to be unlocked");
+            } finally {
+                group.p.locked = false;
+            }
+        });
+
+        it("cascades lock state through nested groups", function () {
+            const outer = getMug('/data/group_with_nested_lock');
+            const subgroup = getMug('/data/group_with_nested_lock/subgroup');
+            const deepChild = getMug('/data/group_with_nested_lock/subgroup/nested_locked');
+            try {
+                outer.p.locked = true;
+                assert(subgroup.p.locked, "expected subgroup to be locked");
+                assert(deepChild.p.locked, "expected nested child to be locked");
+                outer.p.locked = false;
+                assert(!subgroup.p.locked, "expected subgroup to be unlocked");
+                assert(!deepChild.p.locked, "expected nested child to be unlocked");
+            } finally {
+                deepChild.p.locked = true;
+            }
+        });
+
+        it("leaves a child independently toggleable after a group cascade", function () {
+            const group = getMug('/data/group_no_lock');
+            const child = getMug('/data/group_no_lock/nested_unlocked');
+            try {
+                group.p.locked = true;
+                child.p.locked = false;
+                assert(group.p.locked, "group should stay locked");
+                assert(!child.p.locked, "child should be independently unlocked");
+            } finally {
+                child.p.locked = false;
+                group.p.locked = false;
+            }
+        });
     });
 
     describe("locked select questions", function () {

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -214,6 +214,53 @@ describe("The Lock plugin", function() {
         });
     });
 
+    describe("tree icons", function () {
+        function getLockIcon(path) {
+            const mug = getMug(path);
+            const node = call('jstree', 'get_node', mug.ufid);
+            return node.data.extraIcons?.lock || null;
+        }
+
+        it("shows a lock icon on a locked question", function () {
+            const icon = getLockIcon('/data/locked');
+            assert(icon, "expected lock icon on locked question");
+            assert.include(icon, 'fa-lock');
+        });
+
+        it("does not show a lock icon on an unlocked question", function () {
+            assert.isNull(getLockIcon('/data/unlocked'));
+        });
+
+        it("does not show a lock icon on a locked choice", function () {
+            assert.isNull(getLockIcon('/data/locked_select/choice1'));
+        });
+
+        it("updates the lock icon when toggling locked", function () {
+            const mug = getMug('/data/unlocked');
+            try {
+                assert.isNull(getLockIcon('/data/unlocked'));
+                mug.p.locked = true;
+                assert(getLockIcon('/data/unlocked'), "expected lock icon after locking");
+            } finally {
+                mug.p.locked = false;
+            }
+        });
+
+        it("shows a lock icon on a locked group with no unlocked children", function () {
+            const icon = getLockIcon('/data/locked_group');
+            assert(icon, "expected icon on locked group");
+            assert.include(icon, 'fa-lock');
+            assert.notInclude(icon, 'fa-unlock');
+        });
+
+        it("shows an unlock icon on a locked group with unlocked children", function () {
+            const icon = getLockIcon('/data/locked_group_with_unlocked_children');
+            assert(icon, "expected lock icon on locked select");
+            assert.include(icon, 'fa-unlock');
+            assert.notInclude(icon, 'fa-lock');
+        });
+    });
+
     describe("edit_locked_questions feature", function () {
         describe("with the feature enabled", function () {
             before(function (done) {

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -107,6 +107,7 @@ describe("The Lock plugin", function() {
         const pasted = getMug('/data/copy-1-of-locked');
         assert(pasted, "pasted mug should exist");
         assert(!pasted.p.locked);
+        assert(!pasted.p.rawBindAttributes["vellum:lock"]);
         call('getData').core.form.removeMugsFromForm([pasted]);
     });
 

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -253,6 +253,21 @@ describe("The Lock plugin", function() {
             assert.notInclude(icon, 'fa-unlock');
         });
 
+        it("updates parent group icon when child lock state changes", function () {
+            const child = getMug('/data/locked_group_with_unlocked_children/nested_unlocked');
+            try {
+                // initially has unlocked children -> fa-unlock
+                assert.include(getLockIcon('/data/locked_group_with_unlocked_children'), 'fa-unlock');
+                // lock the child -> all children locked -> fa-lock
+                child.p.locked = true;
+                const icon = getLockIcon('/data/locked_group_with_unlocked_children');
+                assert.include(icon, 'fa-lock');
+                assert.notInclude(icon, 'fa-unlock');
+            } finally {
+                child.p.locked = false;
+            }
+        });
+
         it("shows an unlock icon on a locked group with unlocked children", function () {
             const icon = getLockIcon('/data/locked_group_with_unlocked_children');
             assert(icon, "expected lock icon on locked select");

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -130,18 +130,6 @@ describe("The Lock plugin", function() {
             assert.isFalse(locked('/data/group_no_lock', 'nodeID'));
         });
 
-        it("detects locked children recursively", function () {
-            const groupWithNestedLock = getMug('/data/group_with_nested_lock');
-            assert(call('_hasLockedChildren', groupWithNestedLock),
-                "group with deeply nested locked question should have locked children");
-            const subgroup = getMug('/data/group_with_nested_lock/subgroup');
-            assert(call('_hasLockedChildren', subgroup),
-                "subgroup directly containing locked question should have locked children");
-            const groupNoLock = getMug('/data/group_no_lock');
-            assert.isFalse(call('_hasLockedChildren', groupNoLock),
-                "group without locked children should return false");
-        });
-
         it("adds a 'locked children' message to a group that contains a locked question", function () {
             locked('/data/group_with_nested_lock', 'nodeID');
             const mug = getMug('/data/group_with_nested_lock');

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -328,6 +328,14 @@ describe("The Lock plugin", function() {
                 const spec = mug.spec.locked;
                 assert(spec.enabled(mug));
             });
+
+            it("keeps Edit Source XML and Edit Bulk Translations when there are locked questions", function () {
+                const $menu = $(".fd-tools-menu").parent();
+                assert($menu.find('a:contains("Edit Source XML")').length,
+                    "Edit Source XML should be in tools menu");
+                assert($menu.find('a:contains("Edit Bulk Translations")').length,
+                    "Edit Bulk Translations should be in tools menu");
+            });
         });
 
         describe("without the feature enabled", function () {
@@ -349,6 +357,14 @@ describe("The Lock plugin", function() {
                 const mug = getMug('/data/locked');
                 const spec = mug.spec.locked;
                 assert(!spec.enabled(mug));
+            });
+
+            it("removes Edit Source XML and Edit Bulk Translations when there are locked questions", function () {
+                const $menu = $(".fd-tools-menu").parent();
+                assert.equal($menu.find('a:contains("Edit Source XML")').length, 0,
+                    "Edit Source XML should not be in tools menu");
+                assert.equal($menu.find('a:contains("Edit Bulk Translations")').length, 0,
+                    "Edit Bulk Translations should not be in tools menu");
             });
         });
     });

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -212,6 +212,26 @@ describe("The Lock plugin", function() {
             const lockedSelect = getMug('/data/locked_select');
             assert.isFalse(lockedSelect.options.canAddChoices);
         });
+
+        it("removes the 'Add Choice' action when locking a select", function () {
+            const lockedSelect = getMug('/data/unlocked_select');
+            try {
+                lockedSelect.p.locked = true;
+                assert.isFalse(lockedSelect.options.canAddChoices);
+            } finally {
+                lockedSelect.p.locked = false;
+            }
+        });
+
+        it("adds the 'Add Choice' action when unlocking a select", function () {
+            const lockedSelect = getMug('/data/locked_select');
+            try {
+                lockedSelect.p.locked = false;
+                assert(lockedSelect.options.canAddChoices);
+            } finally {
+                lockedSelect.p.locked = true;
+            }
+        });
     });
 
     describe("tree icons", function () {

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -20,7 +20,7 @@ const assert = chai.assert,
 function beforeFn(done) {
     util.init({
         javaRosa: {langs: ['en']},
-        plugins: ['lock'],
+        plugins: ['lock', 'itemset'],
         core: {
             onReady: function () {
                 call('loadXFormOrError', TEST_XML, done);
@@ -227,64 +227,106 @@ describe("The Lock plugin", function() {
     });
 
     describe("locked select questions", function () {
-        it("propagates locked to control-only children when set", function () {
-            const mug = getMug('/data/unlocked_select');
-            const choice = getMug('/data/unlocked_select/choice1');
+        const STATIC_SELECTS = [
+            {type: "Select", lockedPath: '/data/locked_select', unlockedPath: '/data/unlocked_select'},
+            {type: "MSelect", lockedPath: '/data/locked_mselect', unlockedPath: '/data/unlocked_mselect'},
+        ];
+        const DYNAMIC_SELECTS = [
+            {
+                type: "SelectDynamic",
+                lockedPath: '/data/locked_select_dynamic',
+                unlockedPath: '/data/unlocked_select_dynamic',
+            },
+            {
+                type: "MSelectDynamic",
+                lockedPath: '/data/locked_mselect_dynamic',
+                unlockedPath: '/data/unlocked_mselect_dynamic',
+            },
+        ];
+        const ALL_SELECTS = [...STATIC_SELECTS, ...DYNAMIC_SELECTS];
 
-            mug.p.locked = true;
-            assert(choice.p.locked);
-            mug.p.locked = false;
-            assert(!choice.p.locked);
+        ALL_SELECTS.forEach(function ({type, unlockedPath}) {
+            it(`propagates locked to control-only children when ${type} is locked`, function () {
+                const mug = getMug(unlockedPath);
+                const controlOnlyChildren = mug.form.getChildren(mug)
+                    .filter(c => c.options.isControlOnly);
+                assert(controlOnlyChildren.length > 0, "expected at least one control-only child");
+                try {
+                    mug.p.locked = true;
+                    controlOnlyChildren.forEach(child =>
+                        assert(child.p.locked, `expected ${child.__className} to be locked`));
+                    mug.p.locked = false;
+                    controlOnlyChildren.forEach(child =>
+                        assert(!child.p.locked, `expected ${child.__className} to be unlocked`));
+                } finally {
+                    mug.p.locked = false;
+                }
+            });
         });
 
-        it("prevents moving choices into a locked select", function () {
-            const src = getMug('/data/unlocked_select/choice1');
-            const dst = getMug('/data/locked_select');
-            assert.isFalse(call('checkMove',
-                src.ufid, src.__className,
-                dst.ufid, dst.__className,
-                0));
+        STATIC_SELECTS.forEach(function ({type, lockedPath, unlockedPath}) {
+            it(`prevents moving choices into a locked ${type}`, function () {
+                const src = getMug(`${unlockedPath}/choice1`);
+                const dst = getMug(lockedPath);
+                assert.isFalse(call('checkMove',
+                    src.ufid, src.__className,
+                    dst.ufid, dst.__className,
+                    0));
+            });
+
+            it(`prevents pasting a choice into a locked ${type}`, function () {
+                clickQuestion(`${unlockedPath}/choice1`);
+                const serialized = copyPaste.copy();
+                clickQuestion(`${lockedPath}/choice1`);
+                const errors = copyPaste.paste(serialized);
+                assert(errors.length > 0, "expected paste errors");
+            });
+
+            it(`allows pasting a choice into an unlocked ${type}`, function () {
+                clickQuestion(`${lockedPath}/choice1`);
+                const serialized = copyPaste.copy();
+                clickQuestion(`${unlockedPath}/choice1`);
+                const errors = copyPaste.paste(serialized);
+                assert.equal(errors.length, 0, "expected no paste errors");
+            });
+
+            it(`removes the 'Add Choice' action for a locked ${type}`, function () {
+                assert.isFalse(getMug(lockedPath).options.canAddChoices);
+            });
+
+            it(`removes the 'Add Choice' action when locking a ${type}`, function () {
+                const mug = getMug(unlockedPath);
+                try {
+                    mug.p.locked = true;
+                    assert.isFalse(mug.options.canAddChoices);
+                } finally {
+                    mug.p.locked = false;
+                }
+            });
+
+            it(`adds the 'Add Choice' action when unlocking a ${type}`, function () {
+                const mug = getMug(lockedPath);
+                try {
+                    mug.p.locked = false;
+                    assert(mug.options.canAddChoices);
+                } finally {
+                    mug.p.locked = true;
+                }
+            });
         });
 
-        it("prevents pasting a choice into a locked select", function () {
-            clickQuestion('/data/unlocked_select/choice1');
-            const serialized = copyPaste.copy();
-            clickQuestion('/data/locked_select/choice1');
-            const errors = copyPaste.paste(serialized);
-            assert(errors.length > 0, "expected paste errors");
-        });
-
-        it("allows pasting a choice into an unlocked select", function () {
-            clickQuestion('/data/locked_select/choice1');
-            const serialized = copyPaste.copy();
-            clickQuestion('/data/unlocked_select/choice1');
-            const errors = copyPaste.paste(serialized);
-            assert.equal(errors.length, 0, "expected no paste errors");
-        });
-
-        it("removes the 'Add Choice' action for a locked select", function () {
-            const lockedSelect = getMug('/data/locked_select');
-            assert.isFalse(lockedSelect.options.canAddChoices);
-        });
-
-        it("removes the 'Add Choice' action when locking a select", function () {
-            const lockedSelect = getMug('/data/unlocked_select');
-            try {
-                lockedSelect.p.locked = true;
-                assert.isFalse(lockedSelect.options.canAddChoices);
-            } finally {
-                lockedSelect.p.locked = false;
-            }
-        });
-
-        it("adds the 'Add Choice' action when unlocking a select", function () {
-            const lockedSelect = getMug('/data/locked_select');
-            try {
-                lockedSelect.p.locked = false;
-                assert(lockedSelect.options.canAddChoices);
-            } finally {
-                lockedSelect.p.locked = true;
-            }
+        DYNAMIC_SELECTS.forEach(function ({type, lockedPath, unlockedPath}) {
+            it(`does not toggle canAddChoices when locking a ${type}`, function () {
+                const mug = getMug(unlockedPath);
+                const before = mug.options.canAddChoices;
+                try {
+                    mug.p.locked = true;
+                    assert.equal(mug.options.canAddChoices, before,
+                        "canAddChoices should not change for dynamic selects");
+                } finally {
+                    mug.p.locked = false;
+                }
+            });
         });
     });
 

--- a/tests/static/lock/test.xml
+++ b/tests/static/lock/test.xml
@@ -27,6 +27,14 @@
 					<locked_group_with_unlocked_children>
 						<nested_unlocked />
 					</locked_group_with_unlocked_children>
+					<locked_repeat jr:template="" />
+					<locked_repeat_with_unlocked_children jr:template="">
+						<nested_unlocked />
+					</locked_repeat_with_unlocked_children>
+					<locked_fieldlist />
+					<locked_fieldlist_with_unlocked_children>
+						<nested_unlocked />
+					</locked_fieldlist_with_unlocked_children>
 					<locked_select />
 					<unlocked_select />
 				</data>
@@ -42,6 +50,12 @@
 			<bind vellum:nodeset="#form/locked_group" nodeset="/data/locked_group" vellum:lock="all" />
 			<bind vellum:nodeset="#form/locked_group_with_unlocked_children" nodeset="/data/locked_group_with_unlocked_children" vellum:lock="all" />
 			<bind vellum:nodeset="#form/locked_group_with_unlocked_children/nested_unlocked" nodeset="/data/locked_group_with_unlocked_children/nested_unlocked" type="xsd:string" />
+			<bind vellum:nodeset="#form/locked_repeat" nodeset="/data/locked_repeat" vellum:lock="all" />
+			<bind vellum:nodeset="#form/locked_repeat_with_unlocked_children" nodeset="/data/locked_repeat_with_unlocked_children" vellum:lock="all" />
+			<bind vellum:nodeset="#form/locked_repeat_with_unlocked_children/nested_unlocked" nodeset="/data/locked_repeat_with_unlocked_children/nested_unlocked" type="xsd:string" />
+			<bind vellum:nodeset="#form/locked_fieldlist" nodeset="/data/locked_fieldlist" vellum:lock="all" />
+			<bind vellum:nodeset="#form/locked_fieldlist_with_unlocked_children" nodeset="/data/locked_fieldlist_with_unlocked_children" vellum:lock="all" />
+			<bind vellum:nodeset="#form/locked_fieldlist_with_unlocked_children/nested_unlocked" nodeset="/data/locked_fieldlist_with_unlocked_children/nested_unlocked" type="xsd:string" />
 			<bind vellum:nodeset="#form/locked_select" nodeset="/data/locked_select" vellum:lock="all" />
 			<bind vellum:nodeset="#form/unlocked_select" nodeset="/data/unlocked_select" />
 			<itext>
@@ -62,6 +76,12 @@
 						<value>nested_unlocked</value>
 					</text>
 					<text id="locked_group_with_unlocked_children/nested_unlocked-label">
+						<value>nested_unlocked</value>
+					</text>
+					<text id="locked_repeat_with_unlocked_children/nested_unlocked-label">
+						<value>nested_unlocked</value>
+					</text>
+					<text id="locked_fieldlist_with_unlocked_children/nested_unlocked-label">
 						<value>nested_unlocked</value>
 					</text>
 					<text id="locked_select-label">
@@ -106,6 +126,22 @@
 		<group vellum:ref="#form/locked_group_with_unlocked_children" ref="/data/locked_group_with_unlocked_children">
 			<input vellum:ref="#form/locked_group_with_unlocked_children/nested_unlocked" ref="/data/locked_group_with_unlocked_children/nested_unlocked">
 				<label ref="jr:itext('locked_group_with_unlocked_children/nested_unlocked-label')" />
+			</input>
+		</group>
+		<group>
+			<repeat vellum:nodeset="#form/locked_repeat" nodeset="/data/locked_repeat"></repeat>
+		</group>
+		<group>
+			<repeat vellum:nodeset="#form/locked_repeat_with_unlocked_children" nodeset="/data/locked_repeat_with_unlocked_children">
+				<input vellum:ref="#form/locked_repeat_with_unlocked_children/nested_unlocked" ref="/data/locked_repeat_with_unlocked_children/nested_unlocked">
+					<label ref="jr:itext('locked_repeat_with_unlocked_children/nested_unlocked-label')" />
+				</input>
+			</repeat>
+		</group>
+		<group vellum:ref="#form/locked_fieldlist" ref="/data/locked_fieldlist" appearance="field-list"></group>
+		<group vellum:ref="#form/locked_fieldlist_with_unlocked_children" ref="/data/locked_fieldlist_with_unlocked_children" appearance="field-list">
+			<input vellum:ref="#form/locked_fieldlist_with_unlocked_children/nested_unlocked" ref="/data/locked_fieldlist_with_unlocked_children/nested_unlocked">
+				<label ref="jr:itext('locked_fieldlist_with_unlocked_children/nested_unlocked-label')" />
 			</input>
 		</group>
 		<select1 vellum:ref="#form/locked_select" ref="/data/locked_select">

--- a/tests/static/lock/test.xml
+++ b/tests/static/lock/test.xml
@@ -24,6 +24,9 @@
 						<nested_unlocked />
 					</group_no_lock>
 					<locked_group />
+					<locked_group_with_unlocked_children>
+						<nested_unlocked />
+					</locked_group_with_unlocked_children>
 					<locked_select />
 					<unlocked_select />
 				</data>
@@ -37,6 +40,8 @@
 			<bind vellum:nodeset="#form/group_no_lock" nodeset="/data/group_no_lock" />
 			<bind vellum:nodeset="#form/group_no_lock/nested_unlocked" nodeset="/data/group_no_lock/nested_unlocked" type="xsd:string" />
 			<bind vellum:nodeset="#form/locked_group" nodeset="/data/locked_group" vellum:lock="all" />
+			<bind vellum:nodeset="#form/locked_group_with_unlocked_children" nodeset="/data/locked_group_with_unlocked_children" vellum:lock="all" />
+			<bind vellum:nodeset="#form/locked_group_with_unlocked_children/nested_unlocked" nodeset="/data/locked_group_with_unlocked_children/nested_unlocked" type="xsd:string" />
 			<bind vellum:nodeset="#form/locked_select" nodeset="/data/locked_select" vellum:lock="all" />
 			<bind vellum:nodeset="#form/unlocked_select" nodeset="/data/unlocked_select" />
 			<itext>
@@ -54,6 +59,9 @@
 						<value>nested_locked</value>
 					</text>
 					<text id="nested_unlocked-label">
+						<value>nested_unlocked</value>
+					</text>
+					<text id="locked_group_with_unlocked_children/nested_unlocked-label">
 						<value>nested_unlocked</value>
 					</text>
 					<text id="locked_select-label">
@@ -95,6 +103,11 @@
 			</input>
 		</group>
 		<group vellum:ref="#form/locked_group" ref="/data/locked_group"></group>
+		<group vellum:ref="#form/locked_group_with_unlocked_children" ref="/data/locked_group_with_unlocked_children">
+			<input vellum:ref="#form/locked_group_with_unlocked_children/nested_unlocked" ref="/data/locked_group_with_unlocked_children/nested_unlocked">
+				<label ref="jr:itext('locked_group_with_unlocked_children/nested_unlocked-label')" />
+			</input>
+		</group>
 		<select1 vellum:ref="#form/locked_select" ref="/data/locked_select">
 			<label ref="jr:itext('locked_select-label')" />
 			<item>

--- a/tests/static/lock/test.xml
+++ b/tests/static/lock/test.xml
@@ -37,8 +37,15 @@
 					</locked_fieldlist_with_unlocked_children>
 					<locked_select />
 					<unlocked_select />
+					<locked_mselect />
+					<unlocked_mselect />
+					<locked_select_dynamic />
+					<unlocked_select_dynamic />
+					<locked_mselect_dynamic />
+					<unlocked_mselect_dynamic />
 				</data>
 			</instance>
+			<instance id="casedb" src="jr://instance/casedb" />
 			<bind vellum:nodeset="#form/locked" nodeset="/data/locked" type="xsd:string" vellum:lock="all" />
 			<bind vellum:nodeset="#form/unsupported_lock" nodeset="/data/unsupported_lock" type="xsd:string" vellum:lock="other" />
 			<bind vellum:nodeset="#form/unlocked" nodeset="/data/unlocked" type="xsd:string" />
@@ -58,6 +65,12 @@
 			<bind vellum:nodeset="#form/locked_fieldlist_with_unlocked_children/nested_unlocked" nodeset="/data/locked_fieldlist_with_unlocked_children/nested_unlocked" type="xsd:string" />
 			<bind vellum:nodeset="#form/locked_select" nodeset="/data/locked_select" vellum:lock="all" />
 			<bind vellum:nodeset="#form/unlocked_select" nodeset="/data/unlocked_select" />
+			<bind vellum:nodeset="#form/locked_mselect" nodeset="/data/locked_mselect" vellum:lock="all" />
+			<bind vellum:nodeset="#form/unlocked_mselect" nodeset="/data/unlocked_mselect" />
+			<bind vellum:nodeset="#form/locked_select_dynamic" nodeset="/data/locked_select_dynamic" vellum:lock="all" />
+			<bind vellum:nodeset="#form/unlocked_select_dynamic" nodeset="/data/unlocked_select_dynamic" />
+			<bind vellum:nodeset="#form/locked_mselect_dynamic" nodeset="/data/locked_mselect_dynamic" vellum:lock="all" />
+			<bind vellum:nodeset="#form/unlocked_mselect_dynamic" nodeset="/data/unlocked_mselect_dynamic" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="locked-label">
@@ -95,6 +108,30 @@
 					</text>
 					<text id="unlocked_select-choice1-label">
 						<value>choice1</value>
+					</text>
+					<text id="locked_mselect-label">
+						<value>locked_mselect</value>
+					</text>
+					<text id="locked_mselect-choice1-label">
+						<value>choice1</value>
+					</text>
+					<text id="unlocked_mselect-label">
+						<value>unlocked_mselect</value>
+					</text>
+					<text id="unlocked_mselect-choice1-label">
+						<value>choice1</value>
+					</text>
+					<text id="locked_select_dynamic-label">
+						<value>locked_select_dynamic</value>
+					</text>
+					<text id="unlocked_select_dynamic-label">
+						<value>unlocked_select_dynamic</value>
+					</text>
+					<text id="locked_mselect_dynamic-label">
+						<value>locked_mselect_dynamic</value>
+					</text>
+					<text id="unlocked_mselect_dynamic-label">
+						<value>unlocked_mselect_dynamic</value>
 					</text>
 				</translation>
 			</itext>
@@ -158,5 +195,47 @@
 				<value>choice1</value>
 			</item>
 		</select1>
+		<select vellum:ref="#form/locked_mselect" ref="/data/locked_mselect">
+			<label ref="jr:itext('locked_mselect-label')" />
+			<item>
+				<label ref="jr:itext('locked_mselect-choice1-label')" />
+				<value>choice1</value>
+			</item>
+		</select>
+		<select vellum:ref="#form/unlocked_mselect" ref="/data/unlocked_mselect">
+			<label ref="jr:itext('unlocked_mselect-label')" />
+			<item>
+				<label ref="jr:itext('unlocked_mselect-choice1-label')" />
+				<value>choice1</value>
+			</item>
+		</select>
+		<select1 vellum:ref="#form/locked_select_dynamic" ref="/data/locked_select_dynamic">
+			<label ref="jr:itext('locked_select_dynamic-label')" />
+			<itemset nodeset="instance('casedb')/casedb/case[@case_type='mother']">
+				<label ref="case_name" />
+				<value ref="@case_id" />
+			</itemset>
+		</select1>
+		<select1 vellum:ref="#form/unlocked_select_dynamic" ref="/data/unlocked_select_dynamic">
+			<label ref="jr:itext('unlocked_select_dynamic-label')" />
+			<itemset nodeset="instance('casedb')/casedb/case[@case_type='mother']">
+				<label ref="case_name" />
+				<value ref="@case_id" />
+			</itemset>
+		</select1>
+		<select vellum:ref="#form/locked_mselect_dynamic" ref="/data/locked_mselect_dynamic">
+			<label ref="jr:itext('locked_mselect_dynamic-label')" />
+			<itemset nodeset="instance('casedb')/casedb/case[@case_type='mother']">
+				<label ref="case_name" />
+				<value ref="@case_id" />
+			</itemset>
+		</select>
+		<select vellum:ref="#form/unlocked_mselect_dynamic" ref="/data/unlocked_mselect_dynamic">
+			<label ref="jr:itext('unlocked_mselect_dynamic-label')" />
+			<itemset nodeset="instance('casedb')/casedb/case[@case_type='mother']">
+				<label ref="case_name" />
+				<value ref="@case_id" />
+			</itemset>
+		</select>
 	</h:body>
 </h:html>


### PR DESCRIPTION
## Product Description
Adds form tree indicators for question locked status, updates question property enabled state immediately based on locking/unlocking, and adds a "select all"-like lock and unlock for all questions contained in a group when it gets locked or unlocked. 

Not shown: removes "Edit Source XML" and "Edit Bulk Translations" options when a form contains any locked questions and the `edit_locked_questions` feature is false or absent.

https://github.com/user-attachments/assets/60d5d47c-4179-4f86-af6a-37133b84c172



## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19545
UI updates as noted in product description, as well as some small refactors for code readability and efficiency.

## Feature Flag
In HQ the `lock` plugin is enabled by LOCKED_ADMIN_QUESTIONS.

## Safety Assurance

### Safety story
Tested functionality locally. The vast majority of changes here are limited to the lock plugin so any current issues would be constrained to only those with the feature flag enabled for testing purposes, with any remaining edge cases hopefully caught by QA.

### Automated test coverage
Automated testing is added or modified for the key functionality added in this PR.

### QA Plan
This feature will get QA as a whole before removing the feature flag and making it generally available.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
