### PR TITLE
Add a Face Capture question type

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -336,7 +336,7 @@ fn.getQuestionGroups = function () {
     };
 
     if (this.opts().features.face_capture) {
-        mediaGroup.questions.splice(1, 0, "FaceCapture");
+        mediaGroup.questions.splice(3, 0, "FaceCapture");
     }
     if (this.opts().features.support_document_upload) {
         mediaGroup.questions.push("Document");

--- a/src/core.js
+++ b/src/core.js
@@ -335,6 +335,9 @@ fn.getQuestionGroups = function () {
         ]
     };
 
+    if (this.opts().features.face_capture) {
+        mediaGroup.questions.splice(1, 0, "FaceCapture");
+    }
     if (this.opts().features.support_document_upload) {
         mediaGroup.questions.push("Document");
     }

--- a/src/mugs/types/index.js
+++ b/src/mugs/types/index.js
@@ -1,6 +1,6 @@
 import {TextField, PhoneNumber, Secret} from "./text";
 import {Int, Long, Double} from "./numeric";
-import {AudioField, ImageField, Video, Signature, DocumentField} from "./media";
+import {AudioField, ImageField, Video, Signature, FaceCapture, DocumentField} from "./media";
 import {DateField, DateTime, Time} from "./date";
 import {Choice, MSelect, Select} from "./select";
 import {Group, FieldList, Repeat} from "./group";
