### PR TITLE
Allow parent/ prefixes on case property

### DIFF
--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -659,7 +659,7 @@ $.vellum.plugin('caseManagement', {}, {
                             {word: currentValue}
                         )};
                     }
-                    if (currentValue && !/^[a-z][\w-]*$/i.test(currentValue)) {
+                    if (currentValue && !/^(?:parent\/)*[a-z][\w-]*$/i.test(currentValue)) {
                         return gettext(
                             "Case Property should start with a letter and " +
                             "only contain letters, numbers, '-', and '_'"

--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -659,7 +659,7 @@ $.vellum.plugin('caseManagement', {}, {
                             {word: currentValue}
                         )};
                     }
-                    if (currentValue && !/^(?:parent\/)*[a-z][\w-]*$/i.test(currentValue)) {
+                    if (currentValue && !/^(?:(?:parent|host)\/)*[a-z][\w-]*$/i.test(currentValue)) {
                         return gettext(
                             "Case Property should start with a letter and " +
                             "only contain letters, numbers, '-', and '_'"

--- a/tests/caseManagement.js
+++ b/tests/caseManagement.js
@@ -755,6 +755,28 @@ describe("The Case Management plugin", function () {
         });
     });
 
+    describe("with parent path", function () {
+        let mug;
+        before(function () {
+            util.loadXML(BASELINE_XML);
+            mug = call("getMugByPath", "/data/question1");
+        });
+
+        const args = [
+            ["parent/property"],
+            ["parent/parent/property"],
+            ["parent/parent/parent/property"],
+        ];
+        args.forEach(prop => {
+            it(`should allow ${prop} to be referenced without error`, function () {
+                mug.p.caseProperty = prop;
+                util.clickQuestion(mug);
+
+                assert.isTrue(util.isTreeNodeValid(mug), "Unexpected error: " + util.getMessages(mug));
+            });
+        });
+    });
+
     describe("with unknown question path", function () {
         before(function () {
             util.loadXML("");

--- a/tests/caseManagement.js
+++ b/tests/caseManagement.js
@@ -755,7 +755,7 @@ describe("The Case Management plugin", function () {
         });
     });
 
-    describe("with parent path", function () {
+    describe("with parent/host path", function () {
         let mug;
         before(function () {
             util.loadXML(BASELINE_XML);
@@ -766,6 +766,11 @@ describe("The Case Management plugin", function () {
             ["parent/property"],
             ["parent/parent/property"],
             ["parent/parent/parent/property"],
+            ["host/property"],
+            ["host/host/property"],
+            ["parent/host/property"],
+            ["parent/host/parent/property"],
+            ["host/parent/host/property"],
         ];
         args.forEach(prop => {
             it(`should allow ${prop} to be referenced without error`, function () {


### PR DESCRIPTION
## Product Description

Form designers can now reference case properties on a parent or host (or grandparent, great-grandparent, etc.) case by prefixing the property name with one or more `parent/` or `host/` segments — e.g. `parent/property` or `parent/parent/property`. Previously the case property name validator rejected these as invalid, even though the underlying case-property reference is well-formed and supported.

## Technical Summary

- Loosens the case-property name regex in `src/caseManagement.js` to accept a leading sequence of `parent/` or `host/` segments before the property name. The terminal segment still has to begin with a letter and contain only letters, digits, `-`, and `_`.
- No change to XML output, parsing, or any other validation rule.

## Feature Flag

`FORMBUILDER_SAVE_TO_CASE`

## Safety Assurance

### Safety story

The change is a one-character-class extension to a single regex used only for client-side property-name validation in the form builder. It strictly widens what is accepted; previously valid names continue to validate. There is no impact on parsing, serialization, or stored form XML, so existing forms are unaffected.

### Automated test coverage

Added `tests/caseManagement.js` cases covering one, two, and three levels of `parent/` nesting as well as `host/` and various combinations of both, asserting the question tree is valid (no error message). The previous regex would have produced a "Case Property should start with a letter…" error on each.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
