### PR TITLE
Skip advanced case actions when cascading lock from a group

### DIFF
--- a/src/lock.js
+++ b/src/lock.js
@@ -19,6 +19,7 @@ const SELECT_AND_CHOICE_CLASSES = [...STATIC_SELECT_CLASSES, "Choice"];
 const DYNAMIC_SELECT_CLASSES = ["SelectDynamic", "MSelectDynamic"];
 const SELECT_CLASSES = [...STATIC_SELECT_CLASSES, ...DYNAMIC_SELECT_CLASSES];
 const GROUP_CLASSES = ["Group", "Repeat", "FieldList"];
+const NON_LOCKABLE_CLASSES = ["SaveToCase"];  // TODO: allow Advanced Case Actions to be locked
 
 $.vellum.plugin("lock", {}, {
     init: function () {
@@ -214,7 +215,8 @@ function hasLockedDescendants(mug) {
 
 function hasUnlockedDescendants(mug) {
     return mug.form.getChildren(mug).some(child =>
-        !child.p.locked || hasUnlockedDescendants(child)
+        !_.contains(NON_LOCKABLE_CLASSES, child.__className) &&
+        (!child.p.locked || hasUnlockedDescendants(child))
     );
 }
 
@@ -228,6 +230,9 @@ function propagateLockToControlOnlyChildren(mug) {
 
 function cascadeLockToDescendants(mug, value) {
     mug.form.getChildren(mug).forEach(child => {
+        if (_.contains(NON_LOCKABLE_CLASSES, child.__className)) {
+            return;
+        }
         if (child.p.locked !== value) {
             child.p.locked = value;
         } else if (_.contains(GROUP_CLASSES, child.__className)) {

--- a/tests/formdesigner.lock.js
+++ b/tests/formdesigner.lock.js
@@ -20,7 +20,7 @@ const assert = chai.assert,
 function beforeFn(done) {
     util.init({
         javaRosa: {langs: ['en']},
-        plugins: ['lock', 'itemset'],
+        plugins: ['lock', 'itemset', 'saveToCase'],
         features: {edit_locked_questions: true},
         core: {
             onReady: function () {
@@ -225,6 +225,22 @@ describe("The Lock plugin", function() {
                 group.p.locked = false;
             }
         });
+
+        it("does not lock an Advanced Case Action when its parent group is locked", function () {
+            const group = getMug('/data/group_no_lock');
+            const normal = getMug('/data/group_no_lock/nested_unlocked');
+            clickQuestion("group_no_lock");
+            const stc = util.addQuestion("SaveToCase", "g_case", {useCreate: true});
+            try {
+                group.p.locked = true;
+                assert(normal.p.locked, "normal child should lock");
+                assert(!stc.p.locked, "SaveToCase should be skipped");
+            } finally {
+                group.p.locked = false;
+                call('getData').core.form.removeMugsFromForm([stc]);
+            }
+        });
+
     });
 
     describe("locked select questions", function () {
@@ -399,6 +415,21 @@ describe("The Lock plugin", function() {
                     }
                 });
             });
+        });
+
+        it("shows a full lock icon on a locked group whose only unlocked descendant is an Advanced Case Action", function () {
+            const group = getMug('/data/group_no_lock');
+            clickQuestion("group_no_lock");
+            const stc = util.addQuestion("SaveToCase", "icon_case", { useCreate: true });
+            try {
+                group.p.locked = true;
+                const icon = getLockIcon('/data/group_no_lock');
+                assert.include(icon, 'fa-lock');
+                assert.notInclude(icon, 'fa-unlock');
+            } finally {
+                group.p.locked = false;
+                call('getData').core.form.removeMugsFromForm([stc]);
+            }
         });
     });
 


### PR DESCRIPTION
## Product Description
Advanced Case Actions cannot be fully locked right now, so the UI shouldn't pretend that they can be. They will also not contribute toward a group's 'unlock' icon: a group with all locked questions except for Advanced Case Actions will still have the 'lock' icon.

## Technical Summary
https://dimagi.atlassian.net/browse/SAAS-19853
Fixes a bug where Advanced Case Actions in a group would _appear_ to be locked after locking the parent group, but the state would not be maintained. Advanced Case Actions do not have a `<bind>` node in the XML, so to actually implement locking on these questions will be a larger change at a later date. Instead, this PR makes sure these questions don't appear to be locked when they shouldn't / aren't really.

## Safety Assurance

### Safety story
Tested locally to see the intended effects and ran `yarn build` to ensure the code builds correctly.

### Automated test coverage
Added automated tests to see that "SaveToCase" (Advanced Case Actions) questions do not appear to get locked when a parent group is locked, and do not contribute to a parent group's `unlock` icon.

### QA Plan
Not planning formal QA.


### Rollback instructions

<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change
