### PR TITLE
Add question type ConnectWorkAreaUpdate to connect plugin

### DIFF
--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -1,7 +1,7 @@
 /**
  * CommCare Connect plugin for Vellum
  *
- * This plugin add new mug types:
+ * This plugin adds new mug types:
  * - Learn Module
  * - Assessment Score
  * - Delivery Unit
@@ -393,6 +393,7 @@ let mugConfigs = {
                     widget: widgets.xPath,
                     serialize: mugs.serializeXPath,
                     deserialize: mugs.deserializeXPath,
+                    help: gettext('One of the valid values accepted by CommCare Connect like REQUEST_FOR_INACCESSIBLE')
                 },
                 reason: {
                     lstring: gettext("Reason"),

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -351,6 +351,83 @@ let mugConfigs = {
             }),
             _.clone(logicSection),
         ],
+    },
+    ConnectWorkAreaUpdate: {
+        rootName: "work_area_update",
+        childNodes: [
+            {id: "work_area_id"},
+            {id: "status"},
+            {id: "reason"},
+            {id: "additional_details"},
+            {id: "photo_evidence"}
+        ],
+        mugOptions: util.extend(baseMugOptions, {
+            typeName: 'Work Area Update',
+            icon: 'fa fa-wrench',
+            init: mug => {
+                mug.p.work_area_id = "";
+                mug.p.status = "";
+                mug.p.reason = "";
+                mug.p.additional_details = "";
+                mug.p.photo_evidence = "";
+            },
+            spec: util.extend(baseSpec, {
+                work_area_id: {
+                    lstring: gettext("Work Area ID"),
+                    visibility: 'visible',
+                    presence: 'required',
+                    widget: widgets.xPath,
+                    serialize: mugs.serializeXPath,
+                    deserialize: mugs.deserializeXPath,
+                    help: gettext('XPath expression for the work area ID associated with this update.'),
+                },
+                status: {
+                    lstring: gettext("Status"),
+                    visibility: 'visible',
+                    presence: 'required',
+                    widget: widgets.xPath,
+                    serialize: mugs.serializeXPath,
+                    deserialize: mugs.deserializeXPath,
+                },
+                reason: {
+                    lstring: gettext("Reason"),
+                    visibility: 'visible',
+                    presence: 'required',
+                    widget: widgets.xPath,
+                    serialize: mugs.serializeXPath,
+                    deserialize: mugs.deserializeXPath,
+                },
+                additional_details: {
+                    lstring: gettext("Additional Details"),
+                    visibility: 'visible',
+                    presence: 'optional',
+                    widget: widgets.xPath,
+                    serialize: mugs.serializeXPath,
+                    deserialize: mugs.deserializeXPath,
+                },
+                photo_evidence: {
+                    lstring: gettext("Photo Evidence"),
+                    visibility: 'visible',
+                    presence: 'required',
+                    widget: widgets.xPath,
+                    serialize: mugs.serializeXPath,
+                    deserialize: mugs.deserializeXPath,
+                    help: gettext('Reference to the image uploaded for photo evidence'),
+                }
+            })
+        }),
+        sections: [
+            _.extend({}, baseSection, {
+                properties: [
+                    "work_area_id",
+                    "status",
+                    "reason",
+                    "additional_details",
+                    "photo_evidence",
+                ],
+            }),
+            _.clone(logicSection),
+        ],
     }
 };
 

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -1,10 +1,12 @@
 /**
  * CommCare Connect plugin for Vellum
  *
- * This plugin adds two new mug types:
+ * This plugin add new mug types:
  * - Learn Module
  * - Assessment Score
  * - Delivery Unit
+ * - Task
+ * - Work Area Update
  */
 import $ from "jquery";
 import _ from "underscore";

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -156,15 +156,6 @@ let mugConfigs = {
                         return val && val.match(/^\d+$/) ? "pass" : gettext("Must be an integer");
                     },
                     help: gettext('Estimated time to complete the module in hours.'),
-                },
-                relevantAttr: {
-                    visibility: 'visible',
-                    presence: 'optional',
-                    widget: widgets.xPath,
-                    xpathType: "bool",
-                    serialize: mugs.serializeXPath,
-                    deserialize: mugs.deserializeXPath,
-                    lstring: gettext('Display Condition'),
                 }
             })
         }),