@@ -15,6 +15,7 @@ var baseMugTypes = {
         "DateTime": DateTime,
         "Document": DocumentField,
         "Double": Double,
+        "FaceCapture": FaceCapture,
         "FieldList": FieldList,
         "Geopoint": Geopoint,
         "Group": Group,

--- a/src/mugs/types/media.js
+++ b/src/mugs/types/media.js
@@ -40,7 +40,7 @@ var ImageField = util.extend(AudioField, {
     },
     writeCustomXML: function (xmlWriter, mug) {
         AudioField.writeCustomXML(xmlWriter, mug);
-        if (mug.__className === "Image" && mug.p.imageSize) {
+        if ((mug.__className === "Image" || mug.__className === "FaceCapture") && mug.p.imageSize) {
             xmlWriter.writeAttributeString("jr:imageDimensionScaledMax", mug.p.imageSize + "px");
         }
     },
@@ -75,10 +75,22 @@ var Signature = util.extend(ImageField, {
     },
 });
 
+var FaceCapture = util.extend(ImageField, {
+    typeName: gettext('Face Capture'),
+    icon: 'fa fa-user',
+    init: function (mug, form) {
+        ImageField.init(mug, form);
+        mug.p.appearance = "face";
+    },
+    changeTypeTransform: function (mug) {
+        mug.p.appearance = undefined;
+    },
+});
+
 var DocumentField = util.extend(AudioField, {
     typeName: gettext('Document Upload'),
     icon: 'fa fa-file',
     mediaType: "application/*,text/*",
 });
 
-export {AudioField, ImageField, Video, Signature, DocumentField};
+export {AudioField, ImageField, Video, Signature, FaceCapture, DocumentField};

--- a/src/parser.js
+++ b/src/parser.js
@@ -338,7 +338,7 @@ function populateControlMug(mug, $cEl) {
     if (hintEl.length && mug.getPresence("hintLabel") !== 'notallowed') {
         mug.p.hintLabel = xml.humanize(hintEl);
     }
-    if (mug.__className === "Image") {
+    if (mug.__className === "Image" || mug.__className === "FaceCapture") {
         mug.p.imageSize = imageSize ? parseInt(imageSize) : "";
     }
 }
@@ -499,6 +499,8 @@ function buildControlNodeAdaptorMap() {
             } else if (mediaType === 'image/*') { /* fix eclipse syntax highlighter */
                 if (appearance === 'signature') {
                     type = 'Signature';
+                } else if (appearance === 'face') {
+                    type = 'FaceCapture';
                 } else {
                     type = 'Image';
                 }

--- a/tests/questionTypes.js
+++ b/tests/questionTypes.js
@@ -150,6 +150,10 @@ var call = util.call,
             path: 'question22/question23/',
             nodeId: 'question33'
         }, {
+            type: 'FaceCapture',
+            path: 'question22/question23/',
+            nodeId: 'question34'
+        }, {
             type: 'AndroidIntent',
             path: 'question22/question23/',
             nodeId: 'question7'
@@ -402,16 +406,19 @@ describe("Vellum", function () {
                 Trigger: "minimal",
                 PhoneNumber: "numeric",
                 Signature: "signature",
+                FaceCapture: "face",
             },
             remove_appearance = [
                 ["Trigger", questionWithoutDefaultAppearance],
                 ["PhoneNumber", questionWithoutDefaultAppearance],
                 ["Signature", questionWithoutDefaultAppearance],
+                ["FaceCapture", questionWithoutDefaultAppearance],
             ],
             change_appearance = [
                 ["Trigger", _.omit(questionWithDefaultAppearance, "Trigger")],
                 ["PhoneNumber", _.omit(questionWithDefaultAppearance, "PhoneNumber")],
                 ["Signature", _.omit(questionWithDefaultAppearance, "Signature")],
+                ["FaceCapture", _.omit(questionWithDefaultAppearance, "FaceCapture")],
             ];
 
         before(function (done) {
@@ -705,6 +712,67 @@ describe("Image Questions", function() {
         util.loadXML(IMAGE_CAPTURE_XML);
         var image = call("getMugByPath", "/data/image");
         assert.strictEqual(image.p.imageSize, '');
+    });
+});
+
+describe("Face Capture Questions", function() {
+    before(function (done) {
+        util.init({
+            core: {
+                onReady: function () { done(); }
+            }
+        });
+    });
+
+    it("should set appearance to 'face' on init", function() {
+        util.loadXML("");
+        var mug = util.addQuestion("FaceCapture", 'face1');
+        assert.strictEqual(mug.p.appearance, "face");
+    });
+
+    it("should default to small image size (inherits ImageField init)", function() {
+        util.loadXML("");
+        var mug = util.addQuestion("FaceCapture", 'face2');
+        assert.strictEqual(mug.p.imageSize, 250);
+    });
+
+    it("should serialize to upload with mediatype image/* and appearance face", function() {
+        util.loadXML("");
+        util.addQuestion("FaceCapture", 'face3');
+        var xml = util.call("createXML");
+        assert.include(xml, 'mediatype="image/*"');
+        assert.include(xml, 'appearance="face"');
+    });
+
+    it("should parse back to FaceCapture mug from XML with appearance='face'", function() {
+        util.loadXML("");
+        util.addQuestion("FaceCapture", 'face4');
+        var xml = util.call("createXML");
+        util.loadXML(xml);
+        var mug = util.getMug('face4');
+        assert.equal(mug.__className, "FaceCapture");
+    });
+
+    it("should serialize and parse imageSize for FaceCapture", function() {
+        util.loadXML("");
+        var mug = util.addQuestion("FaceCapture", 'face_size');
+        mug.p.imageSize = 500;
+        var xml = util.call("createXML");
+        assert.include(xml, 'jr:imageDimensionScaledMax="500px"');
+        util.loadXML(xml);
+        mug = util.getMug('face_size');
+        assert.equal(mug.p.imageSize, 500);
+    });
+
+    it("should clear appearance on changeType to Image", function() {
+        util.loadXML("");
+        var mug = util.addQuestion("FaceCapture", 'face5');
+        assert.strictEqual(mug.p.appearance, "face");
+        var nodeID = mug.p.nodeID;
+        util.call("changeMugType", mug, "Image");
+        mug = util.getMug(nodeID);
+        assert.equal(mug.__className, "Image");
+        assert.equal(mug.p.appearance, undefined);
     });
 });
 

--- a/tests/static/all_question_types.tsv
+++ b/tests/static/all_question_types.tsv
@@ -27,6 +27,7 @@ Question	Type	Text (en)	Text (hin)	Audio (en)	Audio (hin)	Image (en)	Image (hin)
 /question22/question23/question28	Password															no					
 /question22/question23/question29	Signature Capture															no					
 /question22/question23/question33	Document Upload															no					
+/question22/question23/question34	Face Capture															no					
 /question22/question23/question7	Android App Callout															no					
 /question20	Hidden Value															no					
 /question32	Hidden Value														1 + 2	no					

--- a/tests/static/all_question_types.xml
+++ b/tests/static/all_question_types.xml
@@ -32,6 +32,7 @@
 							<question28 />
 							<question29 />
 							<question33 />
+							<question34 />
 							<question7 />
 						</question23>
 					</question22>
@@ -66,6 +67,7 @@
 			<bind nodeset="/data/question22/question23/question28" type="xsd:string" />
 			<bind nodeset="/data/question22/question23/question29" type="binary" />
 			<bind nodeset="/data/question22/question23/question33" type="binary" />
+			<bind nodeset="/data/question22/question23/question34" type="binary" />
 			<bind nodeset="/data/question22/question23/question7" type="intent" />
 			<bind nodeset="/data/question20" />
 			<bind nodeset="/data/question32" calculate="1 + 2" />
@@ -225,6 +227,7 @@
 					<secret ref="/data/question22/question23/question28" />
 					<upload ref="/data/question22/question23/question29" mediatype="image/*" appearance="signature" />
 					<upload ref="/data/question22/question23/question33" mediatype="application/*,text/*" />
+					<upload ref="/data/question22/question23/question34" mediatype="image/*" jr:imageDimensionScaledMax="250px" appearance="face" />
 					<input ref="/data/question22/question23/question7" appearance="intent:question7" />
 				</group>
 			</repeat>


### PR DESCRIPTION
## Product Description

Adds a **Face Capture** question type to Form Builder

<img width="329" height="299" alt="Screenshot_20260609_175529" src="https://github.com/user-attachments/assets/caec2e51-c8d0-4d45-b02a-71d2bfbaf31c" />

It behaves like an Image Capture question, but its **Appearance Attribute** is set to "face", which tells CommCare Mobile to use the inner (selfie) camera.

<img width="702" height="194" alt="Screenshot_20260609_175703" src="https://github.com/user-attachments/assets/14c23dd4-e96f-4406-b536-f8079f60b244" />

## Technical Summary

:t-rex: Jira: [SAAS-19868](https://dimagi.atlassian.net/browse/SAAS-19868)

The code takes a similar approach to the **Signature Capture** question type: They both modify the **Image Capture** question by changing the "appearance" attribute. Face Capture sets the value to "face".

## Feature Flag

Gated by a `FACE_CAPTURE` feature release flag so that it can be released after CommCare Mobile supports the "face" appearance attribute.

See corresponding PR https://github.com/dimagi/commcare-hq/pull/37811

## Safety Assurance

### Safety story

Small change

Tested locally

### Automated test coverage

Yes

### QA Plan

No

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations

### Labels & Review
- [x] Risk label is set correctly
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change


[SAAS-19868]: https://dimagi.atlassian.net/browse/SAAS-19868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