### PR TITLE
Copy/paste multiple case properties per question + case property validation

### DIFF
--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -1,6 +1,5 @@
 import $ from "jquery";
 import _ from "underscore";
-import mugs from "vellum/mugs";
 import nudgeLearn from "vellum/templates/case_management_learning_nudge.html";
 import nudgeName from "vellum/templates/case_management_name_nudge.html";
 import tmpAutoAssign from "vellum/templates/case_management_auto_assign_name.html";
@@ -624,8 +623,28 @@ $.vellum.plugin('caseManagement', {}, {
                     return questionMappings.length <= 1;
                 },
                 lstring: gettext('Case Property'),
-                serialize: mugs.serializeXPath,
-                deserialize: mugs.deserializeXPath,
+                serialize: (value, key, mug, data) => {
+                    const props = that.data.caseManagement
+                                      .caseMappingsByQuestion[mug.absolutePath];
+                    if (!props?.length) {
+                        return undefined;
+                    }
+                    // Return a space-delimited string of case properties.
+                    // Case properties should not contain spaces, but if they
+                    // do, spaces are converted to underscores.
+                    return props.map(prop => prop.replace(/ /g, "_")).join(" ");
+                },
+                deserialize: (data, key, mug, context) => {
+                    const props = data[key]?.split(" ").filter(v => v);
+                    if (props?.length) {
+                        mug.p.set(key, props[0]);
+                        const maintainer = new CaseMapMaintainer(mug.form, that.data.caseManagement);
+                        _.uniq(props).reverse().forEach(prop => {
+                            maintainer.updateFormMappings(mug.absolutePath, null, prop);
+                        });
+                    }
+                    return undefined;
+                },
                 setter: function (mug, attr, value) {
                     const maintainer = new CaseMapMaintainer(mug.form, that.data.caseManagement);
                     maintainer.updateFormMappings(mug.absolutePath, mug.p[attr], value);

--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -659,6 +659,12 @@ $.vellum.plugin('caseManagement', {}, {
                             {word: currentValue}
                         )};
                     }
+                    if (currentValue && !/^[a-z][\w-]*$/i.test(currentValue)) {
+                        return gettext(
+                            "Case Property should start with a letter and " +
+                            "only contain letters, numbers, '-', and '_'"
+                        );
+                    }
                     return 'pass';
                 },
             },

--- a/tests/caseManagement.js
+++ b/tests/caseManagement.js
@@ -5,6 +5,8 @@ import $ from "jquery";
 import _ from "underscore";
 import util from "tests/utils";
 import xmlLib from "vellum/xml";
+import copyPaste from "vellum/copy-paste";
+import { copyPasteFormat } from "tests/copy-paste";
 import BASELINE_XML from "static/caseManagement/baseline.xml";
 import BASELINE_NO_MAPPING_XML from "static/caseManagement/baseline_no_mapping_block.xml";
 import MULTIPLE_PROPERTIES_XML from "static/caseManagement/multiple_properties.xml";
@@ -193,10 +195,69 @@ describe("The Case Management plugin", function () {
         assert.isFalse(select.prop("disabled"), "question1 case property select should be enabled");
     });
 
+    it("should copy and paste case property", function () {
+        const vellum = $("#vellum").vellum("get");
+        util.loadXML("");
+        util.addQuestion("Text", "text");
+        util.call("onFormSave", {"caseManagement": {"mappings": {
+            "one": [{"question_path": "/data/text"}],
+        }}});
+        util.selectAll();
+        const copy = copyPaste.copy();
+
+        assert.deepEqual(copy, copyPasteFormat([
+            ["id", "type", "caseProperty"],
+            ["/text", "Text", "one"],
+        ]));
+
+        copyPaste.paste(copy);
+        const newMug = call("getMugByPath", "/data/copy-1-of-text");
+        const data = vellum.data.caseManagement;
+
+        assert.equal(newMug.p.caseProperty, "one");
+        assert.deepEqual(data.caseMappingsByQuestion[newMug.absolutePath], ["one"]);
+        assert.deepEqual(data.caseMappings.one, [
+            {question_path: "/data/text"},
+            {question_path: "/data/copy-1-of-text"},
+        ]);
+    });
+
+    it("should copy and paste multiple properties per question", function () {
+        const vellum = $("#vellum").vellum("get");
+        util.loadXML("");
+        util.addQuestion("Text", "text");
+        util.call("onFormSave", {"caseManagement": {"mappings": {
+            "one": [{"question_path": "/data/text"}],
+            "two": [{"question_path": "/data/text"}],
+        }}});
+        util.selectAll();
+        const copy = copyPaste.copy();
+
+        assert.deepEqual(copy, copyPasteFormat([
+            ["id", "type", "caseProperty"],
+            ["/text", "Text", "one two"],
+        ]));
+
+        copyPaste.paste(copy);
+        const newMug = call("getMugByPath", "/data/copy-1-of-text");
+        const data = vellum.data.caseManagement;
+
+        assert.equal(newMug.p.caseProperty, "one");
+        assert.deepEqual(data.caseMappingsByQuestion[newMug.absolutePath], ["one", "two"]);
+        assert.deepEqual(data.caseMappings.one, [
+            {question_path: "/data/text"},
+            {question_path: "/data/copy-1-of-text"},
+        ]);
+        assert.deepEqual(data.caseMappings.two, [
+            {question_path: "/data/text"},
+            {question_path: "/data/copy-1-of-text"},
+        ]);
+    });
+
     it("should save the case property to the XML", function () {
         util.loadXML("");
         util.addQuestion("Text", "question");
-        
+
         // set the value
         const caseManagementSection = getCaseManagementSection();
         const casePropertySelect = caseManagementSection.find(CASE_PROPERTY_WIDGET_TYPE);

--- a/tests/caseManagement.js
+++ b/tests/caseManagement.js
@@ -48,13 +48,6 @@ describe("The Case Management plugin", function () {
             }
         });
     });
