### PR TITLE
Refine task processing

### DIFF
--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -281,6 +281,7 @@ let mugConfigs = {
         childNodes: [
             {id: "name", writeToData: true},
             {id: "description", writeToData: true},
+            {id: "task_slug"},
         ],
         mugOptions: util.extend(baseMugOptions, {
             typeName: 'Task',
@@ -288,6 +289,7 @@ let mugConfigs = {
             init: mug => {
                 mug.p.name = "";
                 mug.p.description = "";
+                mug.p.task_slug = "";
             },
             spec: util.extend(baseSpec, {
                 nodeID: {
@@ -304,6 +306,15 @@ let mugConfigs = {
                     visibility: 'visible',
                     presence: 'required',
                     widget: widgets.richTextarea,
+                },
+                task_slug: {
+                    lstring: gettext("Task Slug"),
+                    visibility: 'visible',
+                    presence: 'required',
+                    widget: widgets.xPath,
+                    serialize: mugs.serializeXPath,
+                    deserialize: mugs.deserializeXPath,
+                    help: gettext('XPath expression for the task slug identifier.'),
                 }
             })
         }),
@@ -313,6 +324,7 @@ let mugConfigs = {
                     "nodeID",
                     "name",
                     "description",
+                    "task_slug",
                 ],
             }),
             _.clone(logicSection),

--- a/src/commcareConnect.js
+++ b/src/commcareConnect.js
@@ -279,33 +279,17 @@ let mugConfigs = {
     ConnectTask: {
         rootName: "task",
         childNodes: [
-            {id: "name", writeToData: true},
-            {id: "description", writeToData: true},
             {id: "task_slug"},
         ],
         mugOptions: util.extend(baseMugOptions, {
             typeName: 'Task',
             icon: 'fa fa-tasks',
             init: mug => {
-                mug.p.name = "";
-                mug.p.description = "";
                 mug.p.task_slug = "";
             },
             spec: util.extend(baseSpec, {
                 nodeID: {
                     lstring: gettext('Task ID'),
-                },
-                name: {
-                    lstring: gettext("Name"),
-                    visibility: 'visible',
-                    presence: 'required',
-                    widget: widgets.text,
-                },
-                description: {
-                    lstring: gettext("Description"),
-                    visibility: 'visible',
-                    presence: 'required',
-                    widget: widgets.richTextarea,
                 },
                 task_slug: {
                     lstring: gettext("Task Slug"),
@@ -322,8 +306,6 @@ let mugConfigs = {
             _.extend({}, baseSection, {
                 properties: [
                     "nodeID",
-                    "name",
-                    "description",
                     "task_slug",
                 ],
             }),

--- a/tests/commcareConnect.js
+++ b/tests/commcareConnect.js
@@ -80,8 +80,6 @@ describe("The CommCareConnect", function() {
             util.loadXML(TASK_XML);
             var task = util.getMug("task_1");
             assert.equal(task.__className, "ConnectTask");
-            assert.equal(task.p.name, "task 1");
-            assert.equal(task.p.description, "Task 1 is fun\nLearning is still fun");
             assert.equal(task.p.task_slug, "instance('commcaresession')/session/data/task_slug");
             assert.equal(task.p.relevantAttr, "x = 3");
             util.assertXmlEqual(call("createXML"), TASK_XML);

--- a/tests/commcareConnect.js
+++ b/tests/commcareConnect.js
@@ -82,6 +82,7 @@ describe("The CommCareConnect", function() {
             assert.equal(task.__className, "ConnectTask");
             assert.equal(task.p.name, "task 1");
             assert.equal(task.p.description, "Task 1 is fun\nLearning is still fun");
+            assert.equal(task.p.task_slug, "instance('commcaresession')/session/data/task_slug");
             assert.equal(task.p.relevantAttr, "x = 3");
             util.assertXmlEqual(call("createXML"), TASK_XML);
         });

--- a/tests/static/commcareConnect/task_module.xml
+++ b/tests/static/commcareConnect/task_module.xml
@@ -10,12 +10,15 @@
 						<task xmlns="http://commcareconnect.com/data/v1/learn" id="task_1">
 							<name>task 1</name>
 							<description>Task 1 is fun&#10;Learning is still fun</description>
+							<task_slug/>
 						</task>
 					</task_1>
 				</data>
 			</instance>
+			<instance src="jr://instance/session" id="commcaresession" />
 			<bind vellum:nodeset="#form/name" nodeset="/data/name" type="xsd:string" />
 			<bind vellum:nodeset="#form/task_1" nodeset="/data/task_1" relevant="x = 3" />
+			<bind nodeset="/data/task_1/task/task_slug" calculate="instance('commcaresession')/session/data/task_slug" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="name-label">

--- a/tests/static/commcareConnect/task_module.xml
+++ b/tests/static/commcareConnect/task_module.xml
@@ -8,8 +8,6 @@
 					<name />
 					<task_1 vellum:role="ConnectTask">
 						<task xmlns="http://commcareconnect.com/data/v1/learn" id="task_1">
-							<name>task 1</name>
-							<description>Task 1 is fun&#10;Learning is still fun</description>
 							<task_slug/>
 						</task>
 					</task_1>


### PR DESCRIPTION
## Product Description
<!-- Where applicable, describe user-facing effects and include screenshots. -->
For connect plugin, refine ConnectTask by allowing to set a task slug dynamically and removing the redundant fields for name and description which are actually entered on Connect and not HQ.

## Technical Summary
<!--
    Provide a link to any tickets, design documents, and/or technical specifications
    associated with this change. Describe the rationale and design decisions.
-->
Was originally looking at an issue that task node was not present on the form submitted. While resolving that realized that the ConnectTask setup needed to allow passing the task slug dynamically instead of setting it as the node ID.
So, added that separate field which also resolved the original concern of task node not being present in the xml (details in the commit message).
Additionally removed the redundant fields.

## Feature Flag
<!-- If this is specific to a feature flag, which one? -->
`COMMCARE_CONNECT`

## Safety Assurance

### Safety story
<!--
Describe how you became confident in this change, such as
local testing, why the change is inherently safe, and/or plans to limit the blast radius of a defect.

In particular consider how existing data may be impacted by this change.
-->
Testing on staging.

### Automated test coverage

<!-- Identify the related test coverage and the tests it would catch -->

### QA Plan

<!--
- Describe QA plan that along with automated test coverages proves this PR is regression free
- Link to QA Ticket
-->


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [X] Risk label is set correctly
- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change
