### PR TITLE
Fix: restore Advanced section title

### DIFF
--- a/src/less-style/question-props.less
+++ b/src/less-style/question-props.less
@@ -203,12 +203,6 @@
             }
         }
 
-        .fd-question-fieldset[data-slug='advanced'] {
-            legend {
-                display: none;
-            }
-        }
-
         .fd-collapse-toggle {
             padding: 10px 0;
             &:has(button.collapsed) {


### PR DESCRIPTION
## Product Description

Fix a bug introduced in https://github.com/dimagi/Vellum/pull/1216. 
The "Advanced" section title disappeared for all regular questions.
This PR restores it.

## Technical Summary

Introduced by cmmit eb1a9615 to hide the legend for Save to case's advanced section.
But [`addCollapseToggle` already hides the legend programmatically](https://github.com/dimagi/Vellum/blob/fe35acfb7340fdee1c399008b0dbfb4fbd34d2d7/src/widgets.js#L697). So the CSS rule is redundant for SaveToCase and incorrectly hides the title on the normal question's Advanced section.  

## Feature Flag


## Safety Assurance

### Safety story

css only change

### Automated test coverage

### QA Plan

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)