### PR TITLE
Fix bubble interaction bugs in rich text editor

### DIFF
--- a/src/less-style/labels.less
+++ b/src/less-style/labels.less
@@ -11,9 +11,15 @@
     vertical-align: middle;
     font-weight: 400;
 
-    &:hover {
+    &:hover, &.selected {
         cursor: pointer;
         color: #ffffff;
+    }
+    // Suppress the OS selection highlight on bubble contents so it doesn't
+    // overlay the `.selected` darken below.
+    &::selection, *::selection {
+        background-color: transparent;
+        color: inherit;
     }
     .close {
         color: @cc-light-cool-accent-low;
@@ -41,7 +47,7 @@
     .close {
         color: @cc-light-cool-accent-low;
     }
-    &:hover {
+    &:hover, &.selected {
         background-color: desaturate(@cc-light-cool-accent-mid, 30%);
         border-color: darken(desaturate(@cc-light-cool-accent-mid, 30%), 5%);
         .close {
@@ -57,7 +63,7 @@
     .close {
         color: @cc-neutral-low;
     }
-    &:hover {
+    &:hover, &.selected {
         background-color: @cc-neutral-mid;
         .close {
             color: @cc-neutral-hi;
@@ -72,7 +78,7 @@
     .close {
         color: @cc-light-warm-accent-low;
     }
-    &:hover {
+    &:hover, &.selected {
         background-color: @cc-light-warm-accent-mid;
         .close {
             color: @cc-light-warm-accent-hi;
@@ -87,7 +93,7 @@
     .close {
         color: @cc-att-neg-low;
     }
-    &:hover {
+    &:hover, &.selected {
         background-color: @cc-att-neg-mid;
         .close {
             color: @cc-att-neg-hi;

--- a/src/richText.js
+++ b/src/richText.js
@@ -372,6 +372,23 @@ var editor = function(input, form, options) {
         );
     }
 
+    function updateBubbleSelectedState() {
+        const selection = window.getSelection();
+        const editorRanges = [];
+        for (let index = 0; index < selection.rangeCount; index++) {
+            const range = selection.getRangeAt(index);
+            if (inputElement.contains(range.commonAncestorContainer)) {
+                editorRanges.push(range);
+            }
+        }
+        if (!editorRanges.length) { return; }
+        inputElement.querySelectorAll('.label-datanode').forEach(bubble => {
+            const isSelected = editorRanges.some(range => range.intersectsNode(bubble));
+            bubble.classList.toggle('selected', isSelected);
+        });
+    }
+    document.addEventListener('selectionchange', updateBubbleSelectedState);
+
     if (arguments.length === 1) {
         throw new Error("editor not initialized: " +
                         $("<div>").append(input).html());
@@ -475,6 +492,7 @@ var editor = function(input, form, options) {
         },
         destroy: function () {
             if (input !== null) {
+                document.removeEventListener('selectionchange', updateBubbleSelectedState);
                 input.removeData("editorWrapper");
                 input = null;
             }

--- a/src/richText.js
+++ b/src/richText.js
@@ -294,31 +294,18 @@ var editor = function(input, form, options) {
             if (zwspBeforeMissing || zwspAfterMissing) {
                 spansToRemove.push(span);
             }
-
-            // There is only the tailing ZWSP left
-            if (nextNode && nextNode.nodeType === Node.TEXT_NODE &&
-                    nextNode.parentNode.getAttribute('contenteditable') === 'true' &&
-                    nextNode.parentNode.lastChild === nextNode &&
-                    nextNode.nodeValue === ZERO_WIDTH_SPACE) {
-
-                spansToRemove.push(span);
-            }
         });
 
         spansToRemove.forEach(span => {
             const prevNode = span.previousSibling;
             const nextNode = span.nextSibling;
-            // remove the previous node or tailing ZWSP if it has one
             if (prevNode && prevNode.nodeType === Node.TEXT_NODE && prevNode.nodeValue.endsWith(ZERO_WIDTH_SPACE)) {
                 prevNode.nodeValue = prevNode.nodeValue.slice(0, -1);
                 if (prevNode.length === 0) {
                     prevNode.remove();
                 }
             }
-            // remove the next node or leading ZWSP if it has one
-            // except if it is the last one in the editor
-            if (nextNode && nextNode.nodeType === Node.TEXT_NODE && nextNode.nodeValue.startsWith(ZERO_WIDTH_SPACE) &&
-                !(nextNode.parentNode.lastChild === nextNode && nextNode.nodeValue === ZERO_WIDTH_SPACE)) {
+            if (nextNode && nextNode.nodeType === Node.TEXT_NODE && nextNode.nodeValue.startsWith(ZERO_WIDTH_SPACE)) {
                 nextNode.nodeValue = nextNode.nodeValue.slice(1);
                 if (nextNode.length === 0) {
                     nextNode.remove();

--- a/src/richText.js
+++ b/src/richText.js
@@ -101,7 +101,7 @@ var editor = function(input, form, options) {
     });
     observer.observe(inputElement, { childList: true, subtree: true });
 
-    function insertHtmlWithSpace(content, insertSpaces = false) {
+    function insertHtmlWithSuffix(content, suffix=' ') {
         const hasFocus = document.activeElement === inputElement;
         let range;
         if (!hasFocus && x && y) {
@@ -153,9 +153,8 @@ var editor = function(input, form, options) {
             range.insertNode(fragment);
             range.collapse();
 
-            if (insertSpaces) {
-                const trailingSpace = document.createTextNode(" ");
-                range.insertNode(trailingSpace);
+            if (suffix) {
+                range.insertNode(document.createTextNode(suffix));
                 range.collapse();
             }
 
@@ -421,9 +420,9 @@ var editor = function(input, form, options) {
         },
         insertExpression: function (xpath) {
             if (options.isExpression) {
-                insertHtmlWithSpace(bubbleExpression(xpath, form), true);
+                insertHtmlWithSuffix(bubbleExpression(xpath, form));
             } else {
-                insertHtmlWithSpace(makeBubble(form, xpath), true);
+                insertHtmlWithSuffix(makeBubble(form, xpath));
             }
             return wrapper;
         },
@@ -431,7 +430,7 @@ var editor = function(input, form, options) {
             if (options.isExpression) {
                 throw new Error("cannot insert output into expression editor");
             }
-            insertHtmlWithSpace(bubbleOutputs(xpath, form));
+            insertHtmlWithSuffix(bubbleOutputs(xpath, form), '');
             return wrapper;
         },
         change: function () {

--- a/src/richText.js
+++ b/src/richText.js
@@ -340,6 +340,38 @@ var editor = function(input, form, options) {
         y = e.clientY;
     });
 
+    let bubbleClickInProgress = false;
+    inputElement.addEventListener('mousedown', function (event) {
+        // Select bubble on click. Use mousedown because it fires before
+        // the browser positions the caret.
+        const bubble = event.target?.closest?.('.label-datanode');
+        if (bubble && inputElement.contains(bubble)) {
+            event.preventDefault();
+            bubbleClickInProgress = true;
+            inputElement.focus();
+            selectBubbleAtom(bubble);
+            setTimeout(() => { bubbleClickInProgress = false; }, 0);
+        }
+    });
+
+    function selectBubbleAtom(bubble) {
+        const prev = bubble.previousSibling;
+        const next = bubble.nextSibling;
+        const parent = bubble.parentNode;
+        const bubbleIndex = Array.prototype.indexOf.call(parent.childNodes, bubble);
+        const hasLeadingZwsp = prev && prev.nodeType === Node.TEXT_NODE &&
+                prev.nodeValue.endsWith(ZERO_WIDTH_SPACE);
+        const hasTrailingZwsp = next && next.nodeType === Node.TEXT_NODE &&
+                next.nodeValue.startsWith(ZERO_WIDTH_SPACE);
+        const startNode = hasLeadingZwsp ? prev : parent;
+        const startOffset = hasLeadingZwsp ? prev.nodeValue.length - 1 : bubbleIndex;
+        const endNode = hasTrailingZwsp ? next : parent;
+        const endOffset = hasTrailingZwsp ? 1 : bubbleIndex + 1;
+        window.getSelection().setBaseAndExtent(
+            startNode, startOffset, endNode, endOffset
+        );
+    }
+
     if (arguments.length === 1) {
         throw new Error("editor not initialized: " +
                         $("<div>").append(input).html());
@@ -515,6 +547,7 @@ var editor = function(input, form, options) {
     });
 
     inputElement.addEventListener('focus', function () {
+        if (bubbleClickInProgress) { return; }
         const lastChild = inputElement.lastChild;
         if (lastChild && lastChild.length > 0) { // should always be true because of the tailing ZWSP
             const selection = window.getSelection();

--- a/src/richText.js
+++ b/src/richText.js
@@ -225,57 +225,80 @@ var editor = function(input, form, options) {
         }
     });
 
-    inputElement.addEventListener('mouseup', checkCursorPosition);
-    inputElement.addEventListener('keyup', checkCursorPosition);
+    inputElement.addEventListener('mouseup', snapSelectionAtBubbleBoundary);
+    inputElement.addEventListener('keyup', snapSelectionAtBubbleBoundary);
 
-    function checkCursorPosition(event) {
+    function snapSelectionAtBubbleBoundary(event) {
+        // The selection's focus end should not fall between a bubble and one of
+        // its surrounding ZWSPs. For a collapsed cursor, follow the arrow-key
+        // direction; otherwise bump outside. For an extended (shift+key)
+        // selection, jump the focus past the entire bubble atom.
         const selection = window.getSelection();
         if (!selection.rangeCount) return;
-
         const range = selection.getRangeAt(0);
-        if (!range.collapsed) return; // Only check when cursor is a point, not a selection
+        const focusNode = selection.focusNode;
+        const focusOffset = selection.focusOffset;
+        if (!focusNode || focusNode.nodeType !== Node.TEXT_NODE) return;
+        const value = focusNode.nodeValue;
 
-        const node = range.startContainer,
-              offset = range.startOffset;
-
-        // The cursor should not be between the bubble span and the ZWSP that surround it.
-        // If it got moved there using arrow keys follow the direction and place it on the
-        // other side of the span. If not, move the cursor to the outside.
-        if (node.nodeType === Node.TEXT_NODE) {
-            // Check if cursor is at the end of a text node that ends with ZWSP
-            if (offset === node.length && node.nodeValue.endsWith(ZERO_WIDTH_SPACE)) {
-                const nextNode = node.nextSibling;
-                if (nextNode && nextNode.nodeName.toLowerCase() === 'span' &&
-                    nextNode.contentEditable === 'false') {
-                    if (event.keyCode === 39) { //right arrow
-                       const nodeAfterSpan = nextNode.nextSibling;
-                       if (nodeAfterSpan && nodeAfterSpan.nodeType === Node.TEXT_NODE) {
-                           range.setStart(nodeAfterSpan, 1);
-                           range.collapse(true);
-                       }
-                    } else {
-                        range.setStart(node, offset - 1);
-                        range.collapse(true);
+        // Right-side boundary: focus at end of text ending with ZWSP.
+        if (focusOffset === value.length && value.endsWith(ZERO_WIDTH_SPACE)) {
+            const bubble = focusNode.nextSibling;
+            const isBubble = bubble?.classList?.contains('label-datanode');
+            if (range.collapsed) {
+                if (isBubble) {
+                    if (event.keyCode === 39) { // right arrow: past atom
+                        range.setStart(bubble.nextSibling, 1);
+                    } else { // bump back outside the leading ZWSP
+                        range.setStart(focusNode, focusOffset - 1);
                     }
-                } else if (!nextNode && node.parentNode.getAttribute('contenteditable') === 'true') { // behind the last ZWSP at the end
-                    range.setStart(node, offset - 1);
+                    range.collapse(true);
+                } else if (!bubble && focusNode.parentNode.getAttribute('contenteditable') === 'true') {
+                    // Behind the editor's trailing sentinel ZWSP.
+                    range.setStart(focusNode, focusOffset - 1);
                     range.collapse(true);
                 }
+            } else if (isBubble) {
+                selection.extend(bubble.nextSibling, 1);
             }
+            return;
+        }
 
-            if (offset === 0 && node.nodeValue.startsWith(ZERO_WIDTH_SPACE)) {
-                const prevNode = node.previousSibling;
-                if (prevNode && prevNode.nodeName.toLowerCase() === 'span' &&
-                    prevNode.contentEditable === 'false') {
-                    if (event.keyCode === 37) { //left arrow
-                        const nodeLeftOfSpan = prevNode.previousSibling;
-                        range.setStart(nodeLeftOfSpan, nodeLeftOfSpan.nodeValue.length - 1); // jumping over span and ZWSP
-                        range.collapse(true);
-                    } else {
-                        range.setStart(node, 1);
-                        range.collapse(true);
+        // Left-side boundary: focus at start of text starting with ZWSP.
+        if (focusOffset === 0 && value.startsWith(ZERO_WIDTH_SPACE)) {
+            const bubble = focusNode.previousSibling;
+            const isBubble = bubble?.classList?.contains('label-datanode');
+            if (range.collapsed) {
+                if (isBubble) {
+                    if (event.keyCode === 37) { // left arrow: past atom
+                        const prev = bubble.previousSibling;
+                        range.setStart(prev, prev.nodeValue.length - 1);
+                    } else { // bump forward outside the trailing ZWSP
+                        range.setStart(focusNode, 1);
                     }
+                    range.collapse(true);
                 }
+            } else if (isBubble) {
+                const prev = bubble.previousSibling;
+                selection.extend(prev, prev.nodeValue.length - 1);
+            }
+            return;
+        }
+
+        // Focus has landed inside a bubble's content (e.g., word-jump or
+        // drag-select crossed into a bubble). Snap it out to the boundary
+        // on the side that extends the selection further.
+        const bubble = focusNode.parentElement?.closest('.label-datanode');
+        if (bubble && !range.collapsed) {
+            const bubbleRange = document.createRange();
+            bubbleRange.selectNode(bubble);
+            const anchorBefore = bubbleRange.comparePoint(
+                selection.anchorNode, selection.anchorOffset) < 0;
+            if (anchorBefore) {
+                selection.extend(bubble.nextSibling, 1);
+            } else {
+                const prev = bubble.previousSibling;
+                selection.extend(prev, prev.nodeValue.length - 1);
             }
         }
     }

--- a/src/richText.js
+++ b/src/richText.js
@@ -232,7 +232,7 @@ var editor = function(input, form, options) {
         // The selection's focus end should not fall between a bubble and one of
         // its surrounding ZWSPs. For a collapsed cursor, follow the arrow-key
         // direction; otherwise bump outside. For an extended (shift+key)
-        // selection, jump the focus past the entire bubble atom.
+        // selection, jump the focus past the entire bubble.
         const selection = window.getSelection();
         if (!selection.rangeCount) return;
         const range = selection.getRangeAt(0);
@@ -247,7 +247,7 @@ var editor = function(input, form, options) {
             const isBubble = bubble?.classList?.contains('label-datanode');
             if (range.collapsed) {
                 if (isBubble) {
-                    if (event.keyCode === 39) { // right arrow: past atom
+                    if (event.keyCode === 39) { // right arrow: past bubble
                         range.setStart(bubble.nextSibling, 1);
                     } else { // bump back outside the leading ZWSP
                         range.setStart(focusNode, focusOffset - 1);
@@ -270,7 +270,7 @@ var editor = function(input, form, options) {
             const isBubble = bubble?.classList?.contains('label-datanode');
             if (range.collapsed) {
                 if (isBubble) {
-                    if (event.keyCode === 37) { // left arrow: past atom
+                    if (event.keyCode === 37) { // left arrow: past bubble
                         const prev = bubble.previousSibling;
                         range.setStart(prev, prev.nodeValue.length - 1);
                     } else { // bump forward outside the trailing ZWSP
@@ -356,7 +356,7 @@ var editor = function(input, form, options) {
             if (event.shiftKey) {
                 extendSelectionPastBubble(bubble);
             } else {
-                selectBubbleAtom(bubble);
+                selectBubble(bubble);
             }
             setTimeout(() => { bubbleClickInProgress = false; }, 0);
         }
@@ -365,11 +365,11 @@ var editor = function(input, form, options) {
     function extendSelectionPastBubble(bubble) {
         const selection = window.getSelection();
         if (selection.rangeCount === 0) {
-            selectBubbleAtom(bubble);
+            selectBubble(bubble);
             return;
         }
         const {anchorNode, anchorOffset} = selection;
-        const [startNode, startOffset, endNode, endOffset] = getBubbleAtomBoundaries(bubble);
+        const [startNode, startOffset, endNode, endOffset] = getBubbleBoundaries(bubble);
         const bubbleRange = document.createRange();
         bubbleRange.selectNode(bubble);
         const anchorIsBeforeBubble = bubbleRange.comparePoint(anchorNode, anchorOffset) < 0;
@@ -378,11 +378,11 @@ var editor = function(input, form, options) {
         selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
     }
 
-    function selectBubbleAtom(bubble) {
-        window.getSelection().setBaseAndExtent(...getBubbleAtomBoundaries(bubble));
+    function selectBubble(bubble) {
+        window.getSelection().setBaseAndExtent(...getBubbleBoundaries(bubble));
     }
 
-    function getBubbleAtomBoundaries(bubble) {
+    function getBubbleBoundaries(bubble) {
         const prev = bubble.previousSibling;
         const next = bubble.nextSibling;
         return [prev, prev.nodeValue.length - 1, next, 1];
@@ -509,7 +509,7 @@ var editor = function(input, form, options) {
             const range = selection.getRangeAt(0),
                   container = document.createElement('div');
             if (e.type === 'cut') {
-                expandRangeOverClippedBubbleAtoms(range);
+                expandRangeOverClippedBubble(range);
             }
             container.appendChild(range.cloneContents());
             selectedText = fromRichText(container.innerHTML, form, options.isExpression);
@@ -532,7 +532,7 @@ var editor = function(input, form, options) {
         }
     }
 
-    function expandRangeOverClippedBubbleAtoms(range) {
+    function expandRangeOverClippedBubble(range) {
         // If the selection includes a bubble's ZWSP boundary but not the bubble
         // itself (unexpected), the post-cut input handler will remove the
         // partially selected bubble, so it must also land on the clipboard.

--- a/src/richText.js
+++ b/src/richText.js
@@ -142,11 +142,6 @@ var editor = function(input, form, options) {
             selection.removeAllRanges();
             selection.addRange(range);
             range.deleteContents();
-            if (insertSpaces) {
-                const leadingSpaceNode = document.createTextNode(ZERO_WIDTH_SPACE);
-                range.insertNode(leadingSpaceNode);
-                range.setStartAfter(leadingSpaceNode);
-            }
 
             const fragment = htmlToFragment(content);
             const nodesNeedingPopovers = [];
@@ -159,8 +154,8 @@ var editor = function(input, form, options) {
             range.collapse();
 
             if (insertSpaces) {
-                const trailingSpaceNode = document.createTextNode(ZERO_WIDTH_SPACE + " ");
-                range.insertNode(trailingSpaceNode);
+                const trailingSpace = document.createTextNode(" ");
+                range.insertNode(trailingSpace);
                 range.collapse();
             }
 
@@ -421,17 +416,6 @@ var editor = function(input, form, options) {
             var richTextValue = toRichText(value, form, options);
             inputElement.innerHTML = richTextValue;
 
-            const nonEditableSpans = inputElement.querySelectorAll('span[contenteditable="false"]');
-            nonEditableSpans.forEach(span => {
-                const prevNode = span.previousSibling,
-                      nextNode = span.nextSibling;
-                if (!prevNode || prevNode.nodeType !== Node.TEXT_NODE || !prevNode.nodeValue.endsWith(ZERO_WIDTH_SPACE)) {
-                    span.parentNode.insertBefore(document.createTextNode(ZERO_WIDTH_SPACE), span);
-                }
-                if (!nextNode || nextNode.nodeType !== Node.TEXT_NODE || !nextNode.nodeValue.startsWith(ZERO_WIDTH_SPACE)) {
-                    span.parentNode.insertBefore(document.createTextNode(ZERO_WIDTH_SPACE), span.nextSibling);
-                }
-            });
             // Add ZWSP at the end to prevent browsers from replacing tailing spaces
             // with other characters changing the overall behavior
             inputElement.innerHTML += ZERO_WIDTH_SPACE;
@@ -452,10 +436,7 @@ var editor = function(input, form, options) {
             if (options.isExpression) {
                 insertHtmlWithSpace(bubbleExpression(xpath, form), true);
             } else {
-                var output = makeBubble(form, xpath);
-                insertHtmlWithSpace($('<p>')
-                    .append(output)
-                    .html(), true);
+                insertHtmlWithSpace(makeBubble(form, xpath), true);
             }
             return wrapper;
         },
@@ -779,12 +760,17 @@ function getBubbleDisplayValue(path, xpathParser) {
 }
 
 /**
- * Make a xpath bubble
+ * Make a xpath bubble wrapped in zero-width-spaces (ZWSP).
+ *
+ * The leading/trailing ZWSPs are part of the bubble's "atomic" boundary;
+ * they give the cursor a real text position next to a contenteditable="false"
+ * span and act as a delete sentinel that the input handler watches.
  *
  * @param xpath - xpath expression to set as the bubble value.
- * @returns jquery object of the bubble
+ * @param attrs - optional extra attributes to set on the bubble span.
+ * @returns HTML string: `ZWSP<span ...>...</span>ZWSP`
  */
-function makeBubble(form, xpath) {
+function makeBubble(form, xpath, attrs) {
     function _parseXPath(xpath, form) {
         if (!FORM_REF_REGEX.test(xpath)) {
             if (form.isValidHashtag(xpath)) {
@@ -819,13 +805,16 @@ function makeBubble(form, xpath) {
             .attr('id', uniqueId)
             .append(icon)
             .append(dispValue);
-
-    return $bubble;
+    if (attrs) {
+        $bubble.attr(attrs);
+    }
+    return ZERO_WIDTH_SPACE + $bubble.prop('outerHTML') + ZERO_WIDTH_SPACE;
 }
 
 /**
  * @param output - <output ...> DOM element
- * @returns - jquery object of xpath bubble or string
+ * @returns - HTML string for the xpath bubble (with surrounding ZWSPs) or
+ *            plain-text fallback when the value isn't a recognized reference.
  */
 function outputToBubble(form, output) {
     var info = extractXPathInfo($(output)),
@@ -838,13 +827,7 @@ function outputToBubble(form, output) {
     if (!startsWithRef || (startsWithRef && containsWhitespace)) {
         return $('<span>').text(xml.normalize(output)).html();
     }
-    // return $('<div>').append(makeBubble(form, xpath).attr(attrs)).html();
-    const m = $('<div>')
-        .append(document.createTextNode(ZERO_WIDTH_SPACE))
-        .append(makeBubble(form, xpath).attr(attrs))
-        .append(document.createTextNode(ZERO_WIDTH_SPACE))
-        .html();
-    return m;
+    return makeBubble(form, xpath, attrs);
 }
 
 /**
@@ -923,10 +906,9 @@ function bubbleExpression(text, form) {
         transform = form.transformHashtags;
     }
     function bubble(hashtag) {
-        return makeBubble(form, hashtag).prop('outerHTML');
+        return makeBubble(form, hashtag);
     }
-    const transformed = transform(text, bubble, true);
-    return transformed;
+    return transform(text, bubble, true);
 }
 
 function unwrapBubbles(text, form, isExpression) {

--- a/src/richText.js
+++ b/src/richText.js
@@ -330,12 +330,36 @@ var editor = function(input, form, options) {
             event.preventDefault();
             bubbleClickInProgress = true;
             inputElement.focus();
-            selectBubbleAtom(bubble);
+            if (event.shiftKey) {
+                extendSelectionPastBubble(bubble);
+            } else {
+                selectBubbleAtom(bubble);
+            }
             setTimeout(() => { bubbleClickInProgress = false; }, 0);
         }
     });
 
+    function extendSelectionPastBubble(bubble) {
+        const selection = window.getSelection();
+        if (selection.rangeCount === 0) {
+            selectBubbleAtom(bubble);
+            return;
+        }
+        const {anchorNode, anchorOffset} = selection;
+        const [startNode, startOffset, endNode, endOffset] = getBubbleAtomBoundaries(bubble);
+        const bubbleRange = document.createRange();
+        bubbleRange.selectNode(bubble);
+        const anchorIsBeforeBubble = bubbleRange.comparePoint(anchorNode, anchorOffset) < 0;
+        const focusNode = anchorIsBeforeBubble ? endNode : startNode;
+        const focusOffset = anchorIsBeforeBubble ? endOffset : startOffset;
+        selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
+    }
+
     function selectBubbleAtom(bubble) {
+        window.getSelection().setBaseAndExtent(...getBubbleAtomBoundaries(bubble));
+    }
+
+    function getBubbleAtomBoundaries(bubble) {
         const prev = bubble.previousSibling;
         const next = bubble.nextSibling;
         const parent = bubble.parentNode;
@@ -344,13 +368,12 @@ var editor = function(input, form, options) {
                 prev.nodeValue.endsWith(ZERO_WIDTH_SPACE);
         const hasTrailingZwsp = next && next.nodeType === Node.TEXT_NODE &&
                 next.nodeValue.startsWith(ZERO_WIDTH_SPACE);
-        const startNode = hasLeadingZwsp ? prev : parent;
-        const startOffset = hasLeadingZwsp ? prev.nodeValue.length - 1 : bubbleIndex;
-        const endNode = hasTrailingZwsp ? next : parent;
-        const endOffset = hasTrailingZwsp ? 1 : bubbleIndex + 1;
-        window.getSelection().setBaseAndExtent(
-            startNode, startOffset, endNode, endOffset
-        );
+        return [
+            /* startNode   */ hasLeadingZwsp ? prev : parent,
+            /* startOffset */ hasLeadingZwsp ? prev.nodeValue.length - 1 : bubbleIndex,
+            /*   endNode   */ hasTrailingZwsp ? next : parent,
+            /*   endOffset */ hasTrailingZwsp ? 1 : bubbleIndex + 1,
+        ];
     }
 
     function updateBubbleSelectedState() {

--- a/src/richText.js
+++ b/src/richText.js
@@ -362,18 +362,7 @@ var editor = function(input, form, options) {
     function getBubbleAtomBoundaries(bubble) {
         const prev = bubble.previousSibling;
         const next = bubble.nextSibling;
-        const parent = bubble.parentNode;
-        const bubbleIndex = Array.prototype.indexOf.call(parent.childNodes, bubble);
-        const hasLeadingZwsp = prev && prev.nodeType === Node.TEXT_NODE &&
-                prev.nodeValue.endsWith(ZERO_WIDTH_SPACE);
-        const hasTrailingZwsp = next && next.nodeType === Node.TEXT_NODE &&
-                next.nodeValue.startsWith(ZERO_WIDTH_SPACE);
-        return [
-            /* startNode   */ hasLeadingZwsp ? prev : parent,
-            /* startOffset */ hasLeadingZwsp ? prev.nodeValue.length - 1 : bubbleIndex,
-            /*   endNode   */ hasTrailingZwsp ? next : parent,
-            /*   endOffset */ hasTrailingZwsp ? 1 : bubbleIndex + 1,
-        ];
+        return [prev, prev.nodeValue.length - 1, next, 1];
     }
 
     function updateBubbleSelectedState() {
@@ -496,11 +485,17 @@ var editor = function(input, form, options) {
         if (selection.rangeCount > 0) {
             const range = selection.getRangeAt(0),
                   container = document.createElement('div');
+            if (e.type === 'cut') {
+                expandRangeOverClippedBubbleAtoms(range);
+            }
             container.appendChild(range.cloneContents());
             selectedText = fromRichText(container.innerHTML, form, options.isExpression);
 
             if (e.type === 'cut') {
                 range.deleteContents();
+                // Run the input handler to clean up any bubble whose ZWSP boundary
+                // the cut clipped, and to push the post-cut state onto the undo stack.
+                inputElement.dispatchEvent(new Event('input', {bubbles: true}));
             }
             if (isInvalid(selectedText)) {
                 selectedText = escapedHashtags.transform(
@@ -512,6 +507,28 @@ var editor = function(input, form, options) {
         if (e.clipboardData) {
             e.clipboardData.setData('text/plain', selectedText);
         }
+    }
+
+    function expandRangeOverClippedBubbleAtoms(range) {
+        // If the selection slices through a bubble's ZWSP boundary without
+        // including the bubble itself, the post-cut input handler will remove
+        // the partially selected bubble, so it must also land on the clipboard.
+        inputElement.querySelectorAll('.label-datanode').forEach(bubble => {
+            if (range.intersectsNode(bubble)) return;
+            const prev = bubble.previousSibling;
+            const next = bubble.nextSibling;
+            const leadingZwspInRange =
+                range.comparePoint(prev, prev.nodeValue.length - 1) === 0 &&
+                range.comparePoint(prev, prev.nodeValue.length) === 0;
+            const trailingZwspInRange =
+                range.comparePoint(next, 0) === 0 &&
+                range.comparePoint(next, 1) === 0;
+            if (leadingZwspInRange) {
+                range.setEnd(next, 1);
+            } else if (trailingZwspInRange) {
+                range.setStart(prev, prev.nodeValue.length - 1);
+            }
+        });
     }
 
     inputElement.addEventListener('copy', handleCopyOrCut);
@@ -595,6 +612,9 @@ var editor = function(input, form, options) {
                 if (!inputElement.innerHTML.endsWith(ZERO_WIDTH_SPACE)) {
                     inputElement.innerHTML += ZERO_WIDTH_SPACE;
                 }
+                // Run the input handler to clean up any bubble whose ZWSP boundary
+                // the inserted content clipped, and to push the new state onto the undo stack.
+                inputElement.dispatchEvent(new Event('input', {bubbles: true}));
             }
         }
     }

--- a/src/richText.js
+++ b/src/richText.js
@@ -422,7 +422,7 @@ var editor = function(input, form, options) {
             if (options.isExpression) {
                 insertHtmlWithSuffix(bubbleExpression(xpath, form));
             } else {
-                insertHtmlWithSuffix(makeBubble(form, xpath));
+                insertHtmlWithSuffix(makeBubble(xpath, form));
             }
             return wrapper;
         },
@@ -756,7 +756,7 @@ function getBubbleDisplayValue(path, xpathParser) {
  * @param attrs - optional extra attributes to set on the bubble span.
  * @returns HTML string: `ZWSP<span ...>...</span>ZWSP`
  */
-function makeBubble(form, xpath, attrs) {
+function makeBubble(xpath, form, attrs) {
     function _parseXPath(xpath, form) {
         if (!FORM_REF_REGEX.test(xpath)) {
             if (form.isValidHashtag(xpath)) {
@@ -802,7 +802,7 @@ function makeBubble(form, xpath, attrs) {
  * @returns - HTML string for the xpath bubble (with surrounding ZWSPs) or
  *            plain-text fallback when the value isn't a recognized reference.
  */
-function outputToBubble(form, output) {
+function outputToBubble(output, form) {
     var info = extractXPathInfo($(output)),
         xpath = form.normalizeHashtag(info.value, true),
         attrs = _.omit(info, 'value'),
@@ -813,7 +813,7 @@ function outputToBubble(form, output) {
     if (!startsWithRef || (startsWithRef && containsWhitespace)) {
         return $('<span>').text(xml.normalize(output)).html();
     }
-    return makeBubble(form, xpath, attrs);
+    return makeBubble(xpath, form, attrs);
 }
 
 /**
@@ -829,12 +829,12 @@ function bubbleOutputs(text, form, escape) {
     if (escape) {
         replacer = function () {
             var id = util.get_guid();
-            places[id] = outputToBubble(form, this);
+            places[id] = outputToBubble(this, form);
             return "{" + id + "}";
         };
     } else {
         replacer = function () {
-            return outputToBubble(form, this);
+            return outputToBubble(this, form);
         };
     }
     el.find('output').replaceWith(replacer);
@@ -892,7 +892,7 @@ function bubbleExpression(text, form) {
         transform = form.transformHashtags;
     }
     function bubble(hashtag) {
-        return makeBubble(form, hashtag);
+        return makeBubble(hashtag, form);
     }
     return transform(text, bubble, true);
 }

--- a/src/richText.js
+++ b/src/richText.js
@@ -533,22 +533,19 @@ var editor = function(input, form, options) {
     }
 
     function expandRangeOverClippedBubbleAtoms(range) {
-        // If the selection slices through a bubble's ZWSP boundary without
-        // including the bubble itself, the post-cut input handler will remove
-        // the partially selected bubble, so it must also land on the clipboard.
+        // If the selection includes a bubble's ZWSP boundary but not the bubble
+        // itself (unexpected), the post-cut input handler will remove the
+        // partially selected bubble, so it must also land on the clipboard.
+        if (range.collapsed) return;
         inputElement.querySelectorAll('.label-datanode').forEach(bubble => {
             if (range.intersectsNode(bubble)) return;
             const prev = bubble.previousSibling;
             const next = bubble.nextSibling;
-            const leadingZwspInRange =
-                range.comparePoint(prev, prev.nodeValue.length - 1) === 0 &&
-                range.comparePoint(prev, prev.nodeValue.length) === 0;
-            const trailingZwspInRange =
-                range.comparePoint(next, 0) === 0 &&
-                range.comparePoint(next, 1) === 0;
-            if (leadingZwspInRange) {
+            const isLeadingZwspSelected = range.comparePoint(prev, prev.nodeValue.length) === 0;
+            const isTrailingZwspSelected = range.comparePoint(next, 0) === 0;
+            if (isLeadingZwspSelected) {
                 range.setEnd(next, 1);
-            } else if (trailingZwspInRange) {
+            } else if (isTrailingZwspSelected) {
                 range.setStart(prev, prev.nodeValue.length - 1);
             }
         });

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -35,6 +35,7 @@
         "afterEach": false,
         /* BROWSER APIS */
         "DataTransfer": false,
-        "ClipboardEvent": false
+        "ClipboardEvent": false,
+        "KeyboardEvent": false
     }
 }

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -171,10 +171,6 @@ function removeSpanId(htmlString) {
     return htmlString.replace(/<span([^>]*)\s+id="[^"]*"([^>]*)>/g, '<span$1$2>');
 }
 
-function removeZWSP(htmlString) {
-    return htmlString.replace(/\u200B/g, '');
-}
-
 describe("Rich text utilities", function() {
     before(setupGlobalForm);
 
@@ -600,11 +596,11 @@ describe("The rich text editor", function () {
                     });
                     input_[0].dispatchEvent(clipboardEvent);
 
-                    const text = removeZWSP(removeSpanId(input_[0].innerHTML));
-                    const expText = removeZWSP(removeSpanId(richText
+                    const text = removeSpanId(input_[0].innerHTML);
+                    const expText = removeSpanId(richText
                         .toRichText(initialExpr, form, opts)
-                        .replace(find, escapeHTML(pasteText))));
-                    assert.equal(text, expText);
+                        .replace(find, escapeHTML(pasteText)) + ZWSP);
+                    assert.equal(escape(text), escape(expText));
                     assert.equal(editor.getValue(),
                         initialExpr.substring(0, selStart) + pasteText +
                         initialExpr.substring(selStart + selLength));

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -850,6 +850,109 @@ describe("The rich text editor", function () {
                     done();
                 });
             });
+
+            it("should extend selection past whole bubble on shift+ArrowRight", function (done) {
+                exprEditor.setValue("1 + #form/text + 2", function () {
+                    const paragraph = exprInput[0].querySelector('p');
+                    const firstText = paragraph.firstChild;
+                    // Select two chars before the bubble's leading ZWSP.
+                    exprInput[0].focus();
+                    const sel = window.getSelection();
+                    sel.setBaseAndExtent(firstText, 2, firstText, 4);
+                    assert.equal(escape(sel.toString()), "+ ", "precondition failed");
+                    // Simulate the browser's default one-char extension into the boundary.
+                    sel.extend(firstText, firstText.nodeValue.length);
+                    assert.equal(escape(sel.toString()), "+ {ZWSP}", "precondition failed");
+
+                    exprInput[0].dispatchEvent(new KeyboardEvent('keyup', {
+                        key: 'ArrowRight',
+                        shiftKey: true,
+                        bubbles: true,
+                    }));
+
+                    const selection = window.getSelection();
+                    assert.equal(escape(selection.toString()), "+ {ZWSP} text{ZWSP}", "unexpected selection");
+                    assert.equal(escape(selection.focusNode), "{ZWSP} + 2", "unexpected focus");
+                    done();
+                });
+            });
+
+            it("should extend selection past whole bubble on shift+ArrowLeft", function (done) {
+                exprEditor.setValue("1 + #form/text + 2", function () {
+                    const paragraph = exprInput[0].querySelector('p');
+                    const trailingText = paragraph.childNodes[2];
+                    // Select two chars after the bubble's trailing ZWSP, focus on the left.
+                    exprInput[0].focus();
+                    const sel = window.getSelection();
+                    sel.setBaseAndExtent(trailingText, 3, trailingText, 1);
+                    assert.equal(escape(sel.toString()), " +", "precondition failed");
+                    // Simulate the browser's default one-char extension into the boundary.
+                    sel.extend(trailingText, 0);
+                    assert.equal(escape(sel.toString()), "{ZWSP} +", "precondition failed");
+
+                    exprInput[0].dispatchEvent(new KeyboardEvent('keyup', {
+                        key: 'ArrowLeft',
+                        shiftKey: true,
+                        bubbles: true,
+                    }));
+
+                    const selection = window.getSelection();
+                    assert.equal(escape(selection.toString()), "{ZWSP} text{ZWSP} +", "unexpected selection");
+                    assert.equal(escape(selection.focusNode), "1 + {ZWSP}", "unexpected focus node");
+                    done();
+                });
+            });
+
+            it("should snap to atomic boundary when selection ends in bubble node", function (done) {
+                exprEditor.setValue("1 + #form/text + 2", function () {
+                    const paragraph = exprInput[0].querySelector('p');
+                    const firstText = paragraph.firstChild;
+                    // bubbleText is 'text' node in <span><i>&nbsp;</i>text</span>
+                    const bubbleText = paragraph.childNodes[1].childNodes[1];
+                    // Simulate post-extension state: focus lies between leading ZWSP and bubble
+                    // (e.g., after a Ctrl+Shift+ArrowRight word jump).
+                    exprInput[0].focus();
+                    const sel = window.getSelection();
+                    sel.setBaseAndExtent(firstText, 0, bubbleText, 0);
+                    assert.equal(escape(sel.toString()), "1 + {ZWSP}", "precondition failed");
+
+                    exprInput[0].dispatchEvent(new KeyboardEvent('keyup', {
+                        key: 'ArrowRight',
+                        shiftKey: true,
+                        ctrlKey: true,
+                        bubbles: true,
+                    }));
+
+                    const selection = window.getSelection();
+                    assert.equal(escape(selection.toString()), "1 + {ZWSP} text{ZWSP}", "unexpected selection");
+                    assert.equal(escape(selection.focusNode), "{ZWSP} + 2", "unexpected focus");
+                    done();
+                });
+            });
+
+            it("should snap to atomic boundary when (reverse) selection ends in bubble node", function (done) {
+                exprEditor.setValue("1 + #form/text + 2", function () {
+                    const paragraph = exprInput[0].querySelector('p');
+                    const trailingText = paragraph.childNodes[2];
+                    // Simulate post-extension state: focus lies between bubble and trailing ZWSP.
+                    exprInput[0].focus();
+                    const sel = window.getSelection();
+                    sel.setBaseAndExtent(trailingText, trailingText.nodeValue.length, trailingText, 0);
+                    assert.equal(escape(sel.toString()), "{ZWSP} + 2", "precondition failed");
+
+                    exprInput[0].dispatchEvent(new KeyboardEvent('keyup', {
+                        key: 'ArrowLeft',
+                        shiftKey: true,
+                        ctrlKey: true,
+                        bubbles: true,
+                    }));
+
+                    const selection = window.getSelection();
+                    assert.equal(escape(selection.toString()), "{ZWSP} text{ZWSP} + 2", "unexpected selection");
+                    assert.equal(escape(selection.focusNode), "1 + {ZWSP}", "unexpected focus");
+                    done();
+                });
+            });
         });
     });
 

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -90,14 +90,18 @@ const ZWSP = "\u200B";
 /**
  * Escape zero-width spaces and normalize non-breaking spaces in string
  *
+ * If the passed value is a DOM node, it is converted to text.
  * Convert non-breaking space (\u00A0) to normal space to resolve
  * selection.toString() difference between Chrome and Firefox.
  *
- * @param {String} str - String to be escaped.
+ * @param {String or Node} val - String or DOM node to be escaped.
  * @returns String with visible {ZWSP} and NBSP normalized to space
  */
-function escape(str) {
-    return str.replace(/\u200B/g, '{ZWSP}').replace(/\u00A0/g, ' ');
+function escape(val) {
+    if (val?.nodeType) {
+        val = val.textContent;
+    }
+    return val.replace(/\u200B/g, '{ZWSP}').replace(/\u00A0/g, ' ');
 }
 
 function icon(iconClass) {
@@ -754,6 +758,46 @@ describe("The rich text editor", function () {
                         assert.equal(exprInput[0].querySelectorAll('.label-datanode').length, 1);
                         done();
                     });
+                });
+            });
+
+            it("should extend selection past bubble on shift+click", function (done) {
+                exprEditor.setValue("1 + #form/text + 2", function () {
+                    const firstText = exprInput[0].querySelector('p').firstChild;
+                    window.getSelection().setBaseAndExtent(firstText, 0, firstText, 0);
+
+                    const bubble = exprInput[0].querySelector('.label-datanode');
+                    bubble.dispatchEvent(new MouseEvent('mousedown', {
+                        bubbles: true,
+                        shiftKey: true,
+                    }));
+
+                    const selection = window.getSelection();
+                    assert.equal(escape(selection.toString()), "1 + {ZWSP} text{ZWSP}", "unexpected selection");
+                    assert.equal(escape(selection.focusNode), "{ZWSP} + 2", "unexpected focus");
+                    done();
+                });
+            });
+
+            it("should extend selection backward past bubble on shift+click", function (done) {
+                exprEditor.setValue("1 + #form/text + 2", function () {
+                    const paragraph = exprInput[0].querySelector('p');
+                    const trailingText = paragraph.childNodes[2];
+                    // Anchor just past the bubble's trailing ZWSP, selection extends to end.
+                    window.getSelection().setBaseAndExtent(
+                        trailingText, 3, trailingText, trailingText.nodeValue.length
+                    );
+
+                    const bubble = exprInput[0].querySelector('.label-datanode');
+                    bubble.dispatchEvent(new MouseEvent('mousedown', {
+                        bubbles: true,
+                        shiftKey: true,
+                    }));
+
+                    const selection = window.getSelection();
+                    assert.equal(escape(selection.toString()), "{ZWSP} text{ZWSP} +", "unexpected selection");
+                    assert.equal(escape(selection.focusNode), "1 + {ZWSP}", "unexpected focus");
+                    done();
                 });
             });
         });

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -87,6 +87,19 @@ var assert = chai.assert,
     }];
 const ZWSP = "\u200B";
 
+/**
+ * Escape zero-width spaces and normalize non-breaking spaces in string
+ *
+ * Convert non-breaking space (\u00A0) to normal space to resolve
+ * selection.toString() difference between Chrome and Firefox.
+ *
+ * @param {String} str - String to be escaped.
+ * @returns String with visible {ZWSP} and NBSP normalized to space
+ */
+function escape(str) {
+    return str.replace(/\u200B/g, '{ZWSP}').replace(/\u00A0/g, ' ');
+}
+
 function icon(iconClass) {
     if (iconClass.startsWith("fa-")) {
         return $('<i>').addClass(iconClass).html('&nbsp;');
@@ -649,6 +662,26 @@ describe("The rich text editor", function () {
                 assert.equal(removeSpanId(text), "<p>" + expected2 + "</p>");
             });
         }));
+
+        describe("bubble selection", function () {
+
+            it("should select bubble atom on mousedown", function (done) {
+                exprEditor.setValue("#form/text", function () {
+                    const bubble = exprInput[0].querySelector('.label-datanode');
+                    bubble.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
+
+                    const selection = window.getSelection();
+                    assert.equal(selection.rangeCount, 1, "selection range count");
+                    const range = selection.getRangeAt(0);
+                    assert.equal(
+                        escape(range.toString()),
+                        escape(`${ZWSP} text${ZWSP}`),
+                        "selection covers leading ZWSP, bubble text, trailing ZWSP"
+                    );
+                    done();
+                });
+            });
+        });
     });
 
     describe("in vellum", function() {

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -133,7 +133,6 @@ function outputValueTemplateFn(path) {
 }
 
 function wrapWithDiv(el) { return $('<div>').append(el); }
-function wrapWithDivP(el) { return wrapWithDiv($('<p>').append(el)); }
 function wrapWithDivPZwsp(el) { return wrapWithDiv($('<p>').text(ZWSP).append(el).append(ZWSP)); }
 function html(value) { return wrapWithDiv(value).html(); }
 
@@ -185,7 +184,7 @@ describe("Rich text utilities", function() {
         _.each(simpleConversions, function(val) {
             it("from text to html: " + val[0], function() {
                 const richTextText = richText.toRichText(val[0], form, opts);
-                const expectedHtml = wrapWithDivP(makeBubble(val[0], val[1], val[2], val[3], getSpanId(richTextText))).html();
+                const expectedHtml = wrapWithDivPZwsp(makeBubble(val[0], val[1], val[2], val[3], getSpanId(richTextText))).html();
                 assert.strictEqual(richTextText, expectedHtml);
             });
 
@@ -239,21 +238,22 @@ describe("Rich text utilities", function() {
         var f_1065 = "#case/f_1065",
             ico = icon('fcc-fd-text'),
             opts = {isExpression: true},
+            wrap = function (bubble) { return ZWSP + html(bubble) + ZWSP; },
             equations = [
                 [
                     "#form/text = #form/othertext",
-                    html(makeBubble('#form/text', 'text', ico, true)) + " = " +
-                    html(makeBubble('#form/othertext', 'othertext', ico, true))
+                    wrap(makeBubble('#form/text', 'text', ico, true)) + " = " +
+                    wrap(makeBubble('#form/othertext', 'othertext', ico, true))
                 ],
                 [
                     "#form/text <= #form/othertext",
-                    html(makeBubble('#form/text', 'text', ico, true)) + " <= " +
-                    html(makeBubble('#form/othertext', 'othertext', ico, true))
+                    wrap(makeBubble('#form/text', 'text', ico, true)) + " <= " +
+                    wrap(makeBubble('#form/othertext', 'othertext', ico, true))
                 ],
                 [
                     f_1065 + " = " + f_1065,
-                    html(makeBubble(f_1065, 'f_1065', icon('fcc-fd-case-property'), "case")) + " = " +
-                    html(makeBubble(f_1065, 'f_1065', icon('fcc-fd-case-property'), "case"))
+                    wrap(makeBubble(f_1065, 'f_1065', icon('fcc-fd-case-property'), "case")) + " = " +
+                    wrap(makeBubble(f_1065, 'f_1065', icon('fcc-fd-case-property'), "case"))
                 ],
             ];
 
@@ -598,9 +598,9 @@ describe("The rich text editor", function () {
                     input_[0].dispatchEvent(clipboardEvent);
 
                     const text = removeZWSP(removeSpanId(input_[0].innerHTML));
-                    const expText = removeSpanId(richText
+                    const expText = removeZWSP(removeSpanId(richText
                         .toRichText(initialExpr, form, opts)
-                        .replace(find, escapeHTML(pasteText)));
+                        .replace(find, escapeHTML(pasteText))));
                     assert.equal(text, expText);
                     assert.equal(editor.getValue(),
                         initialExpr.substring(0, selStart) + pasteText +
@@ -654,7 +654,7 @@ describe("The rich text editor", function () {
             it("should make bubbles on converting to rich text: " + repr, function () {
                 var text = richText.toRichText(result, form, {isExpression: true}),
                     bubble = makeBubble('#form/text', 'text', icon('fcc-fd-text'), true),
-                    expected = (expr.slice(0, i) + html(bubble) + " " + expr.slice(i)),
+                    expected = (expr.slice(0, i) + ZWSP + html(bubble) + ZWSP + " " + expr.slice(i)),
                     expected2 = expected
                         .replace(/  $/, "")  // HACK for "one =  "
                         .replace(/  /g, " &nbsp;")
@@ -693,6 +693,20 @@ describe("The rich text editor", function () {
                     window.getSelection().setBaseAndExtent(tail, 0, tail, 0);
                     document.dispatchEvent(new Event('selectionchange'));
                     assert.isFalse(bubble.classList.contains('selected'), "unmarked when selection moves away");
+                    done();
+                });
+            });
+
+            it("should not orphan a neighbor bubble when an adjacent bubble is deleted", function (done) {
+                exprEditor.setValue("#invalid/xpath `#form/text``#form/othertext`", function () {
+                    const before = exprInput[0].querySelectorAll('.label-datanode');
+                    assert.equal(before.length, 2, "precondition: two bubbles");
+                    const [first] = before;
+                    first.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
+                    window.getSelection().getRangeAt(0).deleteContents();
+                    exprInput[0].dispatchEvent(new Event('input', {bubbles: true}));
+                    const after = exprInput[0].querySelectorAll('.label-datanode');
+                    assert.equal(after.length, 1, "only the clicked bubble is removed");
                     done();
                 });
             });

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -85,6 +85,7 @@ var assert = chai.assert,
             },
         }],
     }];
+const ZWSP = "\u200B";
 
 function icon(iconClass) {
     if (iconClass.startsWith("fa-")) {
@@ -120,7 +121,7 @@ function outputValueTemplateFn(path) {
 
 function wrapWithDiv(el) { return $('<div>').append(el); }
 function wrapWithDivP(el) { return wrapWithDiv($('<p>').append(el)); }
-function wrapWithDivPZwsp(el) { return wrapWithDiv($('<p>').text('\u200b').append(el).append('\u200b')); }
+function wrapWithDivPZwsp(el) { return wrapWithDiv($('<p>').text(ZWSP).append(el).append(ZWSP)); }
 function html(value) { return wrapWithDiv(value).html(); }
 
 function setupGlobalForm(done) {
@@ -708,7 +709,7 @@ describe("The rich text editor", function () {
                 assert.exists(range);
                 assert.isTrue(range.collapsed);
                 assert.strictEqual(range.startContainer, range.startContainer.parentNode.lastChild);
-                assert.strictEqual(range.startContainer.textContent, "\u200B");
+                assert.strictEqual(range.startContainer.textContent, ZWSP);
             });
 
 

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -114,7 +114,7 @@ function icon(iconClass) {
 function externalIcon () { return icon('fcc-fd-case-property'); }
 function externalUnknownIcon () { return icon('fa-solid fa-triangle-exclamation'); }
 
-function makeBubble(xpath, dispValue, icon, internal, id) {
+function makeBubble(xpath, dispValue, icon, internal, id, attrs) {
     var span = $('<span>').addClass('label label-datanode').attr({
         'data-value': xpath,
         'contenteditable': false,
@@ -130,14 +130,17 @@ function makeBubble(xpath, dispValue, icon, internal, id) {
     } else {
         span.addClass('label-datanode-unknown');
     }
-    return span.append(icon).append(dispValue);
+    if (attrs) {
+        span.attr(attrs);
+    }
+    return ZWSP + html(span.append(icon).append(dispValue)) + ZWSP;
 }
 function outputValueTemplateFn(path) {
     return '<output value="' + path + '"></output>';
 }
 
 function wrapWithDiv(el) { return $('<div>').append(el); }
-function wrapWithDivPZwsp(el) { return wrapWithDiv($('<p>').text(ZWSP).append(el).append(ZWSP)); }
+function wrapWithDivP(el) { return wrapWithDiv($('<p>').append(el)); }
 function html(value) { return wrapWithDiv(value).html(); }
 
 function setupGlobalForm(done) {
@@ -188,13 +191,13 @@ describe("Rich text utilities", function() {
         _.each(simpleConversions, function(val) {
             it("from text to html: " + val[0], function() {
                 const richTextText = richText.toRichText(val[0], form, opts);
-                const expectedHtml = wrapWithDivPZwsp(makeBubble(val[0], val[1], val[2], val[3], getSpanId(richTextText))).html();
+                const expectedHtml = wrapWithDivP(makeBubble(val[0], val[1], val[2], val[3], getSpanId(richTextText))).html();
                 assert.strictEqual(richTextText, expectedHtml);
             });
 
             it("from text to html with output value: " + val[0], function() {
                 const richTextText = richText.toRichText(outputValueTemplateFn(val[0]), form);
-                const expectedHtml = wrapWithDivPZwsp(makeBubble(val[0], val[1], val[2], val[3], getSpanId(richTextText))).html();
+                const expectedHtml = wrapWithDivP(makeBubble(val[0], val[1], val[2], val[3], getSpanId(richTextText))).html();
                 assert.strictEqual(richTextText, expectedHtml);
             });
         });
@@ -219,13 +222,14 @@ describe("Rich text utilities", function() {
                 const richTextText = richText.toRichText(outputValueTemplateFn(val.xmlValue), form);
                 assert.equal(
                     richTextText,
-                    wrapWithDivPZwsp(makeBubble(
+                    wrapWithDivP(makeBubble(
                         val.valueInBubble,
                         val.bubbleDispValue,
                         val.icon,
                         val.internalRef,
-                        getSpanId(richTextText)
-                    ).attr(val.extraAttrs)).html()
+                        getSpanId(richTextText),
+                        val.extraAttrs,
+                    )).html()
                 );
             });
         });
@@ -242,22 +246,21 @@ describe("Rich text utilities", function() {
         var f_1065 = "#case/f_1065",
             ico = icon('fcc-fd-text'),
             opts = {isExpression: true},
-            wrap = function (bubble) { return ZWSP + html(bubble) + ZWSP; },
             equations = [
                 [
                     "#form/text = #form/othertext",
-                    wrap(makeBubble('#form/text', 'text', ico, true)) + " = " +
-                    wrap(makeBubble('#form/othertext', 'othertext', ico, true))
+                    makeBubble('#form/text', 'text', ico, true) + " = " +
+                    makeBubble('#form/othertext', 'othertext', ico, true)
                 ],
                 [
                     "#form/text <= #form/othertext",
-                    wrap(makeBubble('#form/text', 'text', ico, true)) + " <= " +
-                    wrap(makeBubble('#form/othertext', 'othertext', ico, true))
+                    makeBubble('#form/text', 'text', ico, true) + " <= " +
+                    makeBubble('#form/othertext', 'othertext', ico, true)
                 ],
                 [
                     f_1065 + " = " + f_1065,
-                    wrap(makeBubble(f_1065, 'f_1065', icon('fcc-fd-case-property'), "case")) + " = " +
-                    wrap(makeBubble(f_1065, 'f_1065', icon('fcc-fd-case-property'), "case"))
+                    makeBubble(f_1065, 'f_1065', icon('fcc-fd-case-property'), "case") + " = " +
+                    makeBubble(f_1065, 'f_1065', icon('fcc-fd-case-property'), "case")
                 ],
             ];
 
@@ -356,9 +359,9 @@ describe("Rich text utilities", function() {
     describe("convert value with output and escaped HTML", function () {
         var items = [
                 ['<h1><output value="#form/text" /></h1>',
-                 '&lt;h1&gt;​{text}​&lt;/h1&gt;'], // string contains zero width spaces
+                 '&lt;h1&gt;{text}&lt;/h1&gt;'],
                 ['<output value="#form/text" /> <tag /> <output value="#form/othertext" />',
-                 '​{text}​ &lt;tag /&gt; ​{othertext}​'], // string contains zero width spaces
+                 '{text} &lt;tag /&gt; {othertext}'],
                 ["{blah}", "{blah}"],
                 ['<output value="unknown(#form/text)" />', '&lt;output value="unknown(#form/text)" /&gt;'],
                 ['<output value="#form/text + now()" />', '&lt;output value="#form/text + now()" /&gt;'],
@@ -374,12 +377,11 @@ describe("Rich text utilities", function() {
                 var result = removeSpanId(richText.bubbleOutputs(item[0], form, true)),
                     expect = item[1].replace(/{(.*?)}/g, function (m, name) {
                         if (form.getIconByPath("#form/" + name)) {
-                            var output = makeBubble("#form/" + name, name, ico, true);
-                            return output[0].outerHTML;
+                            return makeBubble("#form/" + name, name, ico, true);
                         }
                         return m;
                     });
-                assert.equal(result, expect);
+                assert.equal(escape(result), escape(expect));
             });
         });
     });
@@ -655,7 +657,7 @@ describe("The rich text editor", function () {
             it("should make bubbles on converting to rich text: " + repr, function () {
                 var text = richText.toRichText(result, form, {isExpression: true}),
                     bubble = makeBubble('#form/text', 'text', icon('fcc-fd-text'), true),
-                    expected = (expr.slice(0, i) + ZWSP + html(bubble) + ZWSP + " " + expr.slice(i)),
+                    expected = (expr.slice(0, i) + bubble + " " + expr.slice(i)),
                     expected2 = expected
                         .replace(/  $/, "")  // HACK for "one =  "
                         .replace(/  /g, " &nbsp;")

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -681,6 +681,21 @@ describe("The rich text editor", function () {
                     done();
                 });
             });
+
+            it("should mark a bubble as selected while the selection covers it", function (done) {
+                exprEditor.setValue("#form/text", function () {
+                    const bubble = exprInput[0].querySelector('.label-datanode');
+                    bubble.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
+                    document.dispatchEvent(new Event('selectionchange'));
+                    assert.isTrue(bubble.classList.contains('selected'), "marked on click");
+
+                    const tail = exprInput[0].lastChild;
+                    window.getSelection().setBaseAndExtent(tail, 0, tail, 0);
+                    document.dispatchEvent(new Event('selectionchange'));
+                    assert.isFalse(bubble.classList.contains('selected'), "unmarked when selection moves away");
+                    done();
+                });
+            });
         });
     });
 

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -517,7 +517,7 @@ describe("The rich text editor", function () {
             assert.equal(editor.getValue(), 'A');
         });
 
-        function assertCopy($editor, value, callback) {
+        function assertCopy($editor, value) {
             const dataTransfer = new DataTransfer();
             const clipboardEvent = new ClipboardEvent('copy', {
                 clipboardData: dataTransfer,
@@ -528,7 +528,6 @@ describe("The rich text editor", function () {
 
             assert.equal(dataTransfer.getData('text/plain'), value);
             assert.strictEqual(dataTransfer.getData("text/html"), '');
-            callback();
         }
 
         var TEST_LABEL = 'Weight: <output value="#form/text" /> grams',
@@ -537,18 +536,16 @@ describe("The rich text editor", function () {
         it("should copy output tag from rich text editor", function (done) {
             editor.setValue(TEST_LABEL, function () {
                 editor.select(6, 4);
-                assertCopy(input, ': <output value="#form/text" />', function () {
-                    done();
-                });
+                assertCopy(input, ': <output value="#form/text" />');
+                done();
             });
         });
 
         it("should copy expression with hashtags from expression editor", function (done) {
             exprEditor.setValue(TEST_XPATH, function () {
                 exprEditor.select(11, 5);
-                assertCopy(exprInput, "+ (#case/dob", function () {
-                    done();
-                });
+                assertCopy(exprInput, "+ (#case/dob");
+                done();
             });
         });
 

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -800,6 +800,56 @@ describe("The rich text editor", function () {
                     done();
                 });
             });
+
+            it("should clean up neighbor bubble whose ZWSP boundary was clipped by cut", function (done) {
+                exprEditor.setValue("#invalid/xpath `#form/text``#form/othertext`", function () {
+                    const bubbles = exprInput[0].querySelectorAll('.label-datanode');
+                    assert.equal(bubbles.length, 2, "precondition: two bubbles");
+                    const [first] = bubbles;
+                    first.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
+                    // Extend the selection to consume both ZWSPs between the bubbles,
+                    // clipping the second bubble's leading ZWSP.
+                    window.getSelection().getRangeAt(0).setEnd(first.nextSibling, 2);
+
+                    const dataTransfer = new DataTransfer();
+                    exprInput[0].dispatchEvent(new ClipboardEvent('cut', {
+                        clipboardData: dataTransfer,
+                        bubbles: true,
+                        cancelable: true,
+                    }));
+                    assert.equal(dataTransfer.getData('text/plain'), "#form/text#form/othertext");
+
+                    assert.equal(
+                        exprInput[0].querySelectorAll('.label-datanode').length, 0,
+                        "the neighbor with broken ZWSP boundary is also removed"
+                    );
+                    done();
+                });
+            });
+
+            it("should clean up neighbor bubble whose ZWSP boundary was clipped by paste", function (done) {
+                exprEditor.setValue("#invalid/xpath `#form/text``#form/othertext`", function () {
+                    const bubbles = exprInput[0].querySelectorAll('.label-datanode');
+                    assert.equal(bubbles.length, 2, "precondition: two bubbles");
+                    const [first] = bubbles;
+                    first.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
+                    window.getSelection().getRangeAt(0).setEnd(first.nextSibling, 2);
+
+                    const dataTransfer = new DataTransfer();
+                    dataTransfer.setData('text/plain', 'X');
+                    exprInput[0].dispatchEvent(new ClipboardEvent('paste', {
+                        clipboardData: dataTransfer,
+                        bubbles: true,
+                        cancelable: true,
+                    }));
+
+                    assert.equal(
+                        exprInput[0].querySelectorAll('.label-datanode').length, 0,
+                        "the neighbor with broken ZWSP boundary is also removed"
+                    );
+                    done();
+                });
+            });
         });
     });
 

--- a/tests/richText.js
+++ b/tests/richText.js
@@ -707,6 +707,55 @@ describe("The rich text editor", function () {
                     done();
                 });
             });
+
+            it("should copy a selected bubble as its hashtag", function (done) {
+                exprEditor.setValue("1 + #form/text + 2", function () {
+                    const bubble = exprInput[0].querySelector('.label-datanode');
+                    bubble.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
+                    assertCopy(exprInput, "#form/text");
+                    done();
+                });
+            });
+
+            it("should cut a selected bubble leaving no orphan ZWSP", function (done) {
+                exprEditor.setValue("1 + #form/text + 2", function () {
+                    const bubble = exprInput[0].querySelector('.label-datanode');
+                    bubble.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
+
+                    const dataTransfer = new DataTransfer();
+                    exprInput[0].dispatchEvent(new ClipboardEvent('cut', {
+                        clipboardData: dataTransfer,
+                        bubbles: true,
+                        cancelable: true,
+                    }));
+
+                    assert.equal(dataTransfer.getData('text/plain'), "#form/text");
+                    assert.equal(exprEditor.getValue(), "1 +  + 2");
+                    done();
+                });
+            });
+
+            it("should paste a copied bubble", function (done) {
+                exprEditor.setValue("1 + #form/old + 2", function () {
+                    const bubble = exprInput[0].querySelector('.label-datanode');
+                    bubble.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
+
+                    const dataTransfer = new DataTransfer();
+                    dataTransfer.setData('text/plain', '#form/new');
+                    exprInput[0].dispatchEvent(new ClipboardEvent('paste', {
+                        clipboardData: dataTransfer,
+                        bubbles: true,
+                        cancelable: true,
+                    }));
+                    assert.equal(exprEditor.getValue(), '1 + #form/new + 2');
+
+                    // get -> set (reload) to convert hashtag to bubble
+                    exprEditor.setValue(exprEditor.getValue(), function () {
+                        assert.equal(exprInput[0].querySelectorAll('.label-datanode').length, 1);
+                        done();
+                    });
+                });
+            });
         });
     });
 


### PR DESCRIPTION
## Product Description

Improves how reference bubbles behave inside rich text inputs:

- Clicking a bubble now selects it as a single atomic unit and visibly highlights it (darker background, white text), matching the existing hover treatment.
- Shift-clicking past a bubble extends the selection through the bubble cleanly instead of snapping mid-bubble.
- Cut, copy, and paste of selections containing bubbles now produce the expected output and leave the editor in a valid state.
- Two adjacent bubbles no longer cause one to disappear when the other is edited or removed.

https://dimagi.atlassian.net/browse/SAAS-19367

A video demo of _before_ behavior is in the [ticket](https://dimagi.atlassian.net/browse/SAAS-19367
). Below is an _after_ video demo:

https://github.com/user-attachments/assets/351c55fb-9c51-47d9-bd20-d9d94aa46f76

This PR was written with the help of Claude Code.

## Technical Summary

- Centralize zero-width-space (ZWSP) boundary wrapping in `makeBubble` so every bubble owns its own leading and trailing ZWSP. Previously, `outputToBubble` and `bubbleExpression` produced inconsistent markup and adjacent bubbles in expression mode shared a single ZWSP, which let atomic edits on one bubble strip the neighbor's boundary and trigger collateral removal.
- Add a `mousedown` handler on `.label-datanode` bubbles that focuses the input and calls `setBaseAndExtent` across `ZWSP<span>…</span>ZWSP`. A transient `bubbleClickInProgress` flag suppresses the focus handler's "move caret to end" behavior during the click.
- Add a `selectionchange` listener that iterates all ranges and toggles a `.selected` class on intersected bubbles; the listener is detached in `destroy`. Styles added to suppresses the OS selection overlay so it doesn't compete with the class-based fill.
- Snap selection focus to the nearest bubble boundary and preserve the ZWSP invariant across cut/paste so the editor's input handler doesn't see broken boundaries.
- Simplify ZWSP cleanup now that boundaries are owned per-bubble: the "only trailing ZWSP left" branch and the "except last in editor" guard are removed in favor of a single rule — if a boundary is broken, strip remaining boundary chars and remove the span.
- Minor refactors: `insertHtmlWithSpace` → `insertHtmlWithSuffix`, consistent argument order with `form` last, removal of a superfluous `assertCopy` callback, and a `ZWSP` constant.

## Safety Assurance

### Safety story

Changes are scoped to the rich text editor's bubble handling. The ZWSP-wrapping refactor is the highest-risk piece because it changes the DOM shape produced by `makeBubble`; existing expression-mode tests were updated to reflect the now-consistent wrapping, and the simplified cleanup rule is a strict subset of the previous defensive branches. Manual testing covered click-to-select, shift-click extension, keyboard selection across bubble boundaries, cut/copy/paste of single and adjacent bubbles, and deletion of one of two adjacent bubbles.

### Automated test coverage

New tests in `tests/richText.js` cover:

- Copy, cut, and paste of selections that include bubbles (the paste test reproduces the original bug report).
- Selecting a bubble by click and the resulting `.selected` class.
- Shift-click extending selection past a bubble.
- Selection focus snapping to bubble boundaries.

Existing expression-mode tests were updated to expect the now-consistent ZWSP wrapping in `toRichText` output.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations
