### PR TITLE
Add Edit Form Details modal for in Vellum

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2356,6 +2356,8 @@ fn.send = function (formText, saveType) {
 
     data = saveType === 'patch' ? {patch: patch} : {xform: formText};
     data = this.augmentSentData(data, saveType);
+    data.name = this.data.core.form.formName;
+    data.comment = this.data.core.form.formComment;
     data.case_references = JSON.stringify(this.data.core.form._logicManager.caseReferences());
     if (checkForConflict) {
         data.sha1 = CryptoJS.SHA1(this.data.core.lastSavedXForm).toString();

--- a/src/core.js
+++ b/src/core.js
@@ -7,6 +7,7 @@ import CodeMirror from "codemirror";
 import main_template from "vellum/templates/main.html";
 import add_question from "vellum/templates/add_question.html";
 import edit_source from "vellum/templates/edit_source.html";
+import edit_form_details_modal from "vellum/templates/edit_form_details_modal.html";
 import confirm_overwrite from "vellum/templates/confirm_overwrite.html";
 import control_group_stdInput from "vellum/templates/control_group_stdInput.html";
 import form_errors_template from "vellum/templates/form_errors_template.html";
@@ -549,6 +550,10 @@ fn._init_extra_tools = function () {
         });
     });
 
+    this.$f.find('.fd-edit-form-details-button').click(function () {
+        _this.showEditFormDetailsModal();
+    });
+
     // Section toggling menu
     this.$f.find(".fd-content-right").on('click', '.fd-section-changer .dropdown-menu a', function(e) {
         var $link = $(e.target);
@@ -788,6 +793,33 @@ fn.showOverwriteWarning = function(send, formText, serverForm) {
 
     $('#form-differences').hide();
     $modal.modal('show');
+};
+
+fn.showEditFormDetailsModal = function () {
+    var _this = this,
+        form = this.data.core.form,
+        $modal = this.generateNewModal(gettext("Edit Form Details"), [
+            {
+                title: gettext("Update"),
+                cssClasses: "btn-primary",
+                action: function () {
+                    form.setAttr('formName', $nameInput.val());
+                    form.setAttr('formComment', $commentInput.val());
+                    _this.$f.find('.fd-tree .fd-head-text').text(form.formName);
+                    _this.closeModal();
+                }
+            }
+        ], gettext("Cancel")),
+        $body = $(edit_form_details_modal()),
+        $nameInput = $body.find('.fd-form-name').val(form.formName),
+        $commentInput = $body.find('.fd-form-comment').val(form.formComment);
+
+    $modal.find('.modal-body').html($body);
+
+    $modal.modal('show');
+    $modal.one('shown.bs.modal', function () {
+        $nameInput.focus();
+    });
 };
 
 fn.showFormPropertiesModal = function () {

--- a/src/core.js
+++ b/src/core.js
@@ -1362,7 +1362,7 @@ fn.loadXFormOrError = function (formString, done, updateSaveButton) {
             if (_this.opts().core.formIconClass) {
                 _this.$f.find('.fd-form-icon').addClass(_this.opts().core.formIconClass);
             } else {
-                _this.$f.find('.fd-form-icon').addClass('fa fa-edit');
+                _this.$f.find('.fd-form-icon').addClass('fa fa-regular fa-file');
             }
             if (_this.opts().core.defaultHelpTextTemplateId) {
                 _this.$f.find('.fd-default-helptext')

--- a/src/form.js
+++ b/src/form.js
@@ -117,6 +117,7 @@ function Form (opts, vellum, mugTypes) {
     this.mugTypes = mugTypes;
 
     this.formName = vellum.opts().core.formName || gettext("New Form");
+    this.formComment = vellum.opts().core.formComment || "";
     this.noMarkdown = false;
     this.mugMap = {};
     this.instanceMetadata = [InstanceMetadata({})];

--- a/src/less-style/lib/variables.less
+++ b/src/less-style/lib/variables.less
@@ -3,6 +3,7 @@
 @gridGutterWidth: 20px;
 @treeBrowserHeadHeight: 25px;
 
+@menuContainerWidth: 50px;
 @contentPaddingVellum: 12px;
 
 // colors

--- a/src/less-style/structure.less
+++ b/src/less-style/structure.less
@@ -78,7 +78,6 @@ body.vellum-full-screen {
 
             // Heading for any panel (question tree, expression editor, etc.)
             .fd-head {
-                @menuContainerWidth: 50px;
                 color: @white;
                 background-color: @cc-brand-low;
                 font-size: 17px;    // size icons
@@ -110,44 +109,6 @@ body.vellum-full-screen {
                     position: absolute;
                     left: 0;
                     right: @menuContainerWidth - @contentPaddingVellum;
-                }
-
-                // Question tree menu (language switcher, copy, paste, etc.)
-                .fd-head-menu-container {
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                    line-height: 23px;
-                    font-size: @baseFontSize * 0.9;
-                    min-width: @menuContainerWidth;
-
-                    // Icon link to open dropdown
-                    .dropdown {
-                        .dropdown-toggle {
-                            color: @white;
-                            cursor: pointer;
-                            display: block;
-                            padding: 0 @contentPaddingVellum;
-                            text-decoration: none;
-                            background-color: @cc-brand-low;
-
-                            &:hover {
-                                text-decoration: none;
-                                background-color: @cc-brand-mid;
-                            }
-                        }
-
-                        // Menu options
-                        .dropdown-menu {
-                            a {
-                                min-width: 170px;
-
-                                > .hotkey {
-                                    float: right;
-                                }
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/src/less-style/tree-content.less
+++ b/src/less-style/tree-content.less
@@ -81,8 +81,41 @@
                 font-size: 14px;
             }
 
+            // Question tree menu (language switcher, copy, paste, etc.)
             .fd-head-menu-container {
+                position: absolute;
+                right: 0px;
+                top: 0px;
                 line-height: @height;
+                font-size: @baseFontSize * 0.9;
+                min-width: @menuContainerWidth;
+
+                // Icon link to open dropdown
+                .dropdown {
+                    .dropdown-toggle {
+                        color: @white;
+                        cursor: pointer;
+                        display: block;
+                        padding: 0 @contentPaddingVellum;
+                        text-decoration: none;
+                        background-color: @cc-brand-low;
+
+                        &:hover {
+                            text-decoration: none;
+                            background-color: @cc-brand-mid;
+                        }
+                    }
+
+                    // Menu options
+                    .dropdown-menu {
+                        a {
+                            min-width: 170px;
+                            > .hotkey {
+                                float: right;
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/src/less-style/tree-content.less
+++ b/src/less-style/tree-content.less
@@ -89,6 +89,19 @@
                 line-height: @height;
                 font-size: @baseFontSize * 0.9;
                 min-width: @menuContainerWidth;
+                display: flex;
+
+                .fd-edit-form-details-button {
+                    padding: 0 @contentPaddingVellum;
+                    color: @white;
+                    background: @cc-brand-low;
+                    border: 0;
+                    cursor: pointer;
+              
+                    &:hover {
+                        background: @cc-brand-mid;
+                    }
+                }
 
                 // Icon link to open dropdown
                 .dropdown {

--- a/src/templates/edit_form_details_modal.html
+++ b/src/templates/edit_form_details_modal.html
@@ -1,0 +1,12 @@
+<div class="form-group">
+    <label class="control-label col-sm-3"><%-gettext("Form Name")%></label>
+    <div class="col-sm-9">
+        <input type="text" class="form-control fd-form-name" />
+    </div>
+</div>
+<div class="form-group">
+    <label class="control-label col-sm-3"><%-gettext("Comment")%></label>
+    <div class="col-sm-9">
+        <textarea class="form-control fd-form-comment vertical-resize" rows="5"></textarea>
+    </div>
+</div>

--- a/src/templates/main.html
+++ b/src/templates/main.html
@@ -7,6 +7,9 @@
                     <span class="fd-head-text"><%-gettext("Questions")%></span>
                 </h2>
                 <div class="fd-head-menu-container">
+                    <button class="fd-edit-form-details-button" type="button" title="<%-gettext('Edit Form Details')%>">
+                        <i class="fa fa-pencil"></i>
+                    </button>
                     <div class="dropdown">
                         <a class="dropdown-toggle"
                            data-toggle="dropdown">

--- a/tests/core.js
+++ b/tests/core.js
@@ -673,6 +673,62 @@ describe("Vellum core", function () {
         });
     });
 
+    describe("save POST carries name and comment", function () {
+        var SRV_FORM = new Array(20).join(" line one\n line two\n line three\n line four\n line five\n"),
+            vellum, patchData, fullData;
+        before(function (done) {
+            util.init({
+                core: {
+                    onReady: function () {
+                        vellum = this;
+                        done();
+                    },
+                    patchUrl: function (data) {
+                        patchData = data;
+                        return {status: "ok", sha1: "abc"};
+                    },
+                    saveUrl: function (data) {
+                        fullData = data;
+                        return {xform: data.xform};
+                    },
+                },
+            });
+        });
+        beforeEach(function () {
+            patchData = fullData = null;
+            vellum.data.core.saveButton.fire("change");
+            vellum.data.core.lastSavedXForm = SRV_FORM;
+            vellum.data.core.form.setAttr('formName', 'Survey');
+            vellum.data.core.form.setAttr('formComment', 'For Q2 rollout');
+        });
+
+        it("should include name and comment in a patch save", function () {
+            vellum.send(SRV_FORM + " edit", "patch");
+            assert(patchData, "patchUrl was not called");
+            assert(patchData.patch, "patch payload missing");
+            assert.equal(patchData.name, 'Survey');
+            assert.equal(patchData.comment, 'For Q2 rollout');
+        });
+
+        it("should include name and comment in a full save", function () {
+            vellum.send(SRV_FORM + " edit", "full");
+            assert(fullData, "saveUrl was not called");
+            assert(fullData.xform, "xform payload missing");
+            assert.equal(fullData.name, 'Survey');
+            assert.equal(fullData.comment, 'For Q2 rollout');
+        });
+
+        it("should include name and comment when patch is too long and falls back to full", function () {
+            // Tiny new form vs. long SRV_FORM means the patch text is longer
+            // than the new form text, triggering the auto-promote fallback
+            // inside fn.send.
+            vellum.send("abc", "patch");
+            assert(fullData, "saveUrl was not called (fallback didn't fire)");
+            assert.equal(fullData.name, 'Survey');
+            assert.equal(fullData.comment, 'For Q2 rollout');
+        });
+    });
+
     describe("with duplicate ID should", function () {
         var form, dup;
         before(function () {

--- a/tests/main.js
+++ b/tests/main.js
@@ -125,9 +125,11 @@ import('jquery.vellum').then(() => Promise.all([
         }, 500);
     }
 
-    $('#load-saved').click(function () {
+    function loadFromSession() {
         load(session.getItem("vellum.tests.main.lastSavedForm") || "");
-    });
+    }
+
+    $('#load-saved').click(loadFromSession);
 
     if (navigator.userAgent.indexOf('HeadlessChrome') >= 0) {
         load("", function () { mocha.run(); });
@@ -136,7 +138,7 @@ import('jquery.vellum').then(() => Promise.all([
         // (Application > Storage > Session Storage > http://localhost...
         //  > vellum.tests.main.lastSavedForm value)
         // and then add ?load=saved to query string and reload.
-        load(session.getItem("vellum.tests.main.lastSavedForm") || "");
+        loadFromSession();
     } else {
         load(""); // load empty form on initial page load
     }

--- a/tests/main.js
+++ b/tests/main.js
@@ -81,7 +81,10 @@ import('jquery.vellum').then(() => Promise.all([
 ])).then(function() {
     // All tests are now loaded and registered with mocha
 
-    var session = window.sessionStorage;
+    var session = window.sessionStorage,
+        LAST_SAVED_FORM_KEY = "vellum.tests.main.lastSavedForm",
+        LAST_SAVED_FORM_NAME_KEY = "vellum.tests.main.lastSavedFormName",
+        LAST_SAVED_FORM_COMMENT_KEY = "vellum.tests.main.lastSavedFormComment";
 
     function runTests() {
         function showTestResults() {
@@ -104,18 +107,22 @@ import('jquery.vellum').then(() => Promise.all([
     }
     $('#run-tests').click(runTests);
 
-    function load(form, ready) {
+    function load(form, ready, formName, formComment) {
         $('#vellum').empty().vellum($.extend(true, {}, options.options, {
             core: {
                 onReady: ready,
                 saveUrl: function (data) {
-                    session.setItem("vellum.tests.main.lastSavedForm", data.xform);
+                    session.setItem(LAST_SAVED_FORM_KEY, data.xform);
+                    session.setItem(LAST_SAVED_FORM_NAME_KEY, data.name || "");
+                    session.setItem(LAST_SAVED_FORM_COMMENT_KEY, data.comment || "");
                 },
                 patchUrl: function (data) {
                     // fake conflict to retry with saveUrl
                     return {status: 'conflict'};
                 },
-                form: form
+                form: form,
+                formName: formName,
+                formComment: formComment,
             }
         }));
 
@@ -126,7 +133,12 @@ import('jquery.vellum').then(() => Promise.all([
     }
 
     function loadFromSession() {
-        load(session.getItem("vellum.tests.main.lastSavedForm") || "");
+        load(
+            session.getItem(LAST_SAVED_FORM_KEY) || "",
+            undefined,
+            session.getItem(LAST_SAVED_FORM_NAME_KEY) || undefined,
+            session.getItem(LAST_SAVED_FORM_COMMENT_KEY) || undefined
+        );
     }
 
     $('#load-saved').click(loadFromSession);
@@ -136,7 +148,8 @@ import('jquery.vellum').then(() => Promise.all([
     } else if (/[?&]load=saved(&|#|$)/.test(window.location.href)) {
         // Use Chrome dev tools to preset form XML
         // (Application > Storage > Session Storage > http://localhost...
-        //  > vellum.tests.main.lastSavedForm value)
+        //  > vellum.tests.main.lastSavedForm value, plus optionally
+        //  lastSavedFormName / lastSavedFormComment)
         // and then add ?load=saved to query string and reload.
         loadFromSession();
     } else {


### PR DESCRIPTION
## Product Description

This PR is to replace the pencil button that injected by CommCare HQ into Vellum. now Vellum owns both the button and the modal.

This is to solve the issue that when update form name using the HQ injected modal, without reloading the page, Vellum will never know, thus the source XML which is written by Vellum won't contain the new `<title>`, but the `<title>` in server side has been changed, thus Vellum would think there is an conflict, thus gives a warning of overwriting changes.

https://github.com/user-attachments/assets/8fc059df-7fa2-4b65-acbb-b198ac96b144
 

## Technical Summary

Ticket: https://dimagi.atlassian.net/browse/SAAS-18436

Except for adding a new modal and set form's name and comment from the new modal, this commit also update the default icon for form in Vellum ( use icon for Survey ).

## Feature Flag

NA

## Safety Assurance

### Safety story

I did thorough testing locally. The change in Vellum side is mainly UI, and sending the `name` and `comment` attr to existing `edit_form_attr` endpoint in HQ.

### Automated test coverage

New test added**`save POST carries name and comment`** in `tests/core.js`

### QA Plan

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review

- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change