@@ -203,15 +194,6 @@ let mugConfigs = {
                     serialize: mugs.serializeXPath,
                     deserialize: mugs.deserializeXPath,
                     help: gettext('XPath expression for the users assessment score.'),
-                },
-                relevantAttr: {
-                    visibility: 'visible',
-                    presence: 'optional',
-                    widget: widgets.xPath,
-                    xpathType: "bool",
-                    serialize: mugs.serializeXPath,
-                    deserialize: mugs.deserializeXPath,
-                    lstring: gettext('Display Condition')
                 }
             })
         }),
@@ -278,15 +260,6 @@ let mugConfigs = {
                     serialize: mugs.serializeXPath,
                     deserialize: mugs.deserializeXPath,
                     help: gettext('XPath expression for the work area ID associated with this Delivery Unit.'),
-                },
-                relevantAttr: {
-                    visibility: 'visible',
-                    presence: 'optional',
-                    widget: widgets.xPath,
-                    xpathType: "bool",
-                    serialize: mugs.serializeXPath,
-                    deserialize: mugs.deserializeXPath,
-                    lstring: gettext('Display Condition')
                 }
             })
         }),
@@ -331,15 +304,6 @@ let mugConfigs = {
                     visibility: 'visible',
                     presence: 'required',
                     widget: widgets.richTextarea,
-                },
-                relevantAttr: {
-                    visibility: 'visible',
-                    presence: 'optional',
-                    widget: widgets.xPath,
-                    xpathType: "bool",
-                    serialize: mugs.serializeXPath,
-                    deserialize: mugs.deserializeXPath,
-                    lstring: gettext('Display Condition'),
                 }
             })
         }),

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -374,6 +374,9 @@ let mugConfigs = {
                 mug.p.photo_evidence = "";
             },
             spec: util.extend(baseSpec, {
+                nodeID: {
+                    lstring: gettext('Work Area Update ID'),
+                },
                 work_area_id: {
                     lstring: gettext("Work Area ID"),
                     visibility: 'visible',
@@ -421,6 +424,7 @@ let mugConfigs = {
         sections: [
             _.extend({}, baseSection, {
                 properties: [
+                    "nodeID",
                     "work_area_id",
                     "status",
                     "reason",

--- a/tests/commcareConnect.js
+++ b/tests/commcareConnect.js
@@ -5,6 +5,7 @@ import ASSESSMENT_XML from "static/commcareConnect/assessment.xml";
 import TASK_XML from "static/commcareConnect/task_module.xml";
 import DELIVER_XML from "static/commcareConnect/deliver.xml";
 import DELIVER_WORK_AREA_XML from "static/commcareConnect/deliver_with_work_area.xml";
+import WORK_AREA_UPDATE_XML from "static/commcareConnect/work_area_update.xml";
 
 var assert = chai.assert,
     call = util.call;
@@ -83,6 +84,27 @@ describe("The CommCareConnect", function() {
             assert.equal(task.p.description, "Task 1 is fun\nLearning is still fun");
             assert.equal(task.p.relevantAttr, "x = 3");
             util.assertXmlEqual(call("createXML"), TASK_XML);
+        });
+    });
+
+    describe("work area update", function () {
+        it("should load and save", function () {
+            util.loadXML(WORK_AREA_UPDATE_XML);
+            var update = util.getMug("update_1");
+            assert.equal(update.__className, "ConnectWorkAreaUpdate");
+            assert.equal(update.p.work_area_id, "instance('commcaresession')/session/data/work_area_id");
+            assert.equal(update.p.status, "/data/status_choice");
+            assert.equal(update.p.reason, "/data/reason_text");
+            assert.equal(update.p.additional_details, "/data/details");
+            assert.equal(update.p.photo_evidence, "/data/photo");
+            assert.equal(update.p.relevantAttr, "x = 4");
+            util.assertXmlEqual(call("createXML"), WORK_AREA_UPDATE_XML);
+        });
+
+        it("should make additional_details optional", function () {
+            var mug = util.addQuestion("ConnectWorkAreaUpdate", "update");
+            assert.equal(mug.spec.additional_details.presence, "optional");
+            assert.equal(mug.p.additional_details, "");
         });
     });
 });

--- a/tests/commcareConnect.js
+++ b/tests/commcareConnect.js
@@ -106,5 +106,10 @@ describe("The CommCareConnect", function() {
             assert.equal(mug.spec.additional_details.presence, "optional");
             assert.equal(mug.p.additional_details, "");
         });
+
+        it("should label nodeID as 'Work Area Update ID'", function () {
+            var mug = util.addQuestion("ConnectWorkAreaUpdate", "update");
+            assert.equal(mug.spec.nodeID.lstring, "Work Area Update ID");
+        });
     });
 });

