### PR TITLE
Hide case management for ineligible question types

### DIFF
--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -458,6 +458,19 @@ $.vellum.plugin('caseManagement', {}, {
         initAutoAssignName(this);
     },
 
+    postInit: function() {
+        this.__callOld();
+        const types = this.data.core.mugTypes.normalTypes;
+        const exclude = {'Trigger': true, 'SaveToCase': true};
+        _(types).each((type, name) => {
+            if (Object.hasOwn(exclude, name) ||
+                    type.dataType === 'binary' ||  // multimedia: Audio, Image, ...
+                    type.tagName === 'group') {
+                type.spec.caseProperty = { presence: 'notallowed' };
+            }
+        });
+    },
+
     loadXML: function () {
         this.__callOld();
         const _this = this;
@@ -504,19 +517,6 @@ $.vellum.plugin('caseManagement', {}, {
             const writer = new XMLCaseMappingWriter(xmlWriter);
             writer.writeCaseMappingsElement(this.data.caseManagement);
         }
-    },
-
-    getMugTypes: function () {
-        const types = this.__callOld();
-        const excludedTypes = [
-            types.normal.Trigger,
-            types.normal.Group,
-            types.normal.Repeat,
-            types.normal.FieldList
-        ];
-        excludedTypes.forEach(excludedType => excludedType.spec.caseProperty = { presence: 'notallowed' });
-
-        return types;
     },
 
     getSections: function (mug) {

--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -545,6 +545,13 @@ $.vellum.plugin('caseManagement', {}, {
         if (options.slug !== 'caseManagement') {
             return $sec;
         }
+        let parent = mug.parentMug;
+        while (parent) {
+            if (parent.__className === "Repeat") {
+                return $();  // hide section if in repeat group
+            }
+            parent = parent.parentMug;
+        }
         const data = this.data.caseManagement;
         if (data.is_registration_form && !data.caseMappings?.name?.length) {
             const $nudge = $(nudgeName({format: util.format}));

--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -420,7 +420,8 @@ function autoAssignName(vellum) {
     vellum.ensureCurrentMugIsSaved(() => {
         const form = vellum.data.core.form;
         let mug = form.findFirstMatchingChild(null, () => true);
-        if (!mug || mug.p.caseProperty || mug.spec.caseProperty?.presence !== 'optional') {
+        if (!mug || mug.p.caseProperty || !mug.spec.caseProperty ||
+                mug.getPresence("caseProperty") !== 'optional') {
             mug = vellum.addQuestion('DataBindOnly', 'first');
             mug.p.nodeID = form.generate_question_id('case-name');
             mug.p.calculateAttr = 'uuid()';

--- a/tests/caseManagement.js
+++ b/tests/caseManagement.js
@@ -717,21 +717,34 @@ describe("The Case Management plugin", function () {
             save.popover("show");
         });
 
-        it("new mug when first mug is a group", function (done) {
-            util.loadXML("");
-            const group = util.addQuestion("Group", "test");
-            const save = call("getData").core.saveButton.ui;
-            function test() {
-                save.off('shown.bs.popover.test');
-                $(".fd-auto-assign-case-name").trigger("click");
-                const name = call("getMugByPath", "/data/case-name");
-                assert.equal(name.p.nodeID, 'case-name');
-                assert.equal(name.p.caseProperty, 'name');
-                assert.equal(group.p.caseProperty, undefined);
-                done();
-            }
-            save.on('shown.bs.popover.test', test);
-            save.popover("show");
+        describe("new mug when first mug is a", function () {
+            ([
+                "Trigger",
+                "Group",
+                "Repeat",
+                "SaveToCase",
+                "Audio",
+                "Image",
+                "Video",
+                "Document",
+            ]).forEach(type => {
+                it(type, function (done) {
+                    util.loadXML("");
+                    const mug = util.addQuestion(type, "test");
+                    const save = call("getData").core.saveButton.ui;
+                    function test() {
+                        save.off('shown.bs.popover.test');
+                        $(".fd-auto-assign-case-name").trigger("click");
+                        const name = call("getMugByPath", "/data/case-name");
+                        assert.isUndefined(mug.p.caseProperty, type + " caseProperty should be undefined");
+                        assert.equal(name.p.nodeID, 'case-name');
+                        assert.equal(name.p.caseProperty, 'name');
+                        done();
+                    }
+                    save.on('shown.bs.popover.test', test);
+                    save.popover("show");
+                });
+            });
         });
 
         it("new mug with unique node ID", function (done) {

--- a/tests/caseManagement.js
+++ b/tests/caseManagement.js
@@ -106,6 +106,18 @@ describe("The Case Management plugin", function () {
         assert.notExists(getCaseManagementSection()[0]);
     });
 
+    it("should hide the case management section for questions in repeat groups", function () {
+        util.loadXML("");
+        const repeat = util.addQuestion("Repeat", "repeat_group");
+        const group = util.addQuestion("Group", "group");
+        const text = util.addQuestion("Text", "text");
+        util.clickQuestion(text);
+
+        assert.equal(text.parentMug, group);
+        assert.equal(group.parentMug, repeat);
+        assert.notExists(getCaseManagementSection()[0]);
+    });
+
     it("should hide the case management section for question lists", function () {
         util.loadXML("");
         util.addQuestion("FieldList", "question_list");


### PR DESCRIPTION
## Product Description

The Case Management section is now hidden for question types that cannot meaningfully be mapped to case properties. Specifically, the section no longer appears for:

- Multimedia questions (Audio, Image, Video, etc.)
- Save to Case questions (the section didn't actually appear, but auto-assign could assign to it)
- Trigger (label) questions
- Group-type containers (Group, Repeat, Field List)
- Questions inside a Repeat group

The "auto-assign case name" action also now correctly skips these ineligible question types when picking the first question to use as the case name, and will insert a new hidden case-name question instead.

## Technical Summary

- Moved the logic that marks question types as `caseProperty: { presence: 'notallowed' }` out of `getMugTypes` and into a new `postInit` hook. This allows `caseProperty.presence` to be set on `SaveToCase`, which was not previously possible because the `saveToCase` plugin comes later in the call stack than `caseManagement` (depending on configuration).
- Added an explicit check in `getSectionDisplay` so that any question whose ancestor chain contains a `Repeat` returns an empty section. Previously an eligible question inside a Repeat still showed the Case Management UI.
- Updated `autoAssignName` so that when the first question is a type where `caseProperty` is not allowed (no spec or presence `!== 'optional'`), it inserts a new hidden `case-name` data node instead of attempting to reuse the ineligible question. Uses `getPresence` so mug-level overrides are respected.

https://dimagi.atlassian.net/browse/SAAS-19672
https://dimagi.atlassian.net/browse/SAAS-19673

## Feature Flag

`FORMBUILDER_SAVE_TO_CASE`

## Safety Assurance

### Safety story

This change only affects UI visibility of the Case Management section and which question types can be auto-selected as the case name. The underlying form XML and existing case mappings are unchanged. Existing forms that already have case properties set on now-excluded types will continue to function; the UI simply stops offering new mappings for them.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
