### PR TITLE
Allow index references in case properties

### DIFF
--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -659,7 +659,7 @@ $.vellum.plugin('caseManagement', {}, {
                             {word: currentValue}
                         )};
                     }
-                    if (currentValue && !/^[a-z][\w-]*$/i.test(currentValue)) {
+                    if (currentValue && !/^([a-z][\w-]*\/)*[a-z][\w-]*$/i.test(currentValue)) {
                         return gettext(
                             "Case Property should start with a letter and " +
                             "only contain letters, numbers, '-', and '_'"

--- a/tests/caseManagement.js
+++ b/tests/caseManagement.js
@@ -731,6 +731,8 @@ describe("The Case Management plugin", function () {
             "c-",
             "d1",
             "E1",
+            "parent/f",
+            "host/G",
         ]).forEach(value => {
             it(`should allow ${JSON.stringify(value)}`, function () {
                 mug.p.caseProperty = value;
@@ -746,11 +748,41 @@ describe("The Case Management plugin", function () {
             "@c",
             "d$",
             "E ",
+            "parent/f$",
+            "host/ G",
+            "1/h",
         ]).forEach(value => {
             it(`should not allow ${JSON.stringify(value)}`, function () {
                 mug.p.caseProperty = value;
 
                 assert.match(util.getMessages(mug), /should start with a letter/);
+            });
+        });
+    });
+
+    describe("with parent/host path", function () {
+        let mug;
+        before(function () {
+            util.loadXML(BASELINE_XML);
+            mug = call("getMugByPath", "/data/question1");
+        });
+
+        const args = [
+            ["parent/property"],
+            ["parent/parent/property"],
+            ["parent/parent/parent/property"],
+            ["host/property"],
+            ["host/host/property"],
+            ["parent/host/property"],
+            ["parent/host/parent/property"],
+            ["host/parent/host/property"],
+        ];
+        args.forEach(prop => {
+            it(`should allow ${prop} to be referenced without error`, function () {
+                mug.p.caseProperty = prop;
+                util.clickQuestion(mug);
+
+                assert.isTrue(util.isTreeNodeValid(mug), "Unexpected error: " + util.getMessages(mug));
             });
         });
     });


### PR DESCRIPTION
## Product Description
In the Case Management tab of the Form Builder, case property fields previously only accepted a hard-coded set of index prefixes (`parent`, `host`, and `user` when usercase was enabled). Any other index path was flagged with a validation warning, creating visual noise for forms that legitimately reference deeper or alternate index relationships. This change accepts arbitrary multi-segment index references, for example `parent/parent/foo`, `host/host/bar`, or `parent/host/parent/baz` — provided each segment follows the same naming rules already required for case property names: starts with a letter and contains only letters, digits, `_`, or `-`.

## Technical Summary
- Broadened the case-property validation regex in `src/caseManagement.js` to allow zero or more `segment/` prefixes before the final property name.
- Per-segment rules are unchanged, so previously-accepted values stay valid and clearly malformed input is still rejected.

## Feature Flag
`FORMBUILDER_SAVE_TO_CASE`

## Safety Assurance

### Safety story
This is a strict relaxation of a single client-side validation regex. It accepts more strings than before and rejects nothing that was previously accepted, so existing forms and saved data are unaffected. There is no change to XML parsing, generation, or any server interaction. Confidence comes from local test runs and the targeted scope of the diff.

### Automated test coverage

Yes.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