--- a/tests/static/commcareConnect/work_area_update.xml
+++ b/tests/static/commcareConnect/work_area_update.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/E1B03643-109D-4DC6-9737-815E4401DE79" uiVersion="1" version="1" name="Untitled Form">
+					<status_choice />
+					<reason_text />
+					<details />
+					<photo />
+					<update_1 vellum:role="ConnectWorkAreaUpdate">
+						<work_area_update xmlns="http://commcareconnect.com/data/v1/learn" id="update_1">
+							<work_area_id/>
+							<status/>
+							<reason/>
+							<additional_details/>
+							<photo_evidence/>
+						</work_area_update>
+					</update_1>
+				</data>
+			</instance>
+			<instance src="jr://instance/session" id="commcaresession" />
+			<bind vellum:nodeset="#form/status_choice" nodeset="/data/status_choice" type="xsd:string" />
+			<bind vellum:nodeset="#form/reason_text" nodeset="/data/reason_text" type="xsd:string" />
+			<bind vellum:nodeset="#form/details" nodeset="/data/details" type="xsd:string" />
+			<bind vellum:nodeset="#form/photo" nodeset="/data/photo" type="binary" />
+			<bind vellum:nodeset="#form/update_1" nodeset="/data/update_1" relevant="x = 4" />
+			<bind nodeset="/data/update_1/work_area_update/work_area_id" calculate="instance('commcaresession')/session/data/work_area_id" />
+			<bind nodeset="/data/update_1/work_area_update/status" vellum:calculate="#form/status_choice" calculate="/data/status_choice" />
+			<bind nodeset="/data/update_1/work_area_update/reason" vellum:calculate="#form/reason_text" calculate="/data/reason_text" />
+			<bind nodeset="/data/update_1/work_area_update/additional_details" vellum:calculate="#form/details" calculate="/data/details" />
+			<bind nodeset="/data/update_1/work_area_update/photo_evidence" vellum:calculate="#form/photo" calculate="/data/photo" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="status_choice-label">
+						<value>status_choice</value>
+					</text>
+					<text id="reason_text-label">
+						<value>reason_text</value>
+					</text>
+					<text id="details-label">
+						<value>details</value>
+					</text>
+					<text id="photo-label">
+						<value>photo</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input vellum:ref="#form/status_choice" ref="/data/status_choice">
+			<label ref="jr:itext('status_choice-label')" />
+		</input>
+		<input vellum:ref="#form/reason_text" ref="/data/reason_text">
+			<label ref="jr:itext('reason_text-label')" />
+		</input>
+		<input vellum:ref="#form/details" ref="/data/details">
+			<label ref="jr:itext('details-label')" />
+		</input>
+		<upload mediatype="image/*" vellum:ref="#form/photo" ref="/data/photo">
+			<label ref="jr:itext('photo-label')" />
+		</upload>
+	</h:body>
+</h:html>


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
https://dimagi.atlassian.net/browse/CCCT-2397

On same lines as https://github.com/dimagi/Vellum/pull/1194 add a new question type for work area update.

<img width="1499" height="594" alt="image" src="https://github.com/user-attachments/assets/c7e44c49-c261-4f9c-8def-250e929a4d27" />

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
This adds a new question type ConnectWorkAreaUpdate that has all xpaths which will get values from other questions in the forms like all other connect plugin mugs, including a image capture field.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`COMMCARE_CONNECT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
tested on staging. also tests added.
The blast radius is limited to projects with the connect feature flag enabled.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
