### PR TITLE
Always promote owner_id relevant to Owner ID Condition

### DIFF
--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -991,14 +991,7 @@ function promoteStashedCreateBindRelevants(mug) {
     }
 
     if (ownerIdRelevant) {
-        var redundantWithCaseTypeOrName = _.contains(
-            caseTypeAndNameRelevants,
-            ownerIdRelevant
-        );
-        var redundantWithOpenCase = ownerIdRelevant === mug.p.openCaseCondition;
-        if (!redundantWithCaseTypeOrName && !redundantWithOpenCase) {
-            mug.p.ownerIdCondition = ownerIdRelevant;
-        }
+        mug.p.ownerIdCondition = ownerIdRelevant;
     }
 }
 

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -979,8 +979,7 @@ var slugToProp = {
 function promoteStashedCreateBindRelevants(mug) {
     var stashed = mug._stashedCreateBindRelevants || {},
         caseTypeRelevant = stashed.case_type,
-        caseNameRelevant = stashed.case_name,
-        ownerIdRelevant = stashed.owner_id;
+        caseNameRelevant = stashed.case_name;
     delete mug._stashedCreateBindRelevants;
 
     var caseTypeAndNameRelevants = _.compact(
@@ -988,10 +987,6 @@ function promoteStashedCreateBindRelevants(mug) {
     );
     if (caseTypeAndNameRelevants.length && !mug.p.openCaseCondition) {
         mug.p.openCaseCondition = caseTypeAndNameRelevants.join(" and ");
-    }
-
-    if (ownerIdRelevant) {
-        mug.p.ownerIdCondition = ownerIdRelevant;
     }
 }
 
@@ -1130,7 +1125,10 @@ $.vellum.plugin("saveToCase", {}, {
 
                         if (action === "create" && prop === "owner_id") {
                             mug.p.ownerId = el.xmlAttr("calculate");
-                            stashRelevant('owner_id');
+                            var ownerIdRelevant = el.xmlAttr('relevant');
+                            if (ownerIdRelevant) {
+                                mug.p.ownerIdCondition = ownerIdRelevant;
+                            }
                             return;
                         }
 

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -673,12 +673,12 @@ describe("The SaveToCase module", function() {
             assert.notOk(mug.p.ownerIdCondition);
         });
 
-        it("should promote all-same relevant to openCaseCondition and absorb owner_id", function () {
+        it("should promote all-same relevant to openCaseCondition and ownerIdCondition", function () {
             var cond = "/data/name != ''";
             util.loadXML(withRelevants(cond, cond, cond));
             var mug = util.getMug("save_to_case");
             assert.equal(mug.p.openCaseCondition, cond);
-            assert.notOk(mug.p.ownerIdCondition);
+            assert.equal(mug.p.ownerIdCondition, cond);
         });
 
         it("should keep owner_id-only relevant as ownerIdCondition", function () {
@@ -710,12 +710,12 @@ describe("The SaveToCase module", function() {
             assert.equal(mug.p.ownerIdCondition, "/data/name != ''");
         });
 
-        it("should promote shared case_name+owner_id relevant and absorb owner_id", function () {
+        it("should promote shared case_name+owner_id relevant to both conditions", function () {
             var cond = "/data/name != ''";
             util.loadXML(withRelevants(null, cond, cond));
             var mug = util.getMug("save_to_case");
             assert.equal(mug.p.openCaseCondition, cond);
-            assert.notOk(mug.p.ownerIdCondition);
+            assert.equal(mug.p.ownerIdCondition, cond);
         });
 
         it("should output case-level relevant instead of per-property relevant after loading legacy form", function () {
@@ -733,8 +733,9 @@ describe("The SaveToCase module", function() {
             assert.notOk(
                 $xml.find('bind[nodeset="/data/save_to_case/case/create/case_name"]').attr('relevant')
             );
-            assert.notOk(
-                $xml.find('bind[nodeset="/data/save_to_case/case/create/owner_id"]').attr('relevant')
+            assert.equal(
+                $xml.find('bind[nodeset="/data/save_to_case/case/create/owner_id"]').attr('relevant'),
+                cond
             );
         });
     });


### PR DESCRIPTION
## Product Description

Follow-up to #1225. When migrating legacy forms with per-property `relevant` on `owner_id`, always promote it to **Owner ID Condition** instead of absorbing it when it matches the promoted **Open Case Condition**.

## Technical Summary

## Feature Flag

`VELLUM_SAVE_TO_CASE`

## Safety Assurance

### Safety story

Small, isolated change in the legacy-form migration path. The new behavior is strictly more conservative — it preserves an expression rather than dropping it.

### Automated test coverage

Updated tests in `tests/saveToCase.js` under `create section backward compatibility`:
- `should promote all-same relevant to openCaseCondition and ownerIdCondition`
- `should promote shared case_name+owner_id relevant to both conditions`
- `should output case-level relevant instead of per-property relevant after loading legacy form`

### QA Plan

- Load a legacy form where `case_type`/`case_name`/`owner_id` all share the same `relevant` → both Open Case Condition and Owner ID Condition should be populated with that expression.
- Set Open Case Condition and Owner ID Condition to the same expression in the new UI, save, reload → both fields should still be populated.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change