### PR TITLE
Remove reserved types check for Create section

### DIFF
--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -48,10 +48,6 @@ function validatePropertyNameChars(val) {
     return null;
 }
 
-function validateCreatePropertyName(val) {
-    return validatePropertyNameChars(val);
-}
-
 function validateRelationshipChoice(val) {
     if (val && val !== "child" && val !== "extension") {
         return gettext("Relationship must be child or extension.");
@@ -89,7 +85,7 @@ var CREATE_CARD_CONFIG = {
                 fieldClass: "fd-update-property-name",
                 isIdentifier: true,
                 required: true,
-                extraValidator: validateCreatePropertyName,
+                extraValidator: validatePropertyNameChars,
             },
             SAVE_PROPERTY_CALC_FIELD,
             SAVE_PROPERTY_RELEVANT_FIELD,

--- a/src/saveToCase.js
+++ b/src/saveToCase.js
@@ -49,12 +49,6 @@ function validatePropertyNameChars(val) {
 }
 
 function validateCreatePropertyName(val) {
-    if (val && _.contains(["case_type", "case_name", "owner_id"], val)) {
-        return gettext("Use the dedicated field above instead.");
-    }
-    if (val && val === "name") {
-        return gettext("Use the case_name field above instead.");
-    }
     return validatePropertyNameChars(val);
 }
 

--- a/tests/saveToCase.js
+++ b/tests/saveToCase.js
@@ -580,17 +580,6 @@ describe("The SaveToCase module", function() {
             assert.strictEqual(mug.spec.caseName.validationFunc(mug), "pass");
         });
 
-        it("should reject reserved properties in createProperty", function () {
-            util.loadXML("");
-            var mug = util.addQuestion("SaveToCase", "mug");
-            mug.p.useCreate = true;
-            mug.p.caseName = "/data/name";
-            mug.p.createProperty = {
-                case_name: { calculate: "/data/name" },
-            };
-            assert.notEqual(mug.spec.createProperty.validationFunc(mug), "pass");
-        });
-
         it("should emit extra create properties under <update>", function () {
             util.loadXML("");
             var mug = util.addQuestion("SaveToCase", "stc", {
@@ -978,28 +967,6 @@ describe("The SaveToCase module", function() {
             assert.ok(
                 $nameInput.closest(".form-group").hasClass("has-error"),
                 "expected .has-error on name field for invalid property name characters"
-            );
-        });
-
-        it("should flag reserved names (case_type) in Create", function () {
-            util.loadXML("");
-            util.addQuestion("SaveToCase", "mug", {
-                case_id: "uuid()",
-                useCreate: true,
-                case_type: "patient",
-                caseName: "/data/name",
-            });
-            util.clickQuestion("mug");
-            $("[name='property-createProperty']").find(".fd-add-property").trigger("click");
-
-            var $card = $("[name='property-createProperty']")
-                .find(".fd-update-property.fd-card").first();
-            var $nameInput = $card.find(".fd-update-property-name");
-            $nameInput.val("case_type").trigger("change");
-
-            assert.ok(
-                $nameInput.closest(".form-group").hasClass("has-error"),
-                "expected .has-error on name field for reserved property name"
             );
         });
 


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->

Before
<img width="568" height="589" alt="Screenshot 2026-05-05 at 12 04 06 PM" src="https://github.com/user-attachments/assets/23ca4f77-dca6-4a6c-8f3a-8169113ff1dc" />
After the change, user will no longer see error messages.

At first I don't allow user to define `case_type`, `case_name`, `owner_id`, `name` again in the create section's property card. But after I did some compatibility check, I find we have a lot of forms already in this state. Since we allow it in the past, I don't want to raise error now.
The `case_name`, `case_type`, `owner_id` defined in property card will went to update node, and it will override whatever user defined in the dedicated field.
This change is just for backwards compatibility.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Safe, just remove some validation field so the validation rules matches the old rule.
### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