-    beforeEach(() => {
-        const data = $("#vellum").vellum("get").data.caseManagement;
-        if (data) {
-            data.baseline = {};
-            delete data.caseMappings;
-        }
-    });
 
     it("preserves case mapping between loading and writing XML", function () {
         util.loadXML(BASELINE_XML);
@@ -722,6 +715,44 @@ describe("The Case Management plugin", function () {
         const alerts = call("preSaveValidation");
         const msg = _(alerts).find(a => a.indexOf('missing a case name') >= 0);
         assert.ok(msg, JSON.stringify(alerts));
+    });
+
+    describe("Case Property value", function () {
+        let mug;
+        before(function () {
+            util.loadXML("");
+            mug = util.addQuestion("Text", "text");
+        });
+
+        ([  // allowed case property values
+            "",
+            "a",
+            "b_",
+            "c-",
+            "d1",
+            "E1",
+        ]).forEach(value => {
+            it(`should allow ${JSON.stringify(value)}`, function () {
+                mug.p.caseProperty = value;
+
+                assert.equal(util.getMessages(mug), "");
+            });
+        });
+
+        ([  // illegal case property values
+            "_a",
+            "-b",
+            " ",
+            "@c",
+            "d$",
+            "E ",
+        ]).forEach(value => {
+            it(`should not allow ${JSON.stringify(value)}`, function () {
+                mug.p.caseProperty = value;
+
+                assert.match(util.getMessages(mug), /should start with a letter/);
+            });
+        });
     });
 
     describe("with unknown question path", function () {

--- a/tests/copy-paste.js
+++ b/tests/copy-paste.js
@@ -17,7 +17,7 @@ var assert = chai.assert,
 
 function eq(serial, rows, message) {
     if (!_.isString(rows)) {
-        rows = tsv.tabDelimit([HEADER].concat(rows));
+        rows = copyPasteFormat(rows);
     }
     util.assertEqual(serial + "\n", rows + "\n",
                      message || "cut or copy mismatch");
@@ -25,10 +25,14 @@ function eq(serial, rows, message) {
 
 function paste(rows, errors, print) {
     if (!_.isString(rows)) {
-        rows = tsv.tabDelimit([HEADER].concat(rows));
+        rows = copyPasteFormat(rows);
     }
     if (print) { window.console.log(rows); } // debugging helper
     assert.deepEqual(mod.paste(rows), errors || []);
+}
+
+export function copyPasteFormat(rows) {
+    return tsv.tabDelimit([HEADER].concat(rows));
 }
 
 describe("The copy-paste plugin", function () {


### PR DESCRIPTION
## Product Description

When a question is mapped to more than one case property, copying the question and pasting it now preserves all of those case property mappings on the new question. Previously, only a single property survived the round-trip, so users had to re-add the additional mappings by hand.

This branch also tightens validation on the Case Property field. Names must now start with a letter and contain only letters, numbers, `-`, and `_`. Invalid characters surface an inline error instead of being silently accepted and producing malformed form XML downstream. Note that there are plenty of case properties in CommCare that violate the validation rule, possibly because APIs allow arbitrary case property names? In any case, the validation in Vellum is consistent with the HQ app build validation.

## Technical Summary

- Replace the default xpath serialize/deserialize on the `caseProperty` widget with custom handlers that encode/decode all case properties on copy/paste.
- Add a regex check to the existing `caseProperty` validator alongside the reserved-word check.

## Feature Flag

`FORMBUILDER_SAVE_TO_CASE`

## Safety Assurance

### Safety story

The serialize/deserialize change only affects the copy/paste code path for the Case Property widget; normal form save/load is untouched. The validation change is additive — it rejects values consistent with HQ build rules.

### Automated test coverage

- New baseline test exercises copy/paste with a single case property.
- New test exercises copy/paste of a question that is mapped to two case properties, asserting both the clipboard contents and the resulting `caseMappings` / `caseMappingsByQuestion` state on the pasted question.
- New parameterized tests cover allowed values and rejected values for the case property validator.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
