### PR TITLE
Locked questions: bugfixes and QA-raised issues

### DIFF
--- a/src/caseManagement.js
+++ b/src/caseManagement.js
@@ -419,8 +419,7 @@ function autoAssignName(vellum) {
     vellum.ensureCurrentMugIsSaved(() => {
         const form = vellum.data.core.form;
         let mug = form.findFirstMatchingChild(null, () => true);
-        if (!mug || mug.p.caseProperty || !mug.spec.caseProperty ||
-                mug.getPresence("caseProperty") !== 'optional') {
+        if (!canAddCaseName(mug)) {
             mug = vellum.addQuestion('DataBindOnly', 'first');
             mug.p.nodeID = form.generate_question_id('case-name');
             mug.p.calculateAttr = 'uuid()';
@@ -430,6 +429,14 @@ function autoAssignName(vellum) {
         vellum.data.core.saveButton.fire('change');
         vellum.setCurrentMug(mug);
     });
+}
+
+function canAddCaseName(mug) {
+    if (!mug) {
+        return false;
+    }
+    const canSetCaseProperty = mug.spec.caseProperty && mug.getPresence("caseProperty") === 'optional';
+    return canSetCaseProperty && !mug.p.caseProperty && !mug.form.vellum.isPropertyLocked(mug, "caseProperty");
 }
 
 function refreshCurrentMug(vellum) {

--- a/src/core.js
+++ b/src/core.js
@@ -1119,14 +1119,21 @@ fn._createJSTree = function () {
  * drag begins.
  */
 $(document).one("dnd_move.vakata.jstree", function (e, data) {
+    const disableDropForEl = function (el) {
+        return el.getAttribute('disabled') !== null || el.getAttribute('contenteditable') === 'false';
+    };
+
     $(document).on("dnd_move.vakata.jstree", function (e, data) {
-        $('.jstree-drop').addClass('jstree-drop-active');
+        $('.jstree-drop')
+            .not((_, el) => disableDropForEl(el))
+            .addClass('jstree-drop-active');
         var source = $(data.data.obj),
             target = $(data.event.target),
             inst = $.jstree.reference(target);
         if (!inst && target.vellum("get") === source.vellum("get")) {
             // only when not dragging inside the tree
-            if (target.closest('.jstree-drop').length) {
+            const $closest = target.closest('.jstree-drop');
+            if ($closest.length && !disableDropForEl($closest[0])) {
                 data.helper.find('.jstree-icon').removeClass('jstree-er').addClass('jstree-ok');
             } else {
                 data.helper.find('.jstree-icon').removeClass('jstree-ok').addClass('jstree-er');
@@ -1138,7 +1145,12 @@ $(document).one("dnd_move.vakata.jstree", function (e, data) {
             target = $(data.event.target),
             inst = $.jstree.reference(target);
 
-        if (!inst && (target.closest('.jstree-drop').length) && vellum === target.vellum("get")) {
+        const $closest = target.closest('.jstree-drop');
+        if (!inst &&
+            $closest.length &&
+            !disableDropForEl($closest[0]) &&
+            vellum === target.vellum("get")
+        ) {
             if (data.data.origin) {
                 var node = data.data.origin.get_node(data.data.nodes[0]);
                 if (node.data && node.data.handleDrop) {

--- a/src/dataSourceWidgets.js
+++ b/src/dataSourceWidgets.js
@@ -82,7 +82,12 @@ function advancedDataSourceWidget(mug, options, labelText) {
     widget.options.richText = false;
     widget.getUIElement = function () {
         var query = getUIElementWithEditButton(
-                getUIElement(widget.input, labelText),
+                getUIElement(
+                    widget.input,
+                    labelText,
+                    !!widget.isDisabled(),
+                    widget.getHelp(),
+                ),
                 function () {
                     mug.form.vellum.displaySecondaryEditor({
                         source: local_getValue(),
@@ -98,7 +103,8 @@ function advancedDataSourceWidget(mug, options, labelText) {
                             }
                         }
                     });
-                }
+                },
+                !!widget.isDisabled(),
             );
         return $("<div></div>").append(query);
     };

--- a/src/lock.js
+++ b/src/lock.js
@@ -165,8 +165,13 @@ $.vellum.plugin("lock", {}, {
     },
     isPropertyLocked: function (mug, propertyPath) {
         const locked = this.__callOld();
-        if (locked || mug.p.locked) {
+        if (locked) {
             return true;
+        }
+
+        if (mug.p.locked) {
+            // never lock the "Locked" checkbox based on itself
+            return propertyPath !== "locked";
         }
 
         if (propertyPath === 'nodeID' && !this.isMugPathMoveable(mug)) {

--- a/src/lock.js
+++ b/src/lock.js
@@ -178,16 +178,20 @@ $.vellum.plugin("lock", {}, {
             return propertyPath !== "locked";
         }
 
-        if (propertyPath === 'nodeID' && !this.isMugPathMoveable(mug)) {
-            const message = {
-                key: LOCKED_CHILDREN_MSG_KEY,
-                message: gettext(
-                        "This group contains locked questions and cannot be moved or deleted from the form."
-                    ),
-                level: mug.INFO,
-            };
-            mug.addMessage('nodeID', message);
-            return true;
+        if (propertyPath === 'nodeID') {
+            if (!this.isMugPathMoveable(mug)) {
+                const message = {
+                    key: LOCKED_CHILDREN_MSG_KEY,
+                    message: gettext(
+                            "This group contains locked questions and cannot be moved or deleted from the form."
+                        ),
+                    level: mug.INFO,
+                };
+                mug.addMessage('nodeID', message);
+                return true;
+            } else {
+                mug.dropMessage('nodeID', LOCKED_CHILDREN_MSG_KEY);
+            }
         }
         return false;
     },

--- a/src/lock.js
+++ b/src/lock.js
@@ -110,6 +110,10 @@ $.vellum.plugin("lock", {}, {
                 }
             },
             setter: function (mug, attr, value) {
+                if (!isEditable && !mug.form.isLoadingXForm) {
+                    return;
+                }
+
                 if (value === true) {
                     mug.p.rawBindAttributes = mug.p.rawBindAttributes || {};
                     mug.p.rawBindAttributes[LOCKED_BIND_ATTR] = 'all';

--- a/src/lock.js
+++ b/src/lock.js
@@ -102,7 +102,7 @@ $.vellum.plugin("lock", {}, {
             widget: widgets.checkbox,
             enabled: () => isEditable,
             help: gettext("A locked question cannot be edited, moved, or deleted from the form."),
-            helpURL: "https://www.example.com",  // placeholder for public documentation
+            helpURL: "https://dimagi.atlassian.net/wiki/spaces/commcarepublic/pages/3946381318/Locked+Admin+Questions",
             serialize: () => {},
             deserialize: (data, key, mug, context) => {
                 if (mug.p.rawBindAttributes && mug.p.rawBindAttributes[LOCKED_BIND_ATTR]) {

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -280,6 +280,7 @@ var baseKeyValue = function (mug, options) {
     var widget = base(mug, options),
         path = options.widgetValuePath || options.path,
         id = options.id || 'property-' + path;
+    widget.path = path;
     widget.definition = mug.p.getDefinition(options.path);
     options.richText = false;
 
@@ -296,9 +297,6 @@ var baseKeyValue = function (mug, options) {
     widget.kvInput = $('<div class="control-row" />').attr('name', id);
 
     widget.getControl = function () {
-        if (widget.isDisabled()) {
-            // todo
-        }
         return widget.kvInput;
     };
 
@@ -306,6 +304,11 @@ var baseKeyValue = function (mug, options) {
         widget.kvInput.html(widget_control_keyvalue({
             pairs: _.clone(value)
         }));
+        if (widget.isDisabled()) {
+            widget.kvInput.find('input').prop('disabled', true);
+            widget.kvInput.find('.btn').addClass('hide');
+            return;
+        }
         widget.kvInput.find('input').on('change keyup', function () {
             widget.handleChange();
         });

--- a/src/widgets/base.js
+++ b/src/widgets/base.js
@@ -21,8 +21,8 @@ export var base = function(mug, options) {
             return false;
         }
 
-        if (_.isFunction(mug.spec[widget.path].enabled)) {
-            return !mug.spec[widget.path].enabled(mug);
+        if (_.isFunction(mug.spec[widget.path].enabled) && !mug.spec[widget.path].enabled(mug)) {
+            return true;
         }
 
         return mug.form.vellum.isPropertyLocked(mug, widget.path);

--- a/tests/caseManagement.js
+++ b/tests/caseManagement.js
@@ -883,6 +883,30 @@ describe("The Case Management plugin", function () {
             });
         });
 
+        it("new mug when first mug's Case Property is locked", function (done) {
+            util.loadXML("");
+            const mug = util.addQuestion("Text", "first");
+            const vellum = mug.form.vellum;
+            const originalIsPropertyLocked = vellum.isPropertyLocked;
+            vellum.isPropertyLocked = () => true;
+            const save = call("getData").core.saveButton.ui;
+            function test() {
+                save.off('shown.bs.popover.test');
+                try {
+                    $(".fd-auto-assign-case-name").trigger("click");
+                    assert.isUndefined(mug.p.caseProperty, "locked mug should not receive case name");
+                    const name = call("getMugByPath", "/data/case-name");
+                    assert.equal(name.p.nodeID, 'case-name');
+                    assert.equal(name.p.caseProperty, 'name');
+                } finally {
+                    vellum.isPropertyLocked = originalIsPropertyLocked;
+                }
+                done();
+            }
+            save.on('shown.bs.popover.test', test);
+            save.popover("show");
+        });
+
         it("new mug with unique node ID", function (done) {
             util.loadXML("");
             const mug = util.addQuestion("Text", "case-name");

--- a/tests/core.js
+++ b/tests/core.js
@@ -1019,9 +1019,9 @@ describe("Vellum core", function () {
             dropHandler.restore();
         });
 
-        function makeTargetEl(attrs) {
+        function makeTargetEl(attrs, tag = "input") {
             // addClass after attr so .test-drop-target survives any class set via attrs.
-            return $("<input />").attr(attrs || {})
+            return $(`<${tag} />`).attr(attrs || {})
                 .addClass("test-drop-target")
                 .appendTo("#vellum");
         }
@@ -1080,6 +1080,34 @@ describe("Vellum core", function () {
             fireDnd("dnd_stop", $a[0]);
             assert.isFalse($a.hasClass('jstree-drop-active'), "first should be cleared");
             assert.isFalse($b.hasClass('jstree-drop-active'), "second should be cleared");
+        });
+
+        it("rejects a drop on a disabled .jstree-drop target", function () {
+            const $el = makeTargetEl({class: "jstree-drop", disabled: "disabled"});
+            fireDnd("dnd_stop", $el[0]);
+            assert.isFalse(dropHandler.called, "handleDrop should not be called");
+        });
+
+        it("rejects a drop on a contenteditable='false' .jstree-drop target", function () {
+            const $el = makeTargetEl({class: "jstree-drop", contenteditable: "false"}, "div");
+            fireDnd("dnd_stop", $el[0]);
+            assert.isFalse(dropHandler.called, "handleDrop should not be called");
+        });
+
+        it("sets the 'er' icon class on dnd_move over a disabled .jstree-drop target", function () {
+            const $el = makeTargetEl({class: "jstree-drop", disabled: "disabled"});
+            const $icon = fireDnd("dnd_move", $el[0]).helper.find('.jstree-icon');
+            assert($icon.hasClass('jstree-er'), "icon should be jstree-er");
+            assert.isFalse($icon.hasClass('jstree-ok'), "icon should not be jstree-ok");
+        });
+
+        it("does not add jstree-drop-active to a disabled .jstree-drop element", function () {
+            const $enabled = makeTargetEl({class: "jstree-drop"});
+            const $disabled = makeTargetEl({class: "jstree-drop", disabled: "disabled"});
+            fireDnd("dnd_move", $enabled[0]);
+            assert($enabled.hasClass('jstree-drop-active'), "enabled target should be active");
+            assert.isFalse($disabled.hasClass('jstree-drop-active'),
+                "disabled target should not be active");
         });
     });
 });

--- a/tests/core.js
+++ b/tests/core.js
@@ -982,4 +982,104 @@ describe("Vellum core", function () {
             });
         });
     });
+
+    describe("drag and drop outside form tree", function () {
+        let dragSource;
+        
+        const dropHandler = {
+            called: false,
+            init() {
+                this._original = dragSource.node.data.handleDrop;
+                dragSource.node.data.handleDrop = () => { this.called = true; };
+            },
+            reset() { this.called = false; },
+            restore() { dragSource.node.data.handleDrop = this._original; },
+        };
+
+        before(function () {
+            util.loadXML("");
+            util.addQuestion("Text", "dragSource");
+            const tree = $(".fd-question-tree").jstree(true);
+            dragSource = {tree: tree, node: util.findNode(tree, "dragSource")};
+            // Bootstrap the persistent dnd_move/dnd_stop listeners. core.js
+            // registers them lazily via .one("dnd_move.vakata.jstree").
+            fireDnd("dnd_move", makeTargetEl({class: "jstree-drop"})[0]);
+            dropHandler.init();
+        });
+
+        beforeEach(function () {
+            dropHandler.reset();
+        });
+
+        afterEach(function () {
+            $(".test-drop-target").remove();
+        });
+
+        after(function () {
+            dropHandler.restore();
+        });
+
+        function makeTargetEl(attrs) {
+            // addClass after attr so .test-drop-target survives any class set via attrs.
+            return $("<input />").attr(attrs || {})
+                .addClass("test-drop-target")
+                .appendTo("#vellum");
+        }
+
+        function fireDnd(eventName, targetEl) {
+            const data = {
+                data: {
+                    obj: $("#vellum")[0],
+                    origin: dragSource.tree,
+                    nodes: [dragSource.node.id],
+                },
+                event: {target: targetEl, type: "mouseup"},
+                helper: $("<div><i class='jstree-icon'/></div>"),
+            };
+            $(document).trigger(eventName + ".vakata.jstree", [data]);
+            return data;
+        }
+
+        it("accepts a drop on a .jstree-drop target outside the tree", function () {
+            const $el = makeTargetEl({class: "jstree-drop"});
+            fireDnd("dnd_stop", $el[0]);
+            assert(dropHandler.called, "handleDrop should be called");
+        });
+
+        it("rejects a drop on a target outside any .jstree-drop", function () {
+            const $el = makeTargetEl();
+            fireDnd("dnd_stop", $el[0]);
+            assert.isFalse(dropHandler.called, "handleDrop should not be called");
+        });
+
+        it("sets the 'ok' icon class on dnd_move over a .jstree-drop target", function () {
+            const $el = makeTargetEl({class: "jstree-drop"});
+            const $icon = fireDnd("dnd_move", $el[0]).helper.find('.jstree-icon');
+            assert($icon.hasClass('jstree-ok'), "icon should be jstree-ok");
+            assert.isFalse($icon.hasClass('jstree-er'), "icon should not be jstree-er");
+        });
+
+        it("sets the 'er' icon class on dnd_move over a non-.jstree-drop target", function () {
+            const $el = makeTargetEl();
+            const $icon = fireDnd("dnd_move", $el[0]).helper.find('.jstree-icon');
+            assert($icon.hasClass('jstree-er'), "icon should be jstree-er");
+            assert.isFalse($icon.hasClass('jstree-ok'), "icon should not be jstree-ok");
+        });
+
+        it("adds jstree-drop-active to all .jstree-drop elements on dnd_move", function () {
+            const $a = makeTargetEl({class: "jstree-drop"});
+            const $b = makeTargetEl({class: "jstree-drop"});
+            fireDnd("dnd_move", $a[0]);
+            assert($a.hasClass('jstree-drop-active'), "first target should be active");
+            assert($b.hasClass('jstree-drop-active'), "second target should be active");
+        });
+
+        it("removes jstree-drop-active from all .jstree-drop elements on dnd_stop", function () {
+            const $a = makeTargetEl({class: "jstree-drop jstree-drop-active"});
+            const $b = makeTargetEl({class: "jstree-drop jstree-drop-active"});
+            fireDnd("dnd_stop", $a[0]);
+            assert.isFalse($a.hasClass('jstree-drop-active'), "first should be cleared");
+            assert.isFalse($b.hasClass('jstree-drop-active'), "second should be cleared");
+        });
+    });
 });

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -21,6 +21,7 @@ function beforeFn(done) {
     util.init({
         javaRosa: {langs: ['en']},
         plugins: ['lock', 'itemset'],
+        features: {edit_locked_questions: true},
         core: {
             onReady: function () {
                 call('loadXFormOrError', TEST_XML, done);
@@ -403,18 +404,7 @@ describe("The Lock plugin", function() {
 
     describe("edit_locked_questions feature", function () {
         describe("with the feature enabled", function () {
-            before(function (done) {
-                util.init({
-                    javaRosa: {langs: ['en']},
-                    plugins: ['lock'],
-                    features: {edit_locked_questions: true},
-                    core: {
-                        onReady: function () {
-                            call('loadXFormOrError', TEST_XML, done);
-                        }
-                    }
-                });
-            });
+            before(beforeFn);
 
             it("does not add the 'cannot edit' message to locked questions", function () {
                 const mug = getMug('/data/locked');
@@ -444,7 +434,18 @@ describe("The Lock plugin", function() {
         });
 
         describe("without the feature enabled", function () {
-            before(beforeFn);
+            before(function (done) {
+                util.init({
+                    javaRosa: {langs: ['en']},
+                    plugins: ['lock'],
+                    features: {edit_locked_questions: false},
+                    core: {
+                        onReady: function () {
+                            call('loadXFormOrError', TEST_XML, done);
+                        }
+                    }
+                });
+            });
 
             it("adds the 'cannot edit' message to locked questions", function () {
                 const mug = getMug('/data/locked');


### PR DESCRIPTION
## Product Description

A collection of bug fixes for the locked-questions feature, plus a related improvement to the global drag-and-drop behavior:

- Locked Android App Callout questions are now fully read-only — intent extras/responses can't be edited and add/remove buttons are hidden.
- Users without the locked-questions permission can no longer unlock a locked question by tampering with the disabled "Locked" checkbox in DevTools.
- The "This group contains locked questions" message clears once a group no longer contains any locked questions.
- Locked widget inputs (xpath, text, etc.) are no longer valid drop targets — dragging a question from the tree onto a locked input no longer mutates it. The drag helper shows the "error" icon and `jstree-drop-active` highlight is suppressed on disabled drop targets.
- Locked questions are skipped by the auto-case-name flow so it doesn't silently target a question the user can't edit.

## Technical Summary

Vellum side of https://dimagi.atlassian.net/browse/SAAS-19552

Notable changes:
- `src/core.js`: global drag and drop handler now consults `disableDropForEl` (checks `disabled` attribute and `contenteditable='false'`) before treating a `.jstree-drop` element as a valid drop target.
- `src/lock.js`: 
  - Setter for the `locked` property refuses to mutate when the user lacks `edit_locked_questions` permission (after XML load completes). 
  - Clears the `mug-has-locked-children` `nodeID` message on ancestor groups when their last locked descendant becomes unlocked.
  - The "Locked" checkbox itself is excluded from `isPropertyLocked` so it does not inadvertently lock itself.
- `src/widgets.js`: `baseKeyValue` sets `widget.path` so `isDisabled()` resolves through the existing lock check, and `setValue` now disables row inputs and hides add/remove buttons when the widget is disabled.
- `src/widgets/base.js`: a property with a custom `enabled` callback no longer overrides `isPropertyLocked` — locked wins.
- `src/dataSourceWidgets.js`: passes `isDisabled` through both `getUIElement` and `getUIElementWithEditButton`.
- `src/caseManagement.js`: auto-assigned case name now skips locked questions via a new `canAddCaseName` helper that consults `isPropertyLocked`.

## Feature Flag
In HQ, the majority of this functionality is gated behind `LOCKED_ADMIN_QUESTIONS` until release.

## Safety Assurance

### Safety story

Each change is small and locally scoped. The lock-plugin guard against unlocking does not affect users with permission (it short-circuits only when `!isEditable && !isLoadingXForm`), and the drag and drop predicate is additive — existing valid drop targets behave exactly as before. The baseKeyValue change required setting widget.path, which is only used for validation and instance references. Both are safe no-ops for the androidIntentExtra and androidIntentResponse callers, since neither defines a validator or uses instance refs.

Verified locally:
- Android App Callout intent extras + responses become read-only on a locked question (inputs disabled, add/remove hidden).
- A question cannot be unlocked by unchecking the "Locked" checkbox after removing the `disabled` attribute in DevTools (vellum:lock attribute stays set).
- Dragging a tree question into a locked xpath/text/calculate input is rejected; the helper shows the error icon while hovering.
- Dragging into an unlocked input still works as before.
- Locking the last unlocked descendant of a group clears the ancestor's "contains locked questions" message.

### Automated test coverage

New tests in `tests/core.js` for the global drag and drop handler.

Existing `tests/formdesigner.lock.js` tests were updated to pass `edit_locked_questions: true` where they programmatically toggle the locked state (otherwise the new setter guard would silently no-op them).

### QA Plan

https://dimagi.atlassian.net/browse/QA-8497
QA have tested Locked Admin Questions with this branch and its fixes on staging.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)