### PR TITLE
Fix premature 'Case ID is required' warning on SaveToCase

### DIFF
--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -19,19 +19,19 @@ function validateXPath(mug, value) {
 }
 
 function createsCase(mug) {
-    return mug ? mug.p.useCreate : false;
+    return !!(mug && mug.p.useCreate);
 }
 
 function closesCase(mug) {
-    return mug ? mug.p.useClose : false;
+    return !!(mug && mug.p.useClose);
 }
 
 function updatesCase(mug) {
-    return mug ? mug.p.useUpdate : false;
+    return !!(mug && mug.p.useUpdate);
 }
 
 function indexesCase(mug) {
-    return mug ? mug.p.useIndex : false;
+    return !!(mug && mug.p.useIndex);
 }
 
 function usesCases(mug) {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -558,7 +558,7 @@ var slugToProp = {
                     if (mug.p[prop]) {                                                                                                                                                                                       
                         mug.p[prop] = false;                                     
                     }
-                    mug.form.vellum.collapseSection(slug, true);  
+                    mug.form.vellum.collapseSection(slug, true);
                 },
             },
             useCreate: {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -19,19 +19,19 @@ function validateXPath(mug, value) {
 }
 
 function createsCase(mug) {
-    return !!(mug && mug.p.useCreate);
+    return !!mug?.p.useCreate;
 }
 
 function closesCase(mug) {
-    return !!(mug && mug.p.useClose);
+    return !!mug?.p.useClose;
 }
 
 function updatesCase(mug) {
-    return !!(mug && mug.p.useUpdate);
+    return !!mug?.p.useUpdate;
 }
 
 function indexesCase(mug) {
-    return !!(mug && mug.p.useIndex);
+    return !!mug?.p.useIndex;
 }
 
 function usesCases(mug) {

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -565,8 +565,9 @@ var slugToProp = {
                 visibility: 'hidden',
                 presence: 'optional',
                 validationFunc: function (mug) {
-                    // case_id validation depends on useCreate
-                    mug.validate('case_id');
+                    if (mug.p.case_id) {
+                        mug.validate('case_id');
+                    }
                     return 'pass';
                 },
             },

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -554,8 +554,11 @@ var slugToProp = {
                     mug.form.vellum.collapseSection(slug, false);
                 },
                 onDeselect: function (slug, mug) {
-                    mug.p[slugToProp[slug]] = false;
-                    mug.form.vellum.collapseSection(slug, true);
+                    var prop = slugToProp[slug];
+                    if (mug.p[prop]) {                                                                                                                                                                                       
+                        mug.p[prop] = false;                                     
+                    }
+                    mug.form.vellum.collapseSection(slug, true);  
                 },
             },
             useCreate: {

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -94,22 +94,8 @@ describe("The SaveToCase module", function() {
 
     it("should only allow custom case types for create actions", function () {
         util.loadXML("");
-        util.addQuestion("SaveToCase", "stc_update", {
-            case_id: 'a-real-exisitng-case-id',
-            case_type: 'household',
-            useUpdate: true,
-            updateProperty: {
-                'name': { 'calculate': '/data/name' },
-            }
-        });
-        util.addQuestion("SaveToCase", "stc_create", {
-            case_id: 'uuid()',
-            case_type: 'household',
-            useCreate: true,
-            createProperty: {
-                'case_name': { 'calculate': '/data/name' },
-            }
-        });
+        util.addQuestion("SaveToCase", "stc_update", {useUpdate: true});
+        util.addQuestion("SaveToCase", "stc_create", {useCreate: true});
 
         util.clickQuestion("stc_update");
         assert.strictEqual($("[name=property-case_type]").data('select2').options.options.tags, false);


### PR DESCRIPTION
## Product Description

Adding a SaveToCase question or clicking the Create chip on one for the first time fires the "Case ID is required." warning before the user had any chance to fill in the Case ID field. 
This PR is to fix it.

## Technical Summary

Review by commit. Technical reason for each change was added in commit messages.

## Feature Flag

`VELLUM_SAVE_TO_CASE`

## Safety Assurance

### Safety story
It only change when validation messages are surfaced, the underlying validation are unchanged.

### Automated test coverage

### QA Plan

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change